### PR TITLE
[DOCS] Standardize gentypos terminology

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -32,8 +32,8 @@ The tool uses a YAML file to control how typos are generated.
 
 ```yaml
 # File Paths
-input_file: "words.txt"           # Source words to process
-dictionary_file: "dictionary.txt"  # Valid words (to filter out real words)
+input_file: "words.txt"           # Small dictionary to process
+dictionary_file: "dictionary.txt"  # Large dictionary (to filter out real words)
 output_file: "typos.txt"          # Where to save the results
 
 # Output Format: arrow (a -> b), csv (a,b), table (a = "b"), or list (a)
@@ -93,5 +93,5 @@ Supported formats:
 ## How it Works
 
 1.  **Generation:** The tool applies the selected mistake types to every word in your input.
-2.  **Filtering:** It checks the new "typos" against your `dictionary_file`. If a generated typo is actually a real word (like "form" instead of "from"), it is removed. This prevents the tool from flagging correct words as typos.
+2.  **Filtering:** It checks the new "typos" against your `dictionary_file` (the large dictionary). If a generated typo is actually a real word (like "form" instead of "from"), it is removed. This prevents the tool from flagging correct words as typos.
 3.  **Saving:** The final list is formatted and saved to your output file or printed to the screen.

--- a/gentypos.py
+++ b/gentypos.py
@@ -10,7 +10,7 @@ Features:
     - Generates typos based on common typing patterns (skipping letters, swapping neighbors, and so on).
     - Uses keyboard adjacency to predict likely finger-slips on a QWERTY layout.
     - Supports custom substitution rules for specific character patterns (for example, 'ph' -> 'f').
-    - Checks generated typos against a list of valid words and removes any that are correct words.
+    - Checks generated typos against the large dictionary and removes any that are correct words.
     - Can process words directly from the command line or from a text file.
     - Integrates with results from 'typostats.py' to use your own personal typo history.
 
@@ -740,14 +740,14 @@ def _run_typo_generation(
     filtered_typos_count = 0
 
     if all_words:
-        logging.info("Filtering typos against the list of valid words...")
+        logging.info("Filtering typos against the large dictionary...")
         filter_start_time = time.perf_counter()
 
         for typo, correct_words in typo_to_correct_word.items():
             if typo in all_words:
                 filtered_typos_count += 1
                 logging.debug(
-                    "Filtered out typo '%s' as it exists in the list of valid words.", typo
+                    "Filtered out typo '%s' as it exists in the large dictionary.", typo
                 )
                 continue
             filtered_typo_to_correct_word[typo] = ', '.join(correct_words)
@@ -761,8 +761,8 @@ def _run_typo_generation(
             filter_duration,
         )
     else:
-        # No valid word filtering
-        logging.info("Skipping valid word filtering (list of valid words empty or disabled).")
+        # No large dictionary filtering
+        logging.info("Skipping large dictionary filtering (large dictionary empty or disabled).")
         for typo, correct_words in typo_to_correct_word.items():
             filtered_typo_to_correct_word[typo] = ', '.join(correct_words)
 
@@ -836,7 +836,7 @@ def main() -> None:
     gen_group.add_argument(
         '--no-filter',
         action='store_true',
-        help="Do not check typos against the list of valid words (this is faster).",
+        help="Do not check typos against the large dictionary (this is faster).",
     )
     gen_group.add_argument(
         '-v', '--verbose',
@@ -932,11 +932,11 @@ def main() -> None:
         word_list = [w.lower() for w in cli_words]
         logging.info(f"Processing {len(word_list)} words from CLI arguments.")
     else:
-        logging.info("Loading wordlist (source words)...")
+        logging.info("Loading wordlist (small dictionary)...")
         word_set = load_file(settings.input_file)
         word_list = list(word_set)
         logging.info(
-            "Loaded %d words from the source words ('%s').",
+            "Loaded %d words from the small dictionary ('%s').",
             len(word_list),
             settings.input_file,
         )
@@ -952,10 +952,10 @@ def main() -> None:
                 settings.dictionary_file,
             )
         else:
-            logging.info("Loading valid words (list of valid words)...")
+            logging.info("Loading large dictionary...")
             all_words = load_file(settings.dictionary_file)
             logging.info(
-                "Loaded %d words from the list of valid words ('%s').",
+                "Loaded %d words from the large dictionary ('%s').",
                 len(all_words),
                 settings.dictionary_file,
             )

--- a/gentypos.yaml
+++ b/gentypos.yaml
@@ -1,8 +1,8 @@
 # Configuration for Fake Typo Generator
 
 # File Paths
-input_file: "wordlist_small.txt"       # Path to the source words (one per line)
-dictionary_file: "wordlist_large.txt"     # Path to the valid words (used to filter out real words)
+input_file: "wordlist_small.txt"       # Path to the small dictionary (one per line)
+dictionary_file: "wordlist_large.txt"     # Path to the large dictionary (used to filter out real words)
 output_file: "typos_mega.toml"     # Path to the output file
 
 # Output_format options: arrow, csv, table, list


### PR DESCRIPTION
This pull request standardizes the terminology used in the `gentypos` tool to improve clarity for users.

### Type:
Documentation / Internal Help

### What:
Modified `gentypos.py`, `docs/gentypos.md`, and `gentypos.yaml` to use consistent terms for input files.

### Why:
Previously, the input files were referred to as "source words" and "valid words" in some places, and "small dictionary" and "large dictionary" in others. Standardizing on "small dictionary" and "large dictionary" makes the tool easier to understand and aligns with the example configuration files.

**Changes:**
- In `gentypos.py`: Updated docstrings, internal logging messages, and CLI help strings.
- In `docs/gentypos.md`: Updated the main documentation and configuration examples.
- In `gentypos.yaml`: Updated comments to reflect the new terminology.

---
*PR created automatically by Jules for task [9873530473928969768](https://jules.google.com/task/9873530473928969768) started by @RainRat*