### PR TITLE
[FEAT] Add diff preview to scrub and standardize modes

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -138,16 +138,18 @@ These modes help you transform or combine your data.
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) directly on the command line.
   - **In-Place Editing:** Use the `--in-place` flag to modify files directly. If you provide an extension (for example, `--in-place .bak`), the tool will create a backup of each file before modifying it.
   - **Dry Run:** Use the `--dry-run` flag to see how many fixes would be made without actually changing any files.
+  - **Diff Preview:** Use the `--diff` flag to see a unified diff of the changes that would be made. This is useful for reviewing fixes before applying them in-place.
   - **Smart Casing:** Use the `--smart-case` flag to automatically match the casing of the original word. For example, if the mapping is `teh -> the`, then `Teh` will be replaced with `The`, and `TEH` with `THE`.
-  - **Example:** `python multitool.py scrub input.txt --add teh:the --output fixed.txt`
+  - **Example:** `python multitool.py scrub input.txt --add teh:the --diff`
   - **In-Place Example:** `python multitool.py scrub file1.txt file2.txt --mapping corrections.csv --in-place`
 
 - **`standardize`**
   - **What it does:** Fixes inconsistent casing by using the most frequent form. It analyzes your files to find words used with different capitalization (for example, 'database' vs 'Database'). It then automatically replaces all less frequent versions with the most popular one across the entire project. This ensures naming consistency without needing a manual mapping file.
   - **Options:**
     - Supports `--in-place` editing and `--dry-run` preview.
+    - **Diff Preview:** Use the `--diff` flag to see a unified diff of the changes that would be made.
     - Works with standard filters like `--min-length` and `--max-length`.
-  - **Example:** `python multitool.py standardize "**/*" --in-place --min-length 4`
+  - **Example:** `python multitool.py standardize "." --diff --min-length 4`
 
 - **`highlight`**
   - **What it does:** Searches for words from a list, mapping, or extra pairs and colors them in the output. This is useful as a preview before using the `scrub` mode to make permanent changes.

--- a/multitool.py
+++ b/multitool.py
@@ -3,6 +3,7 @@ import shutil
 import argparse
 import csv
 import glob
+import difflib
 from collections import Counter, defaultdict, deque
 import random
 import contextlib
@@ -3488,6 +3489,7 @@ def standardize_mode(
     dry_run: bool = False,
     fuzzy: int = 0,
     threshold: float = 10.0,
+    diff: bool = False,
 ) -> None:
     """
     Standardizes inconsistent casing and optionally spelling of words within files
@@ -3585,6 +3587,8 @@ def standardize_mode(
             logging.warning("In-place modification requested for standard input; ignoring.")
 
         file_lines = _read_file_lines_robust(input_file)
+        # Store original lines without newlines for diffing
+        original_lines = [line.rstrip('\n') for line in file_lines]
         modified_lines = []
         file_replacements = 0
 
@@ -3596,6 +3600,35 @@ def standardize_mode(
             file_replacements += replacements
 
         total_replacements += file_replacements
+
+        if diff and file_replacements > 0:
+            # Generate and write diff
+            # Strip newlines from modified lines for difflib
+            mod_stripped = [line.rstrip('\n') for line in modified_lines]
+            diff_gen = difflib.unified_diff(
+                original_lines,
+                mod_stripped,
+                fromfile=f"a/{input_file}",
+                tofile=f"b/{input_file}",
+                lineterm=""
+            )
+
+            # Check if color is enabled
+            use_color = bool(YELLOW)
+
+            with smart_open_output(output_file) as out:
+                for line in diff_gen:
+                    if use_color:
+                        if line.startswith('+') and not line.startswith('+++'):
+                            out.write(f"{GREEN}{line}{RESET}\n")
+                        elif line.startswith('-') and not line.startswith('---'):
+                            out.write(f"{RED}{line}{RESET}\n")
+                        elif line.startswith('@@'):
+                            out.write(f"{BLUE}{line}{RESET}\n")
+                        else:
+                            out.write(f"{line}\n")
+                    else:
+                        out.write(f"{line}\n")
 
         if in_place is not None and input_file != '-':
             if file_replacements > 0:
@@ -3663,6 +3696,7 @@ def scrub_mode(
     dry_run: bool = False,
     smart_case: bool = False,
     ad_hoc: List[str] | None = None,
+    diff: bool = False,
 ) -> None:
     """
     Performs replacements of typos in text files based on a mapping file or extra pairs.
@@ -3686,6 +3720,8 @@ def scrub_mode(
             logging.warning("In-place modification requested for standard input; ignoring.")
 
         file_lines = _read_file_lines_robust(input_file)
+        # Store original lines without newlines for diffing
+        original_lines = [line.rstrip('\n') for line in file_lines]
         modified_lines = []
         file_replacements = 0
 
@@ -3697,6 +3733,35 @@ def scrub_mode(
             file_replacements += replacements
 
         total_replacements += file_replacements
+
+        if diff and file_replacements > 0:
+            # Generate and write diff
+            # Strip newlines from modified lines for difflib
+            mod_stripped = [line.rstrip('\n') for line in modified_lines]
+            diff_gen = difflib.unified_diff(
+                original_lines,
+                mod_stripped,
+                fromfile=f"a/{input_file}",
+                tofile=f"b/{input_file}",
+                lineterm=""
+            )
+
+            # Check if color is enabled
+            use_color = bool(YELLOW)
+
+            with smart_open_output(output_file) as out:
+                for line in diff_gen:
+                    if use_color:
+                        if line.startswith('+') and not line.startswith('+++'):
+                            out.write(f"{GREEN}{line}{RESET}\n")
+                        elif line.startswith('-') and not line.startswith('---'):
+                            out.write(f"{RED}{line}{RESET}\n")
+                        elif line.startswith('@@'):
+                            out.write(f"{BLUE}{line}{RESET}\n")
+                        else:
+                            out.write(f"{line}\n")
+                    else:
+                        out.write(f"{line}\n")
 
         if in_place is not None and input_file != '-':
             if file_replacements > 0:
@@ -4592,8 +4657,8 @@ MODE_DETAILS = {
     "standardize": {
         "summary": "Fixes inconsistent casing and spelling using the most frequent form.",
         "description": "Analyzes your files to find words used with different capitalization (for example, 'database' vs 'Database') or similar spelling (for example, 'teh' vs 'the'). It then automatically replaces all less frequent versions with the most popular one across the entire project. Use --fuzzy to enable similar word matching based on your project's dominant patterns.",
-        "example": "python multitool.py standardize \"**/*\" --in-place --min-length 4 --fuzzy 1",
-        "flags": "[--in-place] [--dry-run] [--fuzzy N] [--threshold R]",
+        "example": "python multitool.py standardize \".\" --diff --min-length 4 --fuzzy 1",
+        "flags": "[--in-place] [--dry-run] [--diff] [--fuzzy N] [--threshold R]",
     },
     "search": {
         "summary": "Searches for words or patterns in text files.",
@@ -4616,8 +4681,8 @@ MODE_DETAILS = {
     "scrub": {
         "summary": "Replaces typos in text files based on a mapping or extra pairs.",
         "description": "Performs in-place replacements of typos in your text files using a mapping file or extra pairs provided via --add. It tries to preserve the surrounding context (punctuation, whitespace) while fixing errors. It automatically handles compound words like 'CamelCase' and 'snake_case' variables. Supports CSV, Arrow, Table, JSON, and YAML mapping formats.",
-        "example": "python multitool.py scrub input.txt --add teh:the --output fixed.txt",
-        "flags": "MAPPING [FILES...] [--add KEY:VALUE]",
+        "example": "python multitool.py scrub input.txt --add teh:the --diff",
+        "flags": "MAPPING [FILES...] [--add KEY:VALUE] [--diff]",
     },
     "rename": {
         "summary": "Renames files and directories using a mapping file or extra pairs.",
@@ -5533,6 +5598,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action='store_true',
         help="Automatically match the casing of the original word (for example, 'Teh' -> 'The').",
     )
+    scrub_options.add_argument(
+        '--diff',
+        action='store_true',
+        help="Show a unified diff of the changes that would be made.",
+    )
     _add_common_mode_arguments(scrub_parser, include_process_output=False, include_limit=False)
 
     rename_parser = subparsers.add_parser(
@@ -5605,6 +5675,11 @@ def _build_parser() -> argparse.ArgumentParser:
         type=float,
         default=10.0,
         help="The minimum frequency ratio to consider a rare word a typo (default: 10.0).",
+    )
+    standardize_options.add_argument(
+        '--diff',
+        action='store_true',
+        help="Show a unified diff of the changes that would be made.",
     )
     _add_common_mode_arguments(standardize_parser, include_process_output=False, include_limit=True)
 
@@ -6229,6 +6304,7 @@ def main() -> None:
                 'dry_run': getattr(args, 'dry_run', False),
                 'fuzzy': getattr(args, 'fuzzy', 0),
                 'threshold': getattr(args, 'threshold', 10.0),
+                'diff': getattr(args, 'diff', False),
             }
         ),
         'scrub': (
@@ -6247,6 +6323,7 @@ def main() -> None:
                 'in_place': getattr(args, 'in_place', None),
                 'dry_run': getattr(args, 'dry_run', False),
                 'smart_case': getattr(args, 'smart_case', False),
+                'diff': getattr(args, 'diff', False),
             }
         ),
         'zip': (

--- a/tests/test_multitool_diff_preview.py
+++ b/tests/test_multitool_diff_preview.py
@@ -1,0 +1,92 @@
+import os
+import subprocess
+import pytest
+from pathlib import Path
+
+def test_scrub_diff(tmp_path):
+    # Get absolute path to multitool.py
+    root_dir = Path(__file__).resolve().parents[1]
+    multitool_path = root_dir / "multitool.py"
+
+    input_file = tmp_path / "test.txt"
+    input_file.write_text("This is teh test file with a typo.\nAnother line without change.")
+
+    # Run scrub mode with --diff
+    result = subprocess.run(
+        ["python3", str(multitool_path), "scrub", str(input_file), "--add", "teh:the", "--diff"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+
+    output = result.stdout
+    assert "--- a/" + str(input_file) in output
+    assert "+++ b/" + str(input_file) in output
+    assert "-This is teh test file with a typo." in output
+    assert "+This is the test file with a typo." in output
+    assert " Another line without change." in output
+
+def test_standardize_diff(tmp_path):
+    # Get absolute path to multitool.py
+    root_dir = Path(__file__).resolve().parents[1]
+    multitool_path = root_dir / "multitool.py"
+
+    file1 = tmp_path / "file1.txt"
+    file1.write_text("Database database database.")
+    file2 = tmp_path / "file2.txt"
+    file2.write_text("DATABASE database database.")
+
+    # Run standardize mode with --diff
+    # database is most frequent (4 times), Database and DATABASE are once each.
+    result = subprocess.run(
+        ["python3", str(multitool_path), "standardize", str(tmp_path), "--diff"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+
+    output = result.stdout
+    assert "--- a/" + str(file1) in output
+    assert "-Database database database." in output
+    assert "+database database database." in output
+
+    assert "--- a/" + str(file2) in output
+    assert "-DATABASE database database." in output
+    assert "+database database database." in output
+
+def test_diff_patch_compatibility(tmp_path):
+    # Save original working directory
+    old_cwd = os.getcwd()
+    try:
+        # Use relative paths for better patch compatibility in tests
+        os.chdir(tmp_path)
+        input_file_name = "target.txt"
+        input_file = Path(input_file_name)
+        original_content = "Line 1: teh typo\nLine 2: stable"
+        input_file.write_text(original_content)
+
+        # Generate diff using relative path
+        root_dir = Path(__file__).resolve().parents[1]
+        multitool_path = root_dir / "multitool.py"
+
+        diff_result = subprocess.run(
+            ["python3", str(multitool_path), "scrub", input_file_name, "--add", "teh:the", "--diff"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+
+        patch_content = diff_result.stdout
+
+        # Verify with patch --dry-run
+        patch_check = subprocess.run(
+            ["patch", "--dry-run", "-p1"],
+            input=patch_content,
+            capture_output=True,
+            text=True
+        )
+
+        assert patch_check.returncode == 0
+        assert "checking file target.txt" in patch_check.stdout.lower()
+    finally:
+        os.chdir(old_cwd)


### PR DESCRIPTION
Added a `--diff` flag to the `scrub` and `standardize` modes in `multitool.py`. This flag generates a unified diff (colorized in terminals) showing the proposed changes before they are applied. This provides a safe preview for destructive transformations and generates output compatible with standard tools like `patch`.

Key changes:
- Integrated `difflib` into `multitool.py`.
- Updated `scrub_mode` and `standardize_mode` to support diff generation.
- Documented the new flag in CLI help and Markdown docs.
- Added new tests in `tests/test_multitool_diff_preview.py`.

---
*PR created automatically by Jules for task [11058004974053967170](https://jules.google.com/task/11058004974053967170) started by @RainRat*