### PR TITLE
Fix corrections formatting and update mode default

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -312,13 +312,19 @@ def process_new_typos(candidates, args, valid_words):
     formatted = format_typos(filtered_candidates, args.output_format)
     return formatted
 
-def process_new_corrections(candidates, args, words_mapping):
+def process_new_corrections(candidates, args, words_mapping, output_format):
     """
     Process candidate typos to produce new corrections for known typos.
     It loads a words mapping file (ie. words.csv) and for each candidate correction,
     if the "before" word is already known but the "after" is not among its registered fixes,
     then it is output.
-    Returns a sorted, deduplicated list of new corrections (formatted in arrow style).
+    Returns a sorted, deduplicated list of new corrections in "before -> after" form.
+
+    Args:
+        candidates (list): Candidate "before -> after" strings.
+        args: Command-line arguments (currently unused).
+        words_mapping (dict): Mapping of known typos to their corrections.
+        output_format (str): Requested output format; formatting is applied by the caller.
     """
 
     new_corrections = []
@@ -391,7 +397,8 @@ def main():
     # Process new corrections if requested.
     if args.mode in ['corrections', 'both']:
         print("\nProcessing new corrections to existing typos...")
-        new_corrections_result = process_new_corrections(candidates, args, dictionary_mapping)
+        new_corrections_raw = process_new_corrections(candidates, args, dictionary_mapping, args.output_format)
+        new_corrections_result = format_typos(new_corrections_raw, args.output_format)
         print(f"Found {len(new_corrections_result)} new correction(s).")
 
     # Combine results if needed.

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ Scans a Git diff file to find typo corrections. It:
 | `--input_file`      | Path to the input Git diff file.                                                                   | `diff.txt`    |
 | `--output_file`     | Path to the output typos file.                                                                     | `typos.txt`   |
 | `--output_format`   | Format of the output typos. Choices: `arrow`, `csv`, `table`, `list`.                             | `arrow`       |
-| `--mode`            | Extract new typos, corrections to existing ones, or both. Choices: `typos`, `corrections`, `both` | `arrow`       |
+| `--mode`            | Extract new typos, corrections to existing ones, or both. Choices: `typos`, `corrections`, `both` | `typos`       |
 | `--typos_tool_path` | Path to the `typos` tool executable.                                                               | `typos`       |
 | `--allowed_file`    | CSV file containing allowed words to exclude from typos.                                         | `allowed.csv` |
 | `--min_length`      | Minimum length of differing substrings to consider as typos.                                      | `2`           |


### PR DESCRIPTION
## Summary
- Correct default `--mode` value in documentation
- Ensure `process_new_corrections` respects chosen output format

## Testing
- `python -m pytest`
- `python diff2typo.py -h`

------
https://chatgpt.com/codex/tasks/task_e_68c308f94f7c8330b21f2f9018ead833