### PR TITLE
[UI/UX] Standardize visual hierarchy of detailed CLI help

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -4781,31 +4781,33 @@ class ModeHelpAction(argparse.Action):
                 parser.error(f"Unknown mode: {values}")
 
             divider = f"{BLUE}{'─' * 80}{RESET}"
+            label_color = f"{BLUE}{BOLD}"
             block = [
                 divider,
-                f"{BOLD}MODE:{RESET} {GREEN}{values.upper()}{RESET}",
+                f"{label_color}{'MODE:':<13}{RESET}{GREEN}{values.upper()}{RESET}",
                 divider,
-                f"{BOLD}SUMMARY:{RESET}     {details['summary']}",
+                f"{label_color}{'SUMMARY:':<13}{RESET}{details['summary']}",
             ]
 
             if details.get("description"):
-                # Simple indentation for description
                 desc = details['description']
-                block.append(f"{BOLD}DESCRIPTION:{RESET} {desc}")
+                block.append(f"{label_color}{'DESCRIPTION:':<13}{RESET}{desc}")
 
             flags_str = details.get("flags", "[FILES...]")
             first_word = flags_str.split()[0] if flags_str else ""
             # If the flags string starts with a positional label (uppercase, no brackets), show it as part of USAGE
             if first_word.isupper() and not first_word.startswith('[') and not first_word.startswith('-'):
-                block.append(f"\n{BOLD}USAGE:{RESET}       python multitool.py {values} {first_word} [FILES...] [FLAGS]")
+                usage_line = f"python multitool.py {values} {first_word} [FILES...] [FLAGS]"
             else:
-                block.append(f"\n{BOLD}USAGE:{RESET}       python multitool.py {values} [FILES...] [FLAGS]")
+                usage_line = f"python multitool.py {values} [FILES...] [FLAGS]"
+
+            block.append(f"\n{label_color}{'USAGE:':<13}{RESET}{usage_line}")
 
             if details.get("flags"):
-                block.append(f"{BOLD}FLAGS:{RESET}       {YELLOW}{details['flags']}{RESET}")
+                block.append(f"{label_color}{'FLAGS:':<13}{RESET}{YELLOW}{details['flags']}{RESET}")
 
             if details.get("example"):
-                block.append(f"\n{BOLD}EXAMPLE:{RESET}")
+                block.append(f"\n{label_color}EXAMPLE:{RESET}")
                 block.append(f"  {BLUE}{details['example']}{RESET}")
 
             block.append(divider)

--- a/tests/test_multitool_help.py
+++ b/tests/test_multitool_help.py
@@ -51,8 +51,10 @@ def test_mode_help_specific(monkeypatch, capsys):
     captured = capsys.readouterr()
     output = captured.err + captured.out
 
-    assert "MODE: ARROW" in output
-    assert "SUMMARY:     Gets text from lines with arrows." in output
+    assert "MODE:" in output
+    assert "ARROW" in output
+    assert "SUMMARY:" in output
+    assert "Gets text from lines with arrows." in output
 
     # Should not contain other modes
     assert "MODE: CSV" not in output
@@ -81,9 +83,12 @@ def test_mode_help_search_detailed(monkeypatch, capsys):
     captured = capsys.readouterr()
     output = captured.err + captured.out
 
-    assert "MODE: SEARCH" in output
-    assert "SUMMARY:     Search for words or patterns." in output
-    assert "DESCRIPTION: A typo-aware search tool." in output
+    assert "MODE:" in output
+    assert "SEARCH" in output
+    assert "SUMMARY:" in output
+    assert "Search for words or patterns." in output
+    assert "DESCRIPTION:" in output
+    assert "A typo-aware search tool." in output
     assert "EXAMPLE:" in output
     assert "multitool.py search 'teh' report.txt" in output
 


### PR DESCRIPTION
This improvement standardizes the visual hierarchy of the detailed mode help (`--mode-help`) in `multitool.py`. 

**Problem:** 
The previous help output had inconsistent indentation for labels like `SUMMARY:`, `DESCRIPTION:`, and `USAGE:`, leading to a "jagged" left edge that hindered quick scannability. Labels also lacked distinct styling to separate them from the content.

**Solution:**
1.  **Alignment:** All section labels (`MODE:`, `SUMMARY:`, `DESCRIPTION:`, `USAGE:`, `FLAGS:`) now use a fixed-width padding of 13 characters. This creates a clean vertical column for all help text.
2.  **Visual Hierarchy:** Labels are now styled with bold blue (`BLUE` + `BOLD`), matching the tool's primary section headers. This clearly distinguishes metadata from data.
3.  **Robust Tests:** Updated the test suite to verify the presence of labels and content independently of specific whitespace padding, ensuring long-term maintainability.

These changes adhere to the "Invisible Design" principle by making the interface feel more polished and "stock" while prioritizing "Efficiency First" for power users.

---
*PR created automatically by Jules for task [11464316434200465449](https://jules.google.com/task/11464316434200465449) started by @RainRat*