### PR TITLE
[FEAT] Mapping-based auditing for count mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -1400,6 +1400,8 @@ def count_mode(
     delimiter: str | None = None,
     smart: bool = False,
     pairs: bool = False,
+    mapping_file: str | None = None,
+    ad_hoc: List[str] | None = None,
 ) -> None:
     """
     Counts the frequency of each word or pair in the input file(s) and writes the
@@ -1413,8 +1415,27 @@ def count_mode(
     item_counts = Counter()
 
     start_time = time.perf_counter()
-    if pairs:
-        # Mode for counting typo -> correction pairs
+
+    # Mapping-based auditing
+    mapping = None
+    if mapping_file or ad_hoc:
+        mapping = _resolve_full_mapping(mapping_file, ad_hoc, clean_items, quiet=quiet)
+        pairs = True  # Automatically enable pairs for mapping audit
+
+    if mapping:
+        # Audit mode: Count occurrences of mapped typos in input files
+        for input_file in input_files:
+            words_gen = _extract_words_items(input_file, delimiter=delimiter, quiet=quiet, smart=smart)
+            for word in words_gen:
+                raw_count += 1
+                match_key = filter_to_letters(word) if clean_items else word
+                if match_key in mapping:
+                    correction = mapping[match_key]
+                    if min_length <= len(match_key) <= max_length:
+                        filtered_items.append((match_key, correction))
+                        item_counts.update([(match_key, correction)])
+    elif pairs:
+        # Mode for counting typo -> correction pairs from existing mapping files
         for left, right in _extract_pairs(input_files, quiet=quiet):
             raw_count += 1
             if clean_items:
@@ -4518,9 +4539,9 @@ MODE_DETAILS = {
     },
     "count": {
         "summary": "Counts word or pair frequencies.",
-        "description": "Counts frequency and sorts the list from most frequent to least frequent. Use -f arrow for a rich visual report with bar charts. Use --pairs to count word pairs (for example, typo -> correction) instead of single words.",
-        "example": "python multitool.py count typos.log -f arrow --smart --pairs",
-        "flags": "[--min-count N] [-d DELIM] [-S] [-p]",
+        "description": "Counts frequency and sorts the list from most frequent to least frequent. Use -f arrow for a rich visual report with bar charts. Use --pairs to count word pairs (for example, typo -> correction) instead of single words. You can also provide a mapping (via --mapping or --add) to count occurrences of specific typos across your files.",
+        "example": "python multitool.py count . --add teh:the --min-count 5 -f arrow",
+        "flags": "[-s S] [-a K:V] [-d D] [-S] [-p]",
     },
     "filterfragments": {
         "summary": "Removes words found inside others.",
@@ -5097,6 +5118,20 @@ def _build_parser() -> argparse.ArgumentParser:
         '-p', '--pairs',
         action='store_true',
         help='Count frequencies of word pairs (for example, typo -> correction) instead of single words.',
+    )
+    count_options.add_argument(
+        '-s', '--mapping',
+        type=str,
+        required=False,
+        help='Path to the mapping file for auditing.',
+    )
+    count_options.add_argument(
+        '-a', '--add',
+        dest='ad_hoc',
+        type=str,
+        nargs='+',
+        metavar='KEY:VALUE',
+        help='Extra mapping pairs (for example "teh:the") for auditing.',
     )
     _add_common_mode_arguments(count_parser, include_process_output=False)
 
@@ -6149,6 +6184,8 @@ def main() -> None:
                 'delimiter': delimiter,
                 'smart': getattr(args, 'smart', False),
                 'pairs': getattr(args, 'pairs', False),
+                'mapping_file': getattr(args, 'mapping', None),
+                'ad_hoc': getattr(args, 'ad_hoc', None),
             },
         ),
         'filterfragments': (

--- a/tests/test_multitool_count_audit.py
+++ b/tests/test_multitool_count_audit.py
@@ -1,0 +1,79 @@
+import pytest
+import multitool
+import io
+from contextlib import redirect_stdout, redirect_stderr
+
+def test_count_mode_mapping_audit(tmp_path):
+    # Create an input file with some text
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("teh quick brown fox jumps over teh lazy dog. The teh word is a typo.")
+
+    # Create an output file
+    output_file = tmp_path / "output.csv"
+
+    # Run count mode with an ad-hoc mapping
+    multitool.count_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=3,
+        max_length=1000,
+        process_output=False,
+        ad_hoc=["teh:the"],
+        output_format='csv',
+        quiet=True
+    )
+
+    # Check the output
+    content = output_file.read_text()
+    # CSV header: typo,correction,count
+    # Row: teh,the,3
+    assert "teh,the,3" in content
+
+def test_count_mode_mapping_file_audit(tmp_path):
+    # Create an input file
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("misstake misstake mistake error misstake")
+
+    # Create a mapping file
+    mapping_file = tmp_path / "mapping.csv"
+    mapping_file.write_text("misstake,mistake\nmistake,correct")
+
+    output_file = tmp_path / "output.csv"
+
+    multitool.count_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=1000,
+        process_output=False,
+        mapping_file=str(mapping_file),
+        output_format='csv',
+        quiet=True
+    )
+
+    content = output_file.read_text()
+    assert "misstake,mistake,3" in content
+    assert "mistake,correct,1" in content
+    assert "error" not in content
+
+def test_count_mode_no_mapping_behavior(tmp_path):
+    # Ensure default behavior is preserved
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("apple banana apple cherry")
+
+    output_file = tmp_path / "output.csv"
+
+    multitool.count_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=1000,
+        process_output=False,
+        output_format='csv',
+        quiet=True
+    )
+
+    content = output_file.read_text()
+    assert "apple,2" in content
+    assert "banana,1" in content
+    assert "cherry,1" in content


### PR DESCRIPTION
I have implemented a new "Mapping Audit" capability for the `count` mode in `multitool.py`.

### What:
The `count` mode can now accept a typo mapping (via `-s/--mapping` or `-a/--add`). When a mapping is provided, the tool specifically searches for and counts occurrences of those typos within your input files, rather than counting every unique word. The results are reported as typo-correction pairs with their respective frequencies.

### Why:
I noticed that while `multitool.py` had modes to *fix* typos (`scrub`) and *find* them with context (`scan`) using mappings, there was no easy way to *quantify* how often specific known typos appear across a project. Adding this to the `count` mode creates a logical bridge between discovery and remediation, allowing users to prioritize fixes based on actual occurrence data.

### Changes:
- **`multitool.py`**:
    - Enhanced `count_mode` function to support mapping-based logic.
    - Added `-s/--mapping` and `-a/--add` flags to the `count` subparser.
    - Updated `MODE_DETAILS` with new documentation and examples for the auditing feature.
    - Ensured backward compatibility with existing word counting and pair-list counting behaviors.
- **`tests/test_multitool_count_audit.py`**:
    - Added new tests verifying ad-hoc auditing, file-based mapping auditing, and regression safety for default counting.

The feature is zero-configuration and immediately useful for anyone managing large typo lists or auditing project health.

---
*PR created automatically by Jules for task [1265672905757885001](https://jules.google.com/task/1265672905757885001) started by @RainRat*