### PR TITLE
[DOCS] Standardize "Large Dictionary" terminology in diff2typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The **diff2typo Suite** is a set of tools to help you find and fix typos in your
 
 Follow these steps to find typos you have fixed recently and identify your common mistakes.
 
-### 1. Create a Word List
-The tools work best when they know which words are correct. Create a file named `words.csv` and add words you use often (like project names or technical terms), one per line. If you skip this, the tools will still work, but they might flag some correct words as typos.
+### 1. Create a Large Dictionary
+The tools work best when they know which words are correct. Create a file named `words.csv` and add words you use often (like project names or technical terms), one per line. This is your "large dictionary." If you skip this, the tools will still work, but they might flag some correct words as typos.
 
 ### 2. Get Your Recent Changes
 Save your recent Git changes to a file. For example, to see your last 5 changes:

--- a/diff2typo.py
+++ b/diff2typo.py
@@ -2,13 +2,13 @@
 diff2typo.py
 
 Purpose:
-    Read a git diff to find typo corrections and prepare an update for the `typos` tool.
+    Read a Git diff to find typo corrections and prepare an update for the `typos` tool.
     This helps make sure that the typos you find are caught in future code changes.
 
 Features:
-    - Finds typo corrections in git diffs.
+    - Finds typo corrections in Git diffs.
     - Splits compound words based on spaces, underscores, and capital letters.
-    - Skips corrections where the "before" word is already a valid word.
+    - Skips corrections where the "before" word is already in the large dictionary.
     - Works with the `typos` tool to avoid duplicate entries.
     - Automatically detects the word list file format.
     - Allows customization through command-line options.
@@ -167,11 +167,11 @@ def read_words_mapping(file_path: str, required: bool = True) -> Dict[str, Set[s
     Each row should be in the form:
          incorrect_word, correction1, correction2, ...
 
-    We can also accept a list of valid words. They will
+    We can also accept a list of words for the large dictionary. They will
         not have any corrections.
     """
     mapping: Dict[str, Set[str]] = {}
-    rows = _read_csv_rows(file_path, "Dictionary file", required=required)
+    rows = _read_csv_rows(file_path, "Large dictionary file", required=required)
     for row in rows:
         if row:
             incorrect = row[0].strip().lower()
@@ -269,7 +269,7 @@ def find_typos(diff_text: str, min_length: int = 2, max_dist: Optional[int] = No
     Parses the diff text to identify typo corrections.
 
     Args:
-        diff_text (str): The git diff text.
+        diff_text (str): The Git diff text.
         min_length (int): Minimum length of differing substrings to consider as typos.
         max_dist (int, optional): Maximum Levenshtein distance for typos.
 
@@ -377,7 +377,7 @@ def _read_diff_file(file_path: str) -> str:
 
 
 def _read_git_diff(git_args: Optional[str]) -> str:
-    """Fetch diff directly from git using the provided arguments."""
+    """Fetch diff directly from Git using the provided arguments."""
     command = ["git", "diff"]
     if git_args:
         command.extend(shlex.split(git_args))
@@ -492,11 +492,11 @@ def _filter_candidates_by_set(candidates, filter_set, desc, quiet=False):
     return filtered_list
 
 
-def process_new_typos(candidates, args, valid_words, allowed_words):
+def process_new_typos(candidates, args, large_dictionary, allowed_words):
     """
     Find new typos that are not already known.
-    Uses allowed words and a list of valid words to filter the results.
-    The list can be a simple word list (one word per line) or a
+    Uses allowed words and the large dictionary to filter the results.
+    The large dictionary can be a simple word list (one word per line) or a
     CSV file where the first word is a typo and the rest are corrections.
     Returns the formatted list of new typos.
     """
@@ -509,8 +509,8 @@ def process_new_typos(candidates, args, valid_words, allowed_words):
     )
     filtered_candidates = _filter_candidates_by_set(
         candidates,
-        filter_set=valid_words,
-        desc="Filtering dictionary words",
+        filter_set=large_dictionary,
+        desc="Filtering large dictionary words",
         quiet=args.quiet,
     )
 
@@ -538,7 +538,7 @@ def process_new_corrections(candidates, words_mapping, quiet=False):
     new_corrections = []
 
     if not words_mapping:
-        logging.info("Dictionary mapping is empty; skipping new corrections search.")
+        logging.info("Large dictionary mapping is empty; skipping new corrections search.")
         return new_corrections
 
     progress = None
@@ -560,19 +560,19 @@ def process_new_corrections(candidates, words_mapping, quiet=False):
     return new_corrections
 
 
-def process_audit_typos(candidates, args, valid_words, allowed_words):
+def process_audit_typos(candidates, args, large_dictionary, allowed_words):
     """
     Find cases where a correct word was changed into a typo.
     Identifies cases where a word that used to be valid
-    was changed to a word that is not in the dictionary.
+    was changed to a word that is not in the large dictionary.
     """
     audit_candidates = []
     for candidate in candidates:
         if ' -> ' in candidate:
             before, after = [s.strip().lower() for s in candidate.split(' -> ')]
             # Find cases where a valid word was changed to an invalid one
-            if before in valid_words:
-                if after not in valid_words and after not in allowed_words:
+            if before in large_dictionary:
+                if after not in large_dictionary and after not in allowed_words:
                     audit_candidates.append(candidate)
 
     audit_candidates = sorted(set(audit_candidates))
@@ -584,7 +584,7 @@ def main():
 
     # Setup command-line argument parsing
     parser = argparse.ArgumentParser(
-        description=f"{BOLD}Process a git diff to identify typos for the `typos` tool.{RESET}",
+        description=f"{BOLD}Process a Git diff to identify typos for the `typos` tool.{RESET}",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=f"""{BLUE}Examples:{RESET}
   {GREEN}python diff2typo.py diff.txt --output typos.txt --mode typos{RESET}
@@ -598,7 +598,7 @@ def main():
         'input_files',
         nargs='*',
         metavar='FILE',
-        help="One or more input git diff files or patterns. Use '-' to read from standard input.",
+        help="One or more input Git diff files or patterns. Use '-' to read from standard input.",
     )
     io_group.add_argument(
         '--git',
@@ -650,8 +650,8 @@ def main():
         default='typos',
         help=(
             f"{YELLOW}Analysis mode:{RESET}\n"
-            f"  {GREEN}typos{RESET}:       Find new typos that are not in your dictionary (default).\n"
-            f"  {GREEN}corrections{RESET}: Find new corrections for typos already in your dictionary.\n"
+            f"  {GREEN}typos{RESET}:       Find new typos that are not in your large dictionary (default).\n"
+            f"  {GREEN}corrections{RESET}: Find new corrections for typos already in your large dictionary.\n"
             f"  {GREEN}both{RESET}:        Run both analyses and label the results.\n"
             f"  {GREEN}audit{RESET}:       Find cases where a correct word was changed into a typo."
         ),
@@ -680,7 +680,7 @@ def main():
         dest='dictionary_file',
         type=str,
         default='words.csv',
-        help='The file containing valid words (default: words.csv).',
+        help='The file containing the large dictionary (default: words.csv).',
     )
     # Hidden alias for backward compatibility
     parser.add_argument('--dictionary_file', type=str, help=argparse.SUPPRESS, default=argparse.SUPPRESS)
@@ -731,14 +731,14 @@ def main():
     else:
         diff_text = _read_diff_sources(input_files)
 
-    # Load the dictionary (words mapping) once.
+    # Load the large dictionary (words mapping) once.
     # If the file is missing, we don't exit. Instead we just warn and continue without filtering.
     if args.dictionary_file == 'words.csv' and not os.path.exists(args.dictionary_file):
-        logging.warning("Default dictionary file 'words.csv' not found. Skipping valid word filtering.")
-        dictionary_mapping = {}
+        logging.warning("Default large dictionary file 'words.csv' not found. Skipping filtering.")
+        large_dictionary_mapping = {}
     else:
         # If it's NOT the default words.csv, it will also warn and continue if missing.
-        dictionary_mapping = read_words_mapping(args.dictionary_file, required=False)
+        large_dictionary_mapping = read_words_mapping(args.dictionary_file, required=False)
 
     try:
         allowed_words = read_allowed_words(args.allowed_file)
@@ -747,15 +747,15 @@ def main():
             "Failed to read allowed words file '%s': %s", args.allowed_file, exc
         )
         sys.exit(1)
-    # Build a set of valid words. For simple word lists, every entry is treated as
-    # valid. For words.csv files, only the corrections (columns after the first)
-    # are considered valid words.
-    valid_words = set()
-    for typo, fixes in dictionary_mapping.items():
+    # Build a set of words for the large dictionary. For simple word lists, every
+    # entry is treated as correct. For words.csv files, only the corrections
+    # (columns after the first) are considered correct words.
+    large_dictionary = set()
+    for typo, fixes in large_dictionary_mapping.items():
         if fixes:
-            valid_words.update(fixes)
+            large_dictionary.update(fixes)
         else:
-            valid_words.add(typo)
+            large_dictionary.add(typo)
 
     # Find candidate typo corrections from the diff.
     logging.info("Finding potential typo corrections from the diff...")
@@ -771,20 +771,20 @@ def main():
     # Process new typos if requested.
     if args.mode in ['typos', 'both']:
         logging.info("Processing new typos (filtering out known typos)...")
-        new_typos_result = process_new_typos(candidates, args, valid_words, allowed_words)
+        new_typos_result = process_new_typos(candidates, args, large_dictionary, allowed_words)
         logging.info(f"Found {len(new_typos_result)} new typo(s).")
 
     # Process new corrections if requested.
     if args.mode in ['corrections', 'both']:
         logging.info("Processing new corrections to existing typos...")
-        new_corrections_raw = process_new_corrections(candidates, dictionary_mapping, quiet=args.quiet)
+        new_corrections_raw = process_new_corrections(candidates, large_dictionary_mapping, quiet=args.quiet)
         new_corrections_result = format_typos(new_corrections_raw, args.output_format)
         logging.info(f"Found {len(new_corrections_result)} new correction(s).")
 
     # Check for correct words changed into typos if requested.
     if args.mode == 'audit':
         logging.info("Finding cases where correct words were changed into typos...")
-        audit_result = process_audit_typos(candidates, args, valid_words, allowed_words)
+        audit_result = process_audit_typos(candidates, args, large_dictionary, allowed_words)
         logging.info(f"Found {len(audit_result)} case(s) where a correct word was changed to a typo.")
 
     # Combine results if needed.

--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -16,7 +16,7 @@ git diff | python diff2typo.py [OPTIONS]
 
 1. **Find typos in diffs:** Reads Git diff files or data sent directly from other commands to find words you have corrected.
 2. **Variable Support:** Automatically splits compound words like `camelCase` and `snake_case` to find typos hidden inside variable names.
-3. **Smart Filtering:** Uses a dictionary of valid words and a list of "allowed" words to prevent the tool from reporting correct words as typos.
+3. **Smart Filtering:** Uses a large dictionary of correct words and a list of "allowed" words to prevent the tool from reporting correct words as typos.
 4. **Integration:** Can check your findings against the external `typos` tool to ensure your list only contains new mistakes.
 
 ## Options
@@ -26,10 +26,10 @@ git diff | python diff2typo.py [OPTIONS]
 | `FILE` | standard input | One or more input Git diff files. Use `-` to read from standard input. |
 | `--output`, `-o` | the screen | Path to the output file. Use `-` to print to the screen. |
 | `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), or `list` (typo only). |
-| `--mode` | `typos` | **`typos`**: Find new typos that are not in your dictionary (default).<br>**`corrections`**: Find new ways to fix typos that are already in your dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
+| `--mode` | `typos` | **`typos`**: Find new typos that are not in your large dictionary (default).<br>**`corrections`**: Find new ways to fix typos that are already in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
 | `--min-length`, `-m` | `2` | Ignore words shorter than this length. |
 | `--max-dist` | None | Only include typos with a number of character changes up to this value. Useful for filtering out intentional word changes. |
-| `--dictionary`, `-d` | `words.csv` | A file containing valid words. The tool uses this to make sure the "fix" is a real word. |
+| `--dictionary`, `-d` | `words.csv` | A file containing the large dictionary of correct words. The tool uses this to make sure the "fix" is a real word. |
 | `--allowed` | `allowed.csv` | A list of words to explicitly ignore, even if they look like typos. |
 | `--typos-path` | `typos` | The path to the external `typos` tool. |
 | `--quiet`, `-q` | Off | Hide progress bars and status messages. |

--- a/tests/test_diff2typo.py
+++ b/tests/test_diff2typo.py
@@ -130,7 +130,7 @@ def test_process_new_typos(tmp_path, monkeypatch):
     allowed.write_text('teh\n')
     args = SimpleNamespace(typos_tool_path='nonexistent', allowed_file=str(allowed), output_format='arrow', quiet=True)
     candidates = ['mispell -> misspell', 'teh -> the', 'recieve -> receive', 'recieve -> receive']
-    result = diff2typo.process_new_typos(candidates, args, {'mispell'}, {'teh'})
+    result = diff2typo.process_new_typos(candidates, args, large_dictionary={'mispell'}, allowed_words={'teh'})
     assert result == ['recieve -> receive']
 
 
@@ -161,7 +161,7 @@ def test_read_words_mapping_file_not_found(tmp_path, caplog):
     with caplog.at_level(logging.WARNING):
         result = diff2typo.read_words_mapping(str(tmp_path / 'missing.csv'), required=False)
     assert result == {}
-    assert any("Dictionary file" in message and "not found" in message for message in caplog.messages)
+    assert any("Large dictionary file" in message and "not found" in message for message in caplog.messages)
 
 
 def test_read_allowed_words_logs_warning(tmp_path, caplog):
@@ -282,7 +282,7 @@ def test_main_dictionary_file_missing_message(monkeypatch, tmp_path, caplog):
     with caplog.at_level(logging.WARNING):
         diff2typo.main()
 
-    assert any('Dictionary file' in message and 'not found' in message for message in caplog.messages)
+    assert any('Large dictionary file' in message and 'not found' in message for message in caplog.messages)
 
 
 def test_main_reads_stdin(monkeypatch, tmp_path):
@@ -423,7 +423,7 @@ def test_process_new_typos_quiet_suppresses_progress(monkeypatch):
     )
     candidates = ['mispell -> misspell', 'eror -> error']
 
-    result = diff2typo.process_new_typos(candidates, args, valid_words=set(), allowed_words=set())
+    result = diff2typo.process_new_typos(candidates, args, large_dictionary=set(), allowed_words=set())
     assert result == ['eror -> error', 'mispell -> misspell']
 
 

--- a/tests/test_diff2typo_coverage.py
+++ b/tests/test_diff2typo_coverage.py
@@ -107,7 +107,7 @@ def test_process_new_corrections_empty_mapping(caplog):
     with caplog.at_level(logging.INFO):
         result = diff2typo.process_new_corrections(["a -> b"], {}, quiet=True)
         assert result == []
-        assert "Dictionary mapping is empty" in caplog.text
+        assert "Large dictionary mapping is empty" in caplog.text
 
 def test_process_new_corrections_quiet_false():
     diff2typo.process_new_corrections(["a -> b"], {"a": {"c"}}, quiet=False)


### PR DESCRIPTION
This PR standardizes the terminology used for the primary reference word list across the repository.

### Key Changes:
- **README.md:** Replaced "Word List" with "Large Dictionary" in the Quick Start guide.
- **docs/diff2typo.md:** Updated descriptions and table entries to use "large dictionary" and "correct words" instead of "dictionary" and "valid words".
- **diff2typo.py:** 
    - Updated CLI help strings (`--help`) to use "large dictionary".
    - Capitalized "Git" in all docstrings, comments, and help messages.
    - Refactored internal variables (e.g., `valid_words` to `large_dictionary`) and function parameters for consistency.
- **Tests:** Updated `tests/test_diff2typo.py` and `tests/test_diff2typo_coverage.py` to match the new terminology and variable names, ensuring all 53 tests pass.

This alignment improves project consistency and ensures that documentation accurately reflects the tool's internal logic and help text.

---
*PR created automatically by Jules for task [16023013177715788294](https://jules.google.com/task/16023013177715788294) started by @RainRat*