### PR TITLE
[UI/UX] Standardize arrow report format across all modes

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -779,7 +779,7 @@ def _write_paired_output(
             out_file.write("| :--- | :--- |\n")
             for left, right in pairs_list:
                 out_file.write(f"| {left} | {right} |\n")
-        elif output_format == 'arrow' and (out_file.isatty() or os.environ.get('FORCE_COLOR')):
+        elif output_format == 'arrow':
             # Dynamic column width calculation for aligned table
             max_left = max((len(str(left)) for left, _ in pairs_list), default=len(left_header))
             max_left = max(max_left, len(left_header))


### PR DESCRIPTION
**PR Title:** [UI/UX] Standardize arrow report format across all modes 
**Description:** 
* **Context:** CLI 
* **Problem:** The "arrow" output format (aligned table) in `multitool.py` was only rendered when outputting to a TTY. When redirected to a file or pipe, it fell back to a plain "typo -> correction" format, creating an inconsistent user experience and making it difficult to generate aligned reports for documentation or sharing. 
* **Solution:** Removed the TTY-dependency for the "arrow" format's layout logic. The aligned table is now consistently rendered whenever `-f arrow` is specified, regardless of the output destination. Color codes still respect TTY/environment settings. This improves consistency with the `count` mode and provides a more polished "stock" experience for all paired-data modes. 
**Changes:** 
Modified `multitool.py` to ensure `_write_paired_output` always uses the aligned table layout for the `arrow` format.

---
*PR created automatically by Jules for task [17447908457553101428](https://jules.google.com/task/17447908457553101428) started by @RainRat*