### PR TITLE
[FEAT] Direct Git integration for diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -37,6 +37,7 @@ import glob
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -382,6 +383,26 @@ def _read_diff_file(file_path: str) -> str:
         sys.exit(1)
 
 
+def _read_git_diff(git_args: Optional[str]) -> str:
+    """Fetch diff directly from git using the provided arguments."""
+    command = ["git", "diff"]
+    if git_args:
+        command.extend(shlex.split(git_args))
+
+    try:
+        logging.info(f"Running git command: {' '.join(command)}")
+        result = subprocess.run(
+            command, capture_output=True, text=True, check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Git command failed: {e.stderr}")
+        sys.exit(1)
+    except FileNotFoundError:
+        logging.error("Git executable not found.")
+        sys.exit(1)
+
+
 def _read_diff_sources(input_files: Optional[Sequence[str]]) -> str:
     """Return concatenated diff text from standard input or the provided file patterns."""
 
@@ -587,6 +608,12 @@ def main():
         help="One or more input git diff files or patterns. Use '-' to read from standard input.",
     )
     io_group.add_argument(
+        '--git',
+        nargs='?',
+        const='',
+        help="Fetch diff directly from Git. Optional arguments are passed to 'git diff'.",
+    )
+    io_group.add_argument(
         '--input',
         '-i',
         dest='input_files_flag',
@@ -706,7 +733,10 @@ def main():
     flag_inputs = getattr(args, 'input_files_flag', []) or []
     input_files = pos_inputs + flag_inputs
 
-    diff_text = _read_diff_sources(input_files)
+    if args.git is not None:
+        diff_text = _read_git_diff(args.git)
+    else:
+        diff_text = _read_diff_sources(input_files)
 
     # Load the dictionary (words mapping) once.
     # If the file is missing, we don't exit. Instead we just warn and continue without filtering.


### PR DESCRIPTION
I've identified that the primary workflow for `diff2typo.py` involves analyzing Git history, but previously required users to manually pipe output from Git into the tool. To reduce friction and improve the "Happy Path," I implemented **Direct Git Integration**.

### What:
- Added a `--git` flag to `diff2typo.py`.
- This flag allows the tool to execute `git diff` internally and process the output directly.
- It accepts optional arguments that are passed to the underlying Git command (e.g., `--git "HEAD~5"` or `--git master`).
- Uses `shlex` for robust parsing of complex Git arguments.

### Why:
- **Convenience:** Streamlines the core task of learning from past typos fixed in Git.
- **Zero-Configuration:** Works out-of-the-box in any Git repository without requiring external files or pipe knowledge.
- **Symmetry:** The tool is designed to work with Git diffs; it now has the capability to "read" from Git directly instead of just reading "about" Git from a file.

The implementation is non-breaking and maintains full backward compatibility with existing file and stdin processing. All 631 existing tests passed.

---
*PR created automatically by Jules for task [12592853795147312729](https://jules.google.com/task/12592853795147312729) started by @RainRat*