### PR TITLE
refactor: remove redundant typo_types default

### DIFF
--- a/gentypos.py
+++ b/gentypos.py
@@ -373,10 +373,7 @@ def main():
         logging.warning(f"Unknown output format '{output_format}'. Defaulting to 'arrow'.")
         output_format = 'arrow'
 
-    typo_types = config.get(
-        'typo_types',
-        {'deletion': True, 'transposition': True, 'replacement': True, 'duplication': True},
-    )
+    typo_types = config['typo_types']
     replacement_options = config.get(
         'replacement_options',
         {


### PR DESCRIPTION
## Summary
- remove redundant default typo_types configuration in main by relying on validate_config

## Testing
- `pytest -q`
- `python -m py_compile gentypos.py`


------
https://chatgpt.com/codex/tasks/task_e_68c315cc56f48330bdd6efa4a8a7cb77