### PR TITLE
[FEAT] Add quote extraction mode to multitool

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -916,6 +916,21 @@ def _extract_backtick_items(input_file: str, quiet: bool = False) -> Iterable[st
             yield from candidates
 
 
+def _extract_quote_items(input_file: str, quiet: bool = False) -> Iterable[str]:
+    """Yield text found between single or double quotes."""
+    # Pattern matches text inside single or double quotes, correctly handling escaped quotes.
+    # For single quotes, we use lookarounds to avoid matching apostrophes in words (like don't).
+    pattern = re.compile(r'"((?:[^"\\]|\\.)*)"|(?<![a-zA-Z0-9])\'((?:[^\'\\]|\\.)*)\'(?![a-zA-Z0-9])')
+
+    lines = _read_file_lines_robust(input_file)
+    for line in tqdm(lines, desc=f'Processing {input_file} (quote)', unit=' lines', disable=quiet):
+        for match in pattern.finditer(line):
+            # One of the groups will contain the match
+            content = match.group(1) if match.group(1) is not None else match.group(2)
+            if content:
+                yield content
+
+
 def _traverse_data(data: Any, path_parts: List[str]) -> Iterable[str]:
     """Recursively traverse a nested data structure (list/dict) to get values."""
     # If it's a list, apply the current path traversal to every item
@@ -1379,6 +1394,34 @@ def backtick_mode(
         max_length,
         process_output,
         'Backtick',
+        'Successfully got strings.',
+        output_format,
+        quiet,
+        clean_items=clean_items,
+        limit=limit,
+    )
+
+
+def quote_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Wrapper for getting text between quotes."""
+    _process_items(
+        _extract_quote_items,
+        input_files,
+        output_file,
+        min_length,
+        max_length,
+        process_output,
+        'Quote',
         'Successfully got strings.',
         output_format,
         quiet,
@@ -4537,6 +4580,12 @@ MODE_DETAILS = {
         "example": "python multitool.py backtick build.log --output suspects.txt",
         "flags": "",
     },
+    "quote": {
+        "summary": "Gets text found inside quotes.",
+        "description": "Finds text inside single or double quotes (like 'item' or \"item\"). It correctly handles escaped quotes.",
+        "example": "python multitool.py quote source.py --output strings.txt",
+        "flags": "",
+    },
     "csv": {
         "summary": "Gets specific columns from CSV.",
         "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, or --column to pick specific numbers.",
@@ -4765,7 +4814,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GETTING DATA": ["arrow", "table", "backtick", "csv", "markdown", "md-table", "json", "yaml", "line", "words", "ngrams", "regex"],
+        "GETTING DATA": ["arrow", "table", "backtick", "quote", "csv", "markdown", "md-table", "json", "yaml", "line", "words", "ngrams", "regex"],
         "CHANGING DATA": ["combine", "unique", "diff", "highlight", "resolve", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECKING DATA": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
@@ -5028,6 +5077,15 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['backtick']['example']}{RESET}",
     )
     _add_common_mode_arguments(backtick_parser)
+
+    quote_parser = subparsers.add_parser(
+        'quote',
+        help=MODE_DETAILS['quote']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['quote']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['quote']['example']}{RESET}",
+    )
+    _add_common_mode_arguments(quote_parser)
 
     csv_parser = subparsers.add_parser(
         'csv',
@@ -6209,6 +6267,10 @@ def main() -> None:
         ),
         'backtick': (
             backtick_mode,
+            {**common_kwargs, 'output_format': output_format},
+        ),
+        'quote': (
+            quote_mode,
             {**common_kwargs, 'output_format': output_format},
         ),
         'csv': (

--- a/tests/test_multitool_quote.py
+++ b/tests/test_multitool_quote.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Add repository root to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import multitool
+
+@pytest.fixture(autouse=True)
+def disable_tqdm(monkeypatch):
+    """Replace tqdm with identity to avoid progress output during tests."""
+    monkeypatch.setattr(multitool, "tqdm", lambda iterable, *_, **__: iterable)
+
+def test_extract_quote_items(tmp_path):
+    """Verify that single and double quoted items are correctly extracted."""
+    f = tmp_path / "quotes.txt"
+    f.write_text(" 'single' and \"double\" and 'apostrophe\\'s' and \"escaped \\\" quote\" ")
+
+    out = tmp_path / "out.txt"
+    multitool.quote_mode([str(f)], str(out), 1, 100, False, clean_items=False)
+
+    results = out.read_text().splitlines()
+    assert "single" in results
+    assert "double" in results
+    assert "apostrophe\\'s" in results
+    assert "escaped \\\" quote" in results
+
+def test_extract_quote_items_no_apostrophes(tmp_path):
+    """Verify that apostrophes in words are NOT extracted as quotes."""
+    f = tmp_path / "quotes.txt"
+    f.write_text("don't match this but 'match' this")
+
+    out = tmp_path / "out.txt"
+    multitool.quote_mode([str(f)], str(out), 1, 100, False, clean_items=False)
+
+    results = out.read_text().splitlines()
+    assert "match" in results
+    assert "t" not in results
+    assert "don" not in results
+
+def test_extract_quote_items_mixed_and_nested(tmp_path):
+    """Verify handling of mixed and nested quotes (nested as literal content)."""
+    f = tmp_path / "quotes.txt"
+    f.write_text("\"single ' inside double\" and 'double \" inside single' and \"outer 'inner' outer\"")
+
+    out = tmp_path / "out.txt"
+    multitool.quote_mode([str(f)], str(out), 1, 100, False, clean_items=False)
+
+    results = out.read_text().splitlines()
+    assert "single ' inside double" in results
+    assert "double \" inside single" in results
+    assert "outer 'inner' outer" in results


### PR DESCRIPTION
This PR introduces a new `quote` mode to the `multitool.py` utility. 

Following the "Symmetry" ideation heuristic, the `quote` mode complements the existing `backtick` mode by allowing users to extract text found within single (`'`) or double (`"`) quotes. 

Key technical features:
- Robust regex: `r'"((?:[^"\\]|\\.)*)"|(?<![a-zA-Z0-9])\'((?:[^\'\\]|\\.)*)\'(?![a-zA-Z0-9])'`
- Escaped character handling: Correctly processes `\"` or `\'` within strings.
- Apostrophe avoidance: Uses lookarounds to ensure single quotes are only matched when they act as delimiters, skipping apostrophes in words like "don't".
- Integration: Fully integrated into the existing `_process_items` pipeline, including support for output formats (CSV, JSON, etc.) and item cleaning.

Verified with comprehensive unit tests and manual CLI execution.

---
*PR created automatically by Jules for task [7075360650786653458](https://jules.google.com/task/7075360650786653458) started by @RainRat*