### PR TITLE
[DOCS] Standardize terminology across documentation and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The **diff2typo Suite** is a set of tools to help you find and fix typos in your
 
 ## 🚀 Quick Start
 
-Follow these steps to find typos you have fixed recently and identify your common mistakes.
+Follow these steps to find typos you have fixed recently and see your common mistakes.
 
 ### 1. Create a Large Dictionary
 The tools work best when they know which words are correct. Create a file named `words.csv` and add words you use often (like project names or technical terms), one per line. This is your "large dictionary." If you skip this, the tools will still work, but they might flag some correct words as typos.

--- a/diff2typo.py
+++ b/diff2typo.py
@@ -563,7 +563,7 @@ def process_corrections_mode(candidates, words_mapping, quiet=False):
 def process_audit_typos(candidates, args, large_dictionary, allowed_words):
     """
     Find cases where a correct word was changed into a typo.
-    Identifies cases where a word that used to be valid
+    Finds cases where a word that used to be valid
     was changed to a word that is not in the large dictionary.
     """
     audit_candidates = []

--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -243,7 +243,7 @@ These modes help you analyze your data.
   - **Example:** `python multitool.py discovery code.py --smart --rare-max 2 --freq-min 10 --max-dist 1`
 
 - **`casing`**
-  - **What it does:** Finds words that appear in your files with multiple different casing styles (for example, 'hello', 'Hello', 'HELLO'). This is useful for identifying inconsistent naming or typos that differ only by case.
+  - **What it does:** Finds words that appear in your files with multiple different casing styles (for example, 'hello', 'Hello', 'HELLO'). This is useful for finding inconsistent naming or typos that differ only by case.
   - **Options:**
     - `-d`, `--delimiter`: The character to split words by (default: whitespace).
     - `-S`, `--smart`: Split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").
@@ -276,7 +276,7 @@ These modes help you analyze your data.
   - **Example:** `python multitool.py scan . --add teh:the --smart`
 
 - **`verify`**
-  - **What it does:** Identifies which entries in a mapping file or extra pairs are present in the provided input files. It provides a high-level summary of which typos were found and which were missing.
+  - **What it does:** Finds which entries in a mapping file or extra pairs are present in the provided input files. It provides a high-level summary of which typos were found and which were missing.
   - **Options:**
     - Use the `--mapping` flag to provide the file containing typos to check.
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) or words to match directly on the command line.

--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -38,7 +38,7 @@ The tool automatically recognizes three common ways of listing typos:
 - `--2to1`: Specifically look for double-to-single letter replacements.
 - `--include-deletions`: Include cases where you skipped a letter or typed an extra one.
 - `-t`, `--transposition`: Find swapped letters (like `teh` instead of `the`).
-- `-k`, `--keyboard`: Identify typos caused by hitting keys next to each other on the keyboard.
+- `-k`, `--keyboard`: Find typos caused by hitting keys next to each other on the keyboard.
 
 ### Output Options
 - `-f`, `--format`: Choose the output format:
@@ -58,9 +58,9 @@ When using the default **arrow** format, the report displays results in two sect
   ───────────────────────────────────────────────────────
   Total lines processed:              10
   Total pairs processed:              15
-  Replacements identified:            15
+  Replacements found:                 15
   Retention rate:                     100.0%
-  Unique patterns identified:         2
+  Unique patterns found:              2
   Enabled features:                   keyboard, transposition
   Keyboard Adjacency [K]:             12/15 (80.0%)
   Transpositions [T]:                 3/15 (20.0%)
@@ -76,7 +76,7 @@ When using the default **arrow** format, the report displays results in two sect
 ### Analysis Summary
 The dashboard at the top gives you an overview of your typo history:
 - **Total lines/pairs processed:** How much data was analyzed.
-- **Replacements identified:** How many actual mistakes were found.
+- **Replacements found:** How many actual mistakes were found.
 - **Unique patterns:** How many different types of mistakes were found.
 - **Keyboard Adjacency [K]:** Percentage of typos caused by hitting a key next to the correct one.
 - **Transpositions [T]:** Percentage of typos caused by swapping two letters.
@@ -88,13 +88,13 @@ This section breaks down every mistake:
 - **TYPO:** The mistake you actually made.
 - **COUNT:** How many times this specific mistake happened.
 - **%:** What percentage of all identified replacements this mistake represents.
-- **ATTR:** Special markers identifying the type of mistake (for example, `[K]` for keyboard slip).
+- **ATTR:** Special markers showing the type of mistake (for example, `[K]` for keyboard slip).
 - **VISUAL:** A small bar chart for quick comparison.
 
 For example, a row showing `o │ p` means you typed `p` when you meant to type `o`.
 
 ### Typo Attributes (ATTR)
-When you enable analysis features, the tool identifies specific patterns in the **ATTR** column:
+When you enable analysis features, the tool finds specific patterns in the **ATTR** column:
 - **[K]**: Keyboard slip (the keys are next to each other on a QWERTY layout).
 - **[T]**: Transposition (swapped letters, like `teh` instead of `the`).
 - **[M]**: Multiple letters replacement (for example, `m` to `rn` or `ph` to `f`).

--- a/gentypos.py
+++ b/gentypos.py
@@ -4,7 +4,7 @@ gentypos.py
 Purpose:
     Generate common typing errors (typos) for a list of words. This tool helps you
     predict mistakes people might make when typing specific words, which is
-    useful for building robust spell-checkers.
+    useful for building robust similar word matching tools.
 
 Features:
     - Generates typos based on common typing patterns (skipping letters, swapping neighbors, and so on).

--- a/multitool.py
+++ b/multitool.py
@@ -2025,7 +2025,7 @@ def conflict_mode(
     limit: int | None = None,
 ) -> None:
     """
-    Identifies typos that are associated with more than one unique correction.
+    Finds typos that are associated with more than one unique correction.
     """
     start_time = time.perf_counter()
     raw_pairs = _extract_pairs(input_files, quiet=quiet)
@@ -2076,7 +2076,7 @@ def cycles_mode(
     limit: int | None = None,
 ) -> None:
     """
-    Identifies repeated loops in typo-correction pairs.
+    Finds repeated loops in typo-correction pairs.
     """
     start_time = time.perf_counter()
     raw_pairs = _extract_pairs(input_files, quiet=quiet)
@@ -2411,7 +2411,7 @@ def casing_mode(
     limit: int | None = None,
 ) -> None:
     """
-    Identifies words that appear with inconsistent capitalization.
+    Finds words that appear with inconsistent capitalization.
     """
     start_time = time.perf_counter()
     raw_item_count = 0
@@ -2470,7 +2470,7 @@ def diff_mode(
     limit: int | None = None,
 ) -> None:
     """
-    Identifies added, removed, and changed items between two files or lists.
+    Finds added, removed, and changed items between two files or lists.
     """
     start_time = time.perf_counter()
     if pairs:
@@ -2601,7 +2601,7 @@ def repeated_mode(
     limit: int | None = None,
 ) -> None:
     """
-    Identifies consecutive identical words.
+    Finds consecutive identical words.
     """
     start_time = time.perf_counter()
     results = list(_extract_repeated_items(
@@ -2650,7 +2650,7 @@ def discovery_mode(
     smart: bool = False,
 ) -> None:
     """
-    Identifies potential typos by comparing rare words to frequent words.
+    Finds potential typos by comparing rare words to frequent words.
     """
     start_time = time.perf_counter()
     word_counts = Counter()
@@ -2666,7 +2666,7 @@ def discovery_mode(
             if filtered:
                 word_counts.update(filtered)
 
-    # Identify rare and frequent words
+    # Find rare and frequent words
     rare_words = sorted([word for word, count in word_counts.items() if count <= rare_max])
     frequent_words = sorted([word for word, count in word_counts.items() if count >= freq_min], key=len)
 
@@ -3243,7 +3243,7 @@ def resolve_mode(
     limit: int | None = None,
 ) -> None:
     """
-    Identifies and flattens chains of typo corrections. For example, if a list
+    Finds and flattens chains of typo corrections. For example, if a list
     contains A -> B and B -> C, this mode will update it to A -> C and B -> C.
     """
     start_time = time.perf_counter()
@@ -3611,7 +3611,7 @@ def standardize_mode(
                             if min_length <= len(sp_norm) <= max_length:
                                 variation_counts[sp_norm][sp] += 1
 
-    # Pass 2: Identify "winners" and build mapping
+    # Pass 2: Find "winners" and build mapping
     mapping = {}
 
     # 2a: Determine the best casing variation for each normalized word
@@ -4178,7 +4178,7 @@ def verify_mode(
     ad_hoc: List[str] | None = None,
 ) -> None:
     """
-    Identifies which entries in a mapping file are present in the provided input files.
+    Finds which entries in a mapping file are present in the provided input files.
     """
     start_time = time.perf_counter()
     # Load and merge mappings
@@ -4623,7 +4623,7 @@ MODE_DETAILS = {
     },
     "map": {
         "summary": "Replaces items using a mapping.",
-        "description": "Replaces items in your list with new values from a mapping file or extra pairs provided via --add. Supports CSV, Arrow, Table, JSON, and YAML mapping formats. Use --smart-case to preserve capitalization and --pairs to see both original and changed words. Length filters are re-applied to items after they are changed.",
+        "description": "Replaces items in your list with values from a mapping file or extra pairs provided via --add. Supports CSV, Arrow, Table, JSON, and YAML mapping formats. Use --smart-case to preserve capitalization and --pairs to see both original and changed words. Length filters are re-applied to items after they are changed.",
         "example": "python multitool.py map input.txt --add teh:the --smart-case --pairs",
         "flags": "MAPPING [FILES...] [-a K:V] [-p]",
     },
@@ -4647,7 +4647,7 @@ MODE_DETAILS = {
     },
     "conflict": {
         "summary": "Finds typos with multiple fixes.",
-        "description": "Identifies typos in your paired data that are associated with more than one unique correction. Use this to find inconsistencies in your typo lists.",
+        "description": "Finds typos in your paired data that are associated with more than one unique correction. Use this to find inconsistencies in your typo lists.",
         "example": "python multitool.py conflict typos.csv --output-format arrow --output conflicts.txt",
         "flags": "",
     },
@@ -4659,13 +4659,13 @@ MODE_DETAILS = {
     },
     "near_duplicates": {
         "summary": "Finds similar words in one list.",
-        "description": "Identifies pairs of words in your list that are very similar (only a few characters apart). Use this to find potential typos or unintended duplicates in a project.",
+        "description": "Finds pairs of words in your list that are very similar (only a few characters apart). Use this to find potential typos or unintended duplicates in a project.",
         "example": "python multitool.py near_duplicates words.txt --max-dist 1 --show-dist",
         "flags": "[--max-dist N] [--show-dist]",
     },
     "fuzzymatch": {
         "summary": "Finds similar words in two lists.",
-        "description": "Identifies words in your list that are similar to words in a second list (dictionary). Use this to find likely corrections for typos. It defaults to a threshold of 1 character change.",
+        "description": "Finds words in your list that are similar to words in a second list (dictionary). Use this to find likely corrections for typos. It defaults to a threshold of 1 character change.",
         "example": "python multitool.py fuzzymatch typos.txt dictionary.txt --max-dist 1 --show-dist",
         "flags": "[FILE2] [--max-dist N] [--show-dist]",
     },
@@ -4683,25 +4683,25 @@ MODE_DETAILS = {
     },
     "discovery": {
         "summary": "Finds typos in rare words.",
-        "description": "Automatically finds potential typos in a text by identifying rare words that are very similar to frequent words. It assumes that frequent words are likely correct and rare variations are likely typos. This is a powerful way to find errors without needing a dictionary.",
+        "description": "Automatically finds potential typos in a text by finding rare words that are very similar to frequent words. It assumes that frequent words are likely correct and rare variations are likely typos. This is a powerful way to find errors without needing a dictionary.",
         "example": "python multitool.py discovery code.py --smart --rare-max 2 --freq-min 10 --max-dist 1",
         "flags": "[--rare-max N] [-S]",
     },
     "casing": {
         "summary": "Finds inconsistent casing.",
-        "description": "Finds words that appear in your files with multiple different casing styles (for example, 'hello', 'Hello', 'HELLO'). This is useful for identifying inconsistent naming or typos that differ only by case.",
+        "description": "Finds words that appear in your files with multiple different casing styles (for example, 'hello', 'Hello', 'HELLO'). This is useful for finding inconsistent naming or typos that differ only by case.",
         "example": "python multitool.py casing report.txt --smart --output-format arrow",
         "flags": "[-d DELIM] [-S]",
     },
     "cycles": {
-        "summary": "Identifies loops in typo pairs.",
+        "summary": "Finds loops in typo pairs.",
         "description": "Detects cycles in your typo mappings (for example, 'A' maps to 'B' and 'B' maps back to 'A'). Repeated loops can cause issues during automated scrubbing and represent logic errors in your data.",
         "example": "python multitool.py cycles typos.csv --output-format arrow",
         "flags": "",
     },
     "repeated": {
         "summary": "Finds doubled words.",
-        "description": "Identifies doubled words (for example, 'the the') in your text. It outputs the duplicated pair and the suggested fix. Use --smart to handle CamelCase or punctuation.",
+        "description": "Finds doubled words (for example, 'the the') in your text. It outputs the duplicated pair and the suggested fix. Use --smart to handle CamelCase or punctuation.",
         "example": "python multitool.py repeated report.txt --smart --output-format arrow",
         "flags": "[-d DELIM] [-S]",
     },
@@ -4725,7 +4725,7 @@ MODE_DETAILS = {
     },
     "verify": {
         "summary": "Check if typos exist in project.",
-        "description": "Checks a mapping file or extra pairs against your files to see which ones are actually present. Use --prune to output a new mapping containing only the found typos. Use --smart to also search for subword matches in larger compound words.",
+        "description": "Finds which entries in a mapping file or extra pairs are present in the provided input files. It provides a high-level summary of which typos were found and which were missing.",
         "example": "python multitool.py verify . --mapping typos.csv --prune",
         "flags": "MAPPING [FILES...] [-a K:V] [-S] [--prune]",
     },
@@ -4743,7 +4743,7 @@ MODE_DETAILS = {
     },
     "diff": {
         "summary": "Finds differences between files.",
-        "description": "Identifies differences between two files or lists. It can track simple word additions/removals or (with --pairs) find changed corrections for existing typos. Color-coded output highlights what's new (+), what's gone (-), and what changed (~).",
+        "description": "Finds differences between two files or lists. It can track simple word additions/removals or (with --pairs) find changed corrections for existing typos. Color-coded output highlights what's new (+), what's gone (-), and what changed (~).",
         "example": "python multitool.py diff old_typos.csv new_typos.csv --pairs --output-format json",
         "flags": "[FILE2] [-p]",
     },
@@ -4755,7 +4755,7 @@ MODE_DETAILS = {
     },
     "resolve": {
         "summary": "Flatten typo correction chains.",
-        "description": "Identifies and flattens chains of corrections (for example, 'A' -> 'B' and 'B' -> 'C' becomes 'A' -> 'C'). This ensures that your mapping files always point directly to the final correct word, which improves the efficiency of scrubbing and analysis.",
+        "description": "Finds and flattens chains of corrections (for example, 'A' -> 'B' and 'B' -> 'C' becomes 'A' -> 'C'). This ensures that your mapping files always point directly to the final correct word, which improves the efficiency of scrubbing and analysis.",
         "example": "python multitool.py resolve mappings.csv --output resolved.csv",
         "flags": "",
     },
@@ -4987,7 +4987,7 @@ def _build_parser() -> argparse.ArgumentParser:
         nargs='?',
         choices=[*MODE_DETAILS.keys(), 'all'],
         metavar='MODE',
-        help="The mode to show help for (e.g., 'count', 'scrub', 'standardize').",
+        help="The mode to show help for (for example, 'count', 'scrub', 'standardize').",
     )
 
     arrow_parser = subparsers.add_parser(
@@ -5941,7 +5941,7 @@ def _build_parser() -> argparse.ArgumentParser:
     verify_options.add_argument(
         '--prune',
         action='store_true',
-        help='Output a new mapping containing only the found typos.',
+        help='Output a mapping containing only the found typos.',
     )
     _add_common_mode_arguments(verify_parser)
 

--- a/tests/test_multitool_count_audit.py
+++ b/tests/test_multitool_count_audit.py
@@ -8,7 +8,7 @@ def test_count_mode_mapping_audit(tmp_path):
     # Create an output file
     output_file = tmp_path / "output.csv"
 
-    # Run count mode with an ad-hoc mapping
+    # Run count mode with an extra mapping
     multitool.count_mode(
         input_files=[str(input_file)],
         output_file=str(output_file),

--- a/tests/test_multitool_diff_logic.py
+++ b/tests/test_multitool_diff_logic.py
@@ -67,7 +67,7 @@ def test_scrub_mode_diff_integration(tmp_path, capsys):
     input_file = tmp_path / "input.txt"
     input_file.write_text("teh typo")
 
-    # Run scrub_mode with diff=True and ad-hoc mapping
+    # Run scrub_mode with diff=True and extra mapping
     multitool.scrub_mode(
         input_files=[str(input_file)],
         mapping_file=None,

--- a/typostats.py
+++ b/typostats.py
@@ -220,7 +220,7 @@ def is_transposition(typo: str, correction: str) -> list[tuple[str, str]]:
     """
     Checks if a mistake was caused by swapping two letters next to each other.
 
-    For example, it identifies 'teh' instead of 'the' as a swapped letter mistake.
+    For example, it finds 'teh' instead of 'the' as a swapped letter mistake.
 
     Returns:
       A list with the swapped characters if found, otherwise an empty list.
@@ -246,7 +246,7 @@ def get_adjacent_keys(include_diagonals: bool = True) -> dict[str, set[str]]:
     """
     Creates a map of keys that are next to each other on a QWERTY keyboard.
 
-    This is used to identify typos caused by a finger slipping to a nearby key.
+    This is used to find typos caused by a finger slipping to a nearby key.
 
     Args:
         include_diagonals: Whether to count keys that are diagonal to each other.
@@ -301,7 +301,7 @@ def is_one_letter_replacement(
     """
     Checks if a mistake was caused by changing, adding, or removing letters.
 
-    It can identify when one letter was swapped for another, or more complex
+    It can find when one letter was swapped for another, or more complex
     cases like replacing 'm' with 'rn'.
 
     Returns:
@@ -374,7 +374,7 @@ def process_typos(
     """
     Finds common mistake patterns in a list of typo corrections.
 
-    This function reads through your typo list and identifies how letters were replaced.
+    This function reads through your typo list and finds how letters were replaced.
     It can find simple one-letter mistakes, swapped letters, or cases where multiple
     letters were changed at once.
 


### PR DESCRIPTION
This PR implements a project-wide terminology standardization to make the codebase and documentation more accessible and easier to use for a global audience.

**Key Changes:**
- **Simplified Verbs:** Replaced more formal or technical verbs like "identify" (and its variants) with simpler, more direct ones like "find", "show", or "see" across all core scripts, help strings, and documentation files.
- **Plain English:** Replaced Latin abbreviations like "e.g." with the full phrase "for example".
- **Jargon Removal:** Replaced the term "ad-hoc" with "extra" in internal documentation and test comments.
- **Redundancy Reduction:** Removed redundant words like "new" and "already" from CLI help and documentation where they provided no extra meaning.
- **Technical Accuracy:** Standardized the mention of "spell-checkers" to "similar word matching tools" for better accuracy.

These changes follow the style guidelines for simplicity, Plain English, and active voice, ensuring the suite is professional yet approachable.

---
*PR created automatically by Jules for task [1473595994123509855](https://jules.google.com/task/1473595994123509855) started by @RainRat*