### PR TITLE
Simplify subword splitting logic in diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -152,17 +152,10 @@ def split_into_subwords(word: str) -> List[str]:
     Returns:
         list: A list of subwords.
     """
-    # First, split by underscores, spaces, and hyphens
-    parts = re.split(r'[ _-]+', word)
+    pattern = r'[A-Z]?[a-z]+|[A-Z]+(?![a-z])|[0-9]+'
     subwords = []
-    for part in parts:
-        # Split based on casing (camelCase, PascalCase)
-        # This regex will split before uppercase letters that follow lowercase letters
-        split_parts = re.findall(r'[A-Z]?[a-z]+|[A-Z]+(?![a-z])|[0-9]+', part)
-        if split_parts:
-            subwords.extend(split_parts)
-        else:
-            subwords.append(part)
+    for part in re.split(r'[ _-]+', word):
+        subwords.extend(re.findall(pattern, part) or [part])
     return subwords
 
 def read_words_mapping(file_path: str, required: bool = True) -> Dict[str, Set[str]]:


### PR DESCRIPTION
### What:
Refactored the `split_into_subwords` function in `diff2typo.py` to simplify its internal logic.

### Why:
The original implementation used a verbose `if/else` block and multiple steps to handle cases where subword patterns were not found. The new implementation uses a concise `subwords.extend(re.findall(pattern, part) or [part])` pattern within the existing loop. This improves readability and maintainability without changing the external behavior or the handling of edge cases (like strings consisting only of special characters). No breaking changes were introduced, and all 631 tests in the suite pass.

---
*PR created automatically by Jules for task [9915944210084064091](https://jules.google.com/task/9915944210084064091) started by @RainRat*