### PR TITLE
[TEST] [Refactor] Consolidate and test diff generation logic in multitool.py

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -609,6 +609,43 @@ def _extract_pairs(input_files: Sequence[str], quiet: bool = False) -> Iterable[
                     continue
 
 
+def _write_diff_report(
+    input_file: str,
+    original_lines: List[str],
+    modified_lines: List[str],
+    output_file: str,
+) -> None:
+    """Generate and write a colorized unified diff report."""
+    # Strip newlines from lines for difflib compatibility
+    orig_stripped = [line.rstrip('\n') for line in original_lines]
+    mod_stripped = [line.rstrip('\n') for line in modified_lines]
+
+    diff_gen = difflib.unified_diff(
+        orig_stripped,
+        mod_stripped,
+        fromfile=f"a/{input_file}",
+        tofile=f"b/{input_file}",
+        lineterm=""
+    )
+
+    # Check if color is enabled (using global YELLOW as proxy for overall color support)
+    use_color = bool(YELLOW)
+
+    with smart_open_output(output_file) as out:
+        for line in diff_gen:
+            if use_color:
+                if line.startswith('+') and not line.startswith('+++'):
+                    out.write(f"{GREEN}{line}{RESET}\n")
+                elif line.startswith('-') and not line.startswith('---'):
+                    out.write(f"{RED}{line}{RESET}\n")
+                elif line.startswith('@@'):
+                    out.write(f"{BLUE}{line}{RESET}\n")
+                else:
+                    out.write(f"{line}\n")
+            else:
+                out.write(f"{line}\n")
+
+
 def _write_paired_output(
     pairs: Iterable[Tuple[str, str]],
     output_file: str,
@@ -3602,33 +3639,7 @@ def standardize_mode(
         total_replacements += file_replacements
 
         if diff and file_replacements > 0:
-            # Generate and write diff
-            # Strip newlines from modified lines for difflib
-            mod_stripped = [line.rstrip('\n') for line in modified_lines]
-            diff_gen = difflib.unified_diff(
-                original_lines,
-                mod_stripped,
-                fromfile=f"a/{input_file}",
-                tofile=f"b/{input_file}",
-                lineterm=""
-            )
-
-            # Check if color is enabled
-            use_color = bool(YELLOW)
-
-            with smart_open_output(output_file) as out:
-                for line in diff_gen:
-                    if use_color:
-                        if line.startswith('+') and not line.startswith('+++'):
-                            out.write(f"{GREEN}{line}{RESET}\n")
-                        elif line.startswith('-') and not line.startswith('---'):
-                            out.write(f"{RED}{line}{RESET}\n")
-                        elif line.startswith('@@'):
-                            out.write(f"{BLUE}{line}{RESET}\n")
-                        else:
-                            out.write(f"{line}\n")
-                    else:
-                        out.write(f"{line}\n")
+            _write_diff_report(input_file, original_lines, modified_lines, output_file)
 
         if in_place is not None and input_file != '-':
             if file_replacements > 0:
@@ -3735,33 +3746,7 @@ def scrub_mode(
         total_replacements += file_replacements
 
         if diff and file_replacements > 0:
-            # Generate and write diff
-            # Strip newlines from modified lines for difflib
-            mod_stripped = [line.rstrip('\n') for line in modified_lines]
-            diff_gen = difflib.unified_diff(
-                original_lines,
-                mod_stripped,
-                fromfile=f"a/{input_file}",
-                tofile=f"b/{input_file}",
-                lineterm=""
-            )
-
-            # Check if color is enabled
-            use_color = bool(YELLOW)
-
-            with smart_open_output(output_file) as out:
-                for line in diff_gen:
-                    if use_color:
-                        if line.startswith('+') and not line.startswith('+++'):
-                            out.write(f"{GREEN}{line}{RESET}\n")
-                        elif line.startswith('-') and not line.startswith('---'):
-                            out.write(f"{RED}{line}{RESET}\n")
-                        elif line.startswith('@@'):
-                            out.write(f"{BLUE}{line}{RESET}\n")
-                        else:
-                            out.write(f"{line}\n")
-                    else:
-                        out.write(f"{line}\n")
+            _write_diff_report(input_file, original_lines, modified_lines, output_file)
 
         if in_place is not None and input_file != '-':
             if file_replacements > 0:

--- a/tests/test_multitool_diff_logic.py
+++ b/tests/test_multitool_diff_logic.py
@@ -1,0 +1,116 @@
+import sys
+import logging
+import io
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Add repository root to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import multitool
+
+def test_write_diff_report_plain(tmp_path, capsys):
+    # Test diff report without color
+    input_file = "test.txt"
+    original = ["Line 1", "Line 2"]
+    modified = ["Line 1 modified", "Line 2"]
+    output_file = "-" # stdout
+
+    with patch("multitool.YELLOW", ""): # Disable color
+        multitool._write_diff_report(input_file, original, modified, output_file)
+
+    captured = capsys.readouterr()
+    assert "--- a/test.txt" in captured.out
+    assert "+++ b/test.txt" in captured.out
+    assert "-Line 1" in captured.out
+    assert "+Line 1 modified" in captured.out
+    # Ensure no ANSI codes
+    assert "\033[" not in captured.out
+
+def test_write_diff_report_color(tmp_path, capsys):
+    # Test diff report with color
+    input_file = "test.txt"
+    original = ["Line 1", "Line 2"]
+    modified = ["Line 1 modified", "Line 2"]
+    output_file = "-" # stdout
+
+    # Mock colors
+    with patch("multitool.YELLOW", "\033[1;33m"), \
+         patch("multitool.GREEN", "\033[1;32m"), \
+         patch("multitool.RED", "\033[1;31m"), \
+         patch("multitool.BLUE", "\033[1;34m"), \
+         patch("multitool.RESET", "\033[0m"):
+        multitool._write_diff_report(input_file, original, modified, output_file)
+
+    captured = capsys.readouterr()
+    # Check for colorized lines
+    # Red for removed line
+    assert "\033[1;31m-Line 1\033[0m" in captured.out
+    # Green for added line
+    assert "\033[1;32m+Line 1 modified\033[0m" in captured.out
+    # Blue for @@ line
+    assert "\033[1;34m@@" in captured.out
+
+def test_write_diff_report_to_file(tmp_path):
+    # Test diff report writing to a file
+    input_file = "test.txt"
+    original = ["Line 1"]
+    modified = ["Line 1 modified"]
+    output_path = tmp_path / "diff.patch"
+
+    with patch("multitool.YELLOW", ""):
+        multitool._write_diff_report(input_file, original, modified, str(output_path))
+
+    content = output_path.read_text()
+    assert "--- a/test.txt" in content
+    assert "-Line 1" in content
+    assert "+Line 1 modified" in content
+
+def test_scrub_mode_diff_integration(tmp_path, capsys):
+    # Test that scrub_mode correctly calls _write_diff_report
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("teh typo")
+
+    # Run scrub_mode with diff=True and ad-hoc mapping
+    multitool.scrub_mode(
+        input_files=[str(input_file)],
+        mapping_file=None,
+        output_file="-",
+        min_length=1,
+        max_length=100,
+        process_output=True,
+        diff=True,
+        quiet=True,
+        ad_hoc=["teh:the"]
+    )
+
+    captured = capsys.readouterr()
+    assert "--- a/" + str(input_file) in captured.out
+    assert "-teh typo" in captured.out
+    assert "+the typo" in captured.out
+
+def test_standardize_mode_diff_integration(tmp_path, capsys):
+    # Test that standardize_mode correctly calls _write_diff_report
+    file1 = tmp_path / "file1.txt"
+    file1.write_text("Database database database") # database is most frequent
+
+    # We need at least 2 files or 2 occurrences to have a dominant word.
+    # Actually standardize_mode builds a mapping from all input files.
+
+    with patch("multitool.YELLOW", ""):
+        multitool.standardize_mode(
+            input_files=[str(file1)],
+            output_file="-",
+            min_length=1,
+            max_length=100,
+            process_output=True,
+            diff=True,
+            quiet=True
+        )
+
+    captured = capsys.readouterr()
+    assert "--- a/" + str(file1) in captured.out
+    assert "-Database database database" in captured.out
+    assert "+database database database" in captured.out


### PR DESCRIPTION
Consolidated the unified diff generation and colorization logic in `multitool.py` into a new internal helper function `_write_diff_report`. This refactoring eliminates duplication between `scrub_mode` and `standardize_mode` while ensuring consistent newline handling for `difflib`. 

Additionally, implemented a new test suite in `tests/test_multitool_diff_logic.py` that specifically targets the diff reporting logic. These tests mock terminal color support to verify that ANSI escape sequences are correctly applied to the diff output, closing a previously identified coverage gap.

---
*PR created automatically by Jules for task [64811517332444888](https://jules.google.com/task/64811517332444888) started by @RainRat*