### PR TITLE
[UI/UX] Standardize table styling and visual hierarchy in CLI reports

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -807,12 +807,12 @@ def _write_paired_output(
 
             # Header and divider
             padding = "  "
-            # Bold the vertical separator
-            sep = f"{c_bold}│{c_reset}"
+            # Bold blue for table visual elements
+            sep = f"{c_bold}{c_blue}│{c_reset}"
             header = f"{padding}{c_bold}{c_blue}{left_header:<{max_left}}{c_reset} {sep} {c_bold}{c_blue}{right_header:<{max_right}}{c_reset}"
             # 3 chars for the separator " │ "
             visible_width = max_left + max_right + 3
-            divider = f"{padding}{c_bold}{'─' * visible_width}{c_reset}"
+            divider = f"{padding}{c_bold}{c_blue}{'─' * visible_width}{c_reset}"
 
             out_file.write(f"\n{header}\n")
             out_file.write(f"{divider}\n")
@@ -1579,16 +1579,16 @@ def count_mode(
             # Format item labels for visualization
             if pairs:
                 labels = [f"{item[0]} -> {item[1]}" for item, _ in final_results]
-                item_header = "TYPO -> CORRECTION"
+                item_header = "Typo -> Correction"
             else:
                 labels = [str(item) for item, _ in final_results]
-                item_header = "ITEM"
+                item_header = "Item"
 
             # Find max width for columns
             max_item = max((len(label) for label in labels), default=len(item_header))
             max_item = max(max_item, len(item_header))
             max_count_len = max((len(str(count)) for item, count in final_results), default=5)
-            max_count_len = max(max_count_len, 5)  # 'COUNT'
+            max_count_len = max(max_count_len, 5)  # 'Count'
             max_pct = 6  # "100.0%"
             max_bar = 20
 
@@ -1610,18 +1610,19 @@ def count_mode(
 
             # Header and divider
             padding = "  "
-            sep = f"{c_out_bold}│{c_out_reset}"
+            # Bold blue for table visual elements
+            sep = f"{c_out_bold}{c_out_blue}│{c_out_reset}"
 
             # Define table header and divider
             # We use c_out_* for the visual components of the table
             header = (
                 f"{padding}{c_out_bold}{c_out_blue}{item_header:<{max_item}}{c_out_reset} {sep} "
-                f"{c_out_bold}{c_out_blue}{'COUNT':>{max_count_len}}{c_out_reset} {sep} "
+                f"{c_out_bold}{c_out_blue}{'Count':>{max_count_len}}{c_out_reset} {sep} "
                 f"{c_out_bold}{c_out_blue}{'%':>{max_pct}}{c_out_reset} {sep} "
-                f"{c_out_bold}{c_out_blue}{'VISUAL':<{max_bar}}{c_out_reset}"
+                f"{c_out_bold}{c_out_blue}{'Visual':<{max_bar}}{c_out_reset}"
             )
             visible_header_len = max_item + max_count_len + max_pct + max_bar + 9
-            divider = f"{padding}{c_out_bold}{'─' * visible_header_len}{c_out_reset}"
+            divider = f"{padding}{c_out_bold}{c_out_blue}{'─' * visible_header_len}{c_out_reset}"
             header_block = f"\n{header}\n{divider}\n"
 
             # If not quiet OR writing to a file, prepare and write the summary and header block.

--- a/tests/test_multitool_count_enhanced_visual.py
+++ b/tests/test_multitool_count_enhanced_visual.py
@@ -50,9 +50,9 @@ def test_count_mode_visual_report_content(tmp_path, monkeypatch):
     assert "ANALYSIS SUMMARY" in content
     assert "Total words encountered" in content
     assert "Retention rate" in content
-    assert "ITEM" in content
-    assert "COUNT" in content
-    assert "VISUAL" in content
+    assert "Item" in content
+    assert "Count" in content
+    assert "Visual" in content
     assert "apple" in content
     assert "banana" in content
     assert "66.7%" in content

--- a/tests/test_multitool_count_pairs.py
+++ b/tests/test_multitool_count_pairs.py
@@ -81,7 +81,7 @@ def test_count_mode_pairs_arrow_visual(tmp_path):
     )
 
     content = output_file.read_text()
-    assert "TYPO -> CORRECTION" in content
+    assert "Typo -> Correction" in content
     assert "teh -> the" in content
     assert "recieve -> receive" in content
 

--- a/tests/test_multitool_final_gaps.py
+++ b/tests/test_multitool_final_gaps.py
@@ -62,7 +62,7 @@ def test_count_mode_arrow_stderr_coverage(tmp_path):
 
                 stderr_output = mock_stderr.getvalue()
                 assert "ANALYSIS SUMMARY" in stderr_output
-                assert "ITEM" in stderr_output # Header
+                assert "Item" in stderr_output # Header
 
 def test_highlight_mode_limit(tmp_path):
     """Cover line 3091: limit in highlight_mode."""
@@ -133,4 +133,4 @@ def test_count_mode_arrow_to_file_header_coverage(tmp_path):
 
     content = output_file.read_text()
     assert "ANALYSIS SUMMARY" in content
-    assert "ITEM" in content
+    assert "Item" in content


### PR DESCRIPTION
### [UI/UX] Standardize table styling and visual hierarchy in CLI reports

**Context:** CLI
**Problem:** The "arrow" report format (the primary visual reporting mode) had inconsistent styling compared to the tool's standard "ANALYSIS SUMMARY" blocks. Vertical separators and horizontal dividers lacked accent coloring, and some headers used all-caps while others used title case, which impaired visual cohesion and scannability.
**Solution:** I standardized the styling and visual hierarchy of all "arrow" format reports. Specifically:
- Introduced Bold Blue styling for vertical separators (`│`) and horizontal dividers (`─`) in `_write_paired_output` and `count_mode`, aligning them with the project's dashboard aesthetic.
- Updated column headers in `count_mode` and other modes (e.g., "ITEM" -> "Item", "COUNT" -> "Count", "TYPO -> CORRECTION" -> "Typo -> Correction") to use Title Case, improving readability and consistency with other tool outputs.
- Updated the test suite (`test_multitool_count_enhanced_visual.py`, `test_multitool_count_pairs.py`, `test_multitool_final_gaps.py`) to match the new formatting.

**Changes:**
- Modified `multitool.py` to update visual styles and header text in `_write_paired_output` and `count_mode`.
- Updated test assertions in `tests/test_multitool_count_enhanced_visual.py`, `tests/test_multitool_count_pairs.py`, and `tests/test_multitool_final_gaps.py`.

---
*PR created automatically by Jules for task [11822023812172645626](https://jules.google.com/task/11822023812172645626) started by @RainRat*