### PR TITLE
Add tests for typostats

### DIFF
--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add repository root to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import typostats
+
+
+def test_is_one_letter_replacement_basic():
+    assert typostats.is_one_letter_replacement('tezt', 'test') == ('s', 'z')
+    assert typostats.is_one_letter_replacement('test', 'test') is None
+    assert typostats.is_one_letter_replacement('abc', 'xyz') is None
+
+
+def test_is_one_letter_replacement_one_to_two():
+    assert typostats.is_one_letter_replacement('aa', 'a', allow_two_char=True) == ('a', 'aa')
+    assert typostats.is_one_letter_replacement('aa', 'a', allow_two_char=False) is None
+
+
+def test_process_typos_counts_and_filtering():
+    lines = [
+        'tezt, test',
+        'lavel, level',
+        'aa, a',
+        'fóo, foo',  # non-ASCII; should be skipped
+    ]
+    counts = typostats.process_typos(lines, allow_two_char=True)
+    assert counts == {('s', 'z'): 1, ('e', 'a'): 1, ('a', 'aa'): 1}
+
+
+def test_generate_report_arrow(capsys):
+    counts = {('s', 'z'): 3, ('e', 'a'): 1}
+    typostats.generate_report(counts, min_occurrences=2, output_format='arrow')
+    captured = capsys.readouterr().out
+    assert 's -> z: 3' in captured
+    assert 'e -> a' not in captured


### PR DESCRIPTION
## Summary
- add unit tests for is_one_letter_replacement including one-to-two character replacements
- cover process_typos counting and non-ASCII filtering
- verify generate_report arrow output respects minimum occurrences

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c34e5bbafc8330bfe1bcd0118a27bc