### PR TITLE
[DOCS] Align search mode help strings in multitool.py

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -5368,8 +5368,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     search_parser = subparsers.add_parser(
         'search',
-        help="Searches for words or patterns in text files.",
+        help=MODE_DETAILS['search']['summary'],
         formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['search']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['search']['example']}{RESET}",
     )
     search_options = search_parser.add_argument_group(f"{BLUE}SEARCH OPTIONS{RESET}")
     search_options.add_argument(

--- a/tests/test_multitool_help.py
+++ b/tests/test_multitool_help.py
@@ -70,3 +70,34 @@ def test_mode_help_invalid(monkeypatch, capsys):
     output = captured.err + captured.out
 
     assert "invalid choice" in output or "argument --mode-help: invalid choice" in output
+
+def test_mode_help_search_detailed(monkeypatch, capsys):
+    """Test 'multitool.py --mode-help search' displays detailed help for search mode."""
+    monkeypatch.setattr(sys, 'argv', ['multitool.py', '--mode-help', 'search'])
+
+    with pytest.raises(SystemExit):
+        multitool.main()
+
+    captured = capsys.readouterr()
+    output = captured.err + captured.out
+
+    assert "MODE: SEARCH" in output
+    assert "SUMMARY:     Search for words or patterns." in output
+    assert "DESCRIPTION: A typo-aware search tool." in output
+    assert "EXAMPLE:" in output
+    assert "multitool.py search 'teh' report.txt" in output
+
+def test_search_standard_help(monkeypatch, capsys):
+    """Test 'python multitool.py search --help' displays correct description and example."""
+    monkeypatch.setattr(sys, 'argv', ['multitool.py', 'search', '--help'])
+
+    with pytest.raises(SystemExit):
+        multitool.main()
+
+    captured = capsys.readouterr()
+    output = captured.err + captured.out
+
+    # argparse uses Example: (not BOLD) in epilog by default in our setup
+    assert "A typo-aware search tool." in output
+    assert "Example:" in output
+    assert "python multitool.py search 'teh' report.txt" in output


### PR DESCRIPTION
Aligned the `search` mode's CLI help text in `multitool.py` with the rest of the utility's modes. By utilizing the `MODE_DETAILS` dictionary for the subparser's `help`, `description`, and `epilog` fields, the tool now provides a consistent and detailed help message (including a usage example) when a user runs `python3 multitool.py search --help`. Expanded the test suite in `tests/test_multitool_help.py` to cover these documentation improvements.

---
*PR created automatically by Jules for task [10719952297589712670](https://jules.google.com/task/10719952297589712670) started by @RainRat*