### PR TITLE
[FEAT] Add context line support to search and scan modes in multitool

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2806,6 +2806,31 @@ def words_mode(
     )
 
 
+def _format_search_line(
+    filename: str,
+    line_idx: int,
+    line_content: str,
+    is_match: bool,
+    show_filename: bool,
+    line_numbers: bool,
+    use_color: bool,
+) -> str:
+    """Formats a single line for search/scan output with optional filename and line number."""
+    sep = ":" if is_match else "-"
+    prefix_parts = []
+    if show_filename:
+        prefix_parts.append(filename)
+    if line_numbers:
+        prefix_parts.append(str(line_idx + 1))
+
+    if prefix_parts:
+        raw_prefix = sep.join(prefix_parts) + sep
+        if use_color:
+            return f"{BOLD}{BLUE}{raw_prefix}{RESET} {line_content}"
+        return f"{raw_prefix} {line_content}"
+    return line_content
+
+
 def search_mode(
     input_files: Sequence[str],
     query: str,
@@ -2820,6 +2845,8 @@ def search_mode(
     clean_items: bool = True,
     limit: int | None = None,
     with_filename: bool | None = None,
+    before_context: int = 0,
+    after_context: int = 0,
 ) -> None:
     """
     Searches for words or patterns in text files, supporting similar word matching and smart subword detection.
@@ -2861,12 +2888,13 @@ def search_mode(
 
     for input_file in input_files:
         file_lines = _read_file_lines_robust(input_file)
-        file_matches = 0
+        # Store original lines without trailing newlines for consistent rendering
+        file_contents = [line.rstrip("\n") for line in file_lines]
+        match_indices = {}  # index -> highlighted_line
 
-        for i, line in enumerate(
-            tqdm(file_lines, desc=f"Searching {input_file}", unit=" lines", disable=quiet)
+        for i, line_content in enumerate(
+            tqdm(file_contents, desc=f"Searching {input_file}", unit=" lines", disable=quiet)
         ):
-            line_content = line.rstrip("\n")
             spans = []
 
             # 1. Exact match on whole line first (case-insensitive)
@@ -2920,8 +2948,6 @@ def search_mode(
                             break
 
             if spans:
-                file_matches += 1
-
                 spans.sort()
                 merged = []
                 if spans:
@@ -2942,27 +2968,40 @@ def search_mode(
                         highlighted_line += f"{YELLOW}{line_content[start:end]}{RESET}"
                         last_idx = end
                     highlighted_line += line_content[last_idx:]
-                    display_line = highlighted_line
+                    match_indices[i] = highlighted_line
                 else:
-                    display_line = line_content
+                    match_indices[i] = line_content
 
-                prefix_parts = []
-                if show_filename:
-                    prefix_parts.append(input_file)
-                if line_numbers:
-                    prefix_parts.append(str(i+1))
+        if not match_indices:
+            continue
 
-                if prefix_parts:
-                    raw_prefix = ":".join(prefix_parts) + ":"
-                    display_line = (
-                        f"{BOLD}{BLUE}{raw_prefix}{RESET} {display_line}"
-                        if use_color
-                        else f"{raw_prefix} {display_line}"
+        total_matches += len(match_indices)
+
+        # Collect context blocks
+        sorted_indices = sorted(match_indices.keys())
+        last_rendered_idx = -1
+
+        for idx in sorted_indices:
+            # Determine block start and end
+            start = max(0, idx - before_context)
+            end = min(len(file_contents), idx + after_context + 1)
+
+            # If there's a gap between blocks, add separator
+            if last_rendered_idx != -1 and start > last_rendered_idx:
+                accumulated_lines.append("--")
+
+            # Render lines in the window that haven't been rendered yet
+            current_start = max(start, last_rendered_idx)
+            for j in range(current_start, end):
+                is_match = j in match_indices
+                content = match_indices[j] if is_match else file_contents[j]
+                accumulated_lines.append(
+                    _format_search_line(
+                        input_file, j, content, is_match, show_filename, line_numbers, use_color
                     )
+                )
 
-                accumulated_lines.append(display_line)
-
-        total_matches += file_matches
+            last_rendered_idx = end
 
     if process_output:
         accumulated_lines = sorted(set(accumulated_lines))
@@ -4047,6 +4086,8 @@ def scan_mode(
     line_numbers: bool = False,
     with_filename: bool | None = None,
     ad_hoc: List[str] | None = None,
+    before_context: int = 0,
+    after_context: int = 0,
 ) -> None:
     """
     Scans files for occurrences of words from a mapping file or extra pairs, providing context.
@@ -4069,10 +4110,10 @@ def scan_mode(
 
     for input_file in input_files:
         file_lines = _read_file_lines_robust(input_file)
-        file_matches = 0
+        file_contents = [line.rstrip('\n') for line in file_lines]
+        match_indices = {}  # index -> highlighted_line
 
-        for i, line in enumerate(tqdm(file_lines, desc=f"Scanning {input_file}", unit=" lines", disable=quiet)):
-            line_content = line.rstrip('\n')
+        for i, line_content in enumerate(tqdm(file_contents, desc=f"Scanning {input_file}", unit=" lines", disable=quiet)):
             parts = pattern.split(line_content)
             match_found = False
 
@@ -4097,9 +4138,7 @@ def scan_mode(
                         break
 
             if match_found:
-                file_matches += 1
-
-                # Second pass: apply highlighting for the output
+                # Highlight if color is enabled
                 if use_color:
                     new_parts = []
                     for part in parts:
@@ -4123,27 +4162,37 @@ def scan_mode(
                                 new_parts.append(part)
                         else:
                             new_parts.append(part)
-                    display_line = "".join(new_parts)
+                    match_indices[i] = "".join(new_parts)
                 else:
-                    display_line = line_content
+                    match_indices[i] = line_content
 
-                prefix_parts = []
-                if show_filename:
-                    prefix_parts.append(input_file)
-                if line_numbers:
-                    prefix_parts.append(str(i+1))
+        if not match_indices:
+            continue
 
-                if prefix_parts:
-                    raw_prefix = ":".join(prefix_parts) + ":"
-                    display_line = (
-                        f"{BOLD}{BLUE}{raw_prefix}{RESET} {display_line}"
-                        if use_color
-                        else f"{raw_prefix} {display_line}"
+        total_matches += len(match_indices)
+
+        # Collect context blocks
+        sorted_indices = sorted(match_indices.keys())
+        last_rendered_idx = -1
+
+        for idx in sorted_indices:
+            start = max(0, idx - before_context)
+            end = min(len(file_contents), idx + after_context + 1)
+
+            if last_rendered_idx != -1 and start > last_rendered_idx:
+                accumulated_lines.append("--")
+
+            current_start = max(start, last_rendered_idx)
+            for j in range(current_start, end):
+                is_match = j in match_indices
+                content = match_indices[j] if is_match else file_contents[j]
+                accumulated_lines.append(
+                    _format_search_line(
+                        input_file, j, content, is_match, show_filename, line_numbers, use_color
                     )
+                )
 
-                accumulated_lines.append(display_line)
-
-        total_matches += file_matches
+            last_rendered_idx = end
 
     if process_output:
         accumulated_lines = sorted(set(accumulated_lines))
@@ -4713,15 +4762,15 @@ MODE_DETAILS = {
     },
     "search": {
         "summary": "Search for words or patterns.",
-        "description": "A typo-aware search tool. It searches for a query in your files and can find similar words (typos) or subword matches. It supports highlighting and line numbers.",
-        "example": "python multitool.py search 'teh' report.txt --max-dist 1 --line-numbers",
-        "flags": "QUERY [FILES...] [-S] [-n]",
+        "description": "A typo-aware search tool. It searches for a query in your files and can find similar words (typos) or subword matches. It supports highlighting, line numbers, and context lines.",
+        "example": "python multitool.py search 'teh' report.txt --max-dist 1 --line-numbers -C 2",
+        "flags": "QUERY [FILES...] [-S] [-n] [-B N] [-A N] [-C N]",
     },
     "scan": {
         "summary": "Audit project for known typos.",
-        "description": "Like a batch version of the 'search' mode. It searches for every word in a mapping file or provided via --add and reports all matches with filename, line number, and highlighting. Use this to audit your project for known typos without making any changes.",
-        "example": "python multitool.py scan . --add teh:the --smart",
-        "flags": "MAPPING [FILES...] [-a K:V] [-S]",
+        "description": "Like a batch version of the 'search' mode. It searches for every word in a mapping file or provided via --add and reports all matches with filename, line number, and highlighting. It also supports context lines.",
+        "example": "python multitool.py scan . --add teh:the --smart -A 1",
+        "flags": "MAPPING [FILES...] [-a K:V] [-S] [-B N] [-A N] [-C N]",
     },
     "verify": {
         "summary": "Check if typos exist in project.",
@@ -5507,6 +5556,23 @@ def _build_parser() -> argparse.ArgumentParser:
         dest='with_filename',
         help="Suppress the prefixing of filenames on output.",
     )
+    search_options.add_argument(
+        '-B', '--before-context',
+        type=int,
+        default=0,
+        help="Show this many lines of context before each match.",
+    )
+    search_options.add_argument(
+        '-A', '--after-context',
+        type=int,
+        default=0,
+        help="Show this many lines of context after each match.",
+    )
+    search_options.add_argument(
+        '-C', '--context',
+        type=int,
+        help="Show this many lines of context before and after each match.",
+    )
     _add_common_mode_arguments(search_parser)
 
     set_parser = subparsers.add_parser(
@@ -5909,6 +5975,23 @@ def _build_parser() -> argparse.ArgumentParser:
         dest='with_filename',
         help="Suppress the prefixing of filenames on output.",
     )
+    scan_options.add_argument(
+        '-B', '--before-context',
+        type=int,
+        default=0,
+        help="Show this many lines of context before each match.",
+    )
+    scan_options.add_argument(
+        '-A', '--after-context',
+        type=int,
+        default=0,
+        help="Show this many lines of context after each match.",
+    )
+    scan_options.add_argument(
+        '-C', '--context',
+        type=int,
+        help="Show this many lines of context before and after each match.",
+    )
     _add_common_mode_arguments(scan_parser)
 
     verify_parser = subparsers.add_parser(
@@ -6065,6 +6148,16 @@ def main() -> None:
 
     # Store for handler
     args.input = input_paths
+
+    # Resolve context flags (merge -C into -A and -B if -A/-B are not set)
+    before_context = getattr(args, 'before_context', 0)
+    after_context = getattr(args, 'after_context', 0)
+    context = getattr(args, 'context', None)
+    if context is not None:
+        if before_context == 0:
+            before_context = context
+        if after_context == 0:
+            after_context = context
 
     # Fallback logic for modes that require a secondary file (for example, zip, map, scrub, highlight)
     # If the flag is missing, we check positional arguments.
@@ -6320,6 +6413,8 @@ def main() -> None:
                 'smart': getattr(args, 'smart', False),
                 'line_numbers': getattr(args, 'line_numbers', False),
                 'with_filename': getattr(args, 'with_filename', None),
+                'before_context': before_context,
+                'after_context': after_context,
             }
         ),
         'unique': (
@@ -6528,6 +6623,8 @@ def main() -> None:
                 'smart': getattr(args, 'smart', False),
                 'line_numbers': getattr(args, 'line_numbers', False),
                 'with_filename': getattr(args, 'with_filename', None),
+                'before_context': before_context,
+                'after_context': after_context,
             }
         ),
         'verify': (

--- a/tests/test_multitool_context.py
+++ b/tests/test_multitool_context.py
@@ -1,0 +1,153 @@
+import sys
+import os
+import re
+import pytest
+
+# Add the repository root to the Python path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from multitool import search_mode, scan_mode
+
+def strip_ansi(text):
+    """Remove ANSI escape sequences from a string."""
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    return ansi_escape.sub('', text)
+
+@pytest.fixture
+def sample_file(tmp_path):
+    f = tmp_path / "sample.txt"
+    content = "\n".join([
+        "line 1",
+        "line 2",
+        "line 3 (MATCH)",
+        "line 4",
+        "line 5",
+        "line 6",
+        "line 7 (MATCH)",
+        "line 8",
+        "line 9",
+        "line 10"
+    ])
+    f.write_text(content, encoding='utf-8')
+    return f
+
+def test_search_context_after(sample_file, tmp_path):
+    output = tmp_path / "output.txt"
+    search_mode(
+        input_files=[str(sample_file)],
+        query="MATCH",
+        output_file=str(output),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        after_context=2,
+        line_numbers=True,
+        with_filename=True
+    )
+
+    results = output.read_text(encoding='utf-8').splitlines()
+    # Expectation for first match (idx 2): line 3, 4, 5
+    # Expectation for second match (idx 6): line 7, 8, 9
+    # Non-contiguous, so separator "--" expected
+
+    clean_results = [strip_ansi(r) for r in results]
+
+    # Prefix format: filename:line: for match, filename-line- for context
+    fname = str(sample_file)
+    expected = [
+        f"{fname}:3: line 3 (MATCH)",
+        f"{fname}-4- line 4",
+        f"{fname}-5- line 5",
+        "--",
+        f"{fname}:7: line 7 (MATCH)",
+        f"{fname}-8- line 8",
+        f"{fname}-9- line 9"
+    ]
+
+    assert clean_results == expected
+
+def test_search_context_before(sample_file, tmp_path):
+    output = tmp_path / "output.txt"
+    search_mode(
+        input_files=[str(sample_file)],
+        query="MATCH",
+        output_file=str(output),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        before_context=1,
+        line_numbers=True,
+        with_filename=True
+    )
+
+    results = output.read_text(encoding='utf-8').splitlines()
+    clean_results = [strip_ansi(r) for r in results]
+
+    fname = str(sample_file)
+    expected = [
+        f"{fname}-2- line 2",
+        f"{fname}:3: line 3 (MATCH)",
+        "--",
+        f"{fname}-6- line 6",
+        f"{fname}:7: line 7 (MATCH)"
+    ]
+
+    assert clean_results == expected
+
+def test_search_context_both(sample_file, tmp_path):
+    output = tmp_path / "output.txt"
+    # Merge context overlap: match at 2 and 6.
+    # With -C 2:
+    #   Block 1: 0, 1, 2, 3, 4
+    #   Block 2: 4, 5, 6, 7, 8
+    # They touch at index 4, so they should be merged without separator.
+    search_mode(
+        input_files=[str(sample_file)],
+        query="MATCH",
+        output_file=str(output),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        before_context=2,
+        after_context=2,
+        line_numbers=True,
+        with_filename=True
+    )
+
+    results = output.read_text(encoding='utf-8').splitlines()
+    clean_results = [strip_ansi(r) for r in results]
+
+    assert "--" not in clean_results
+    assert len(clean_results) == 9 # indices 0 through 8
+    fname = str(sample_file)
+    assert f"{fname}:3: line 3 (MATCH)" == clean_results[2]
+    assert f"{fname}:7: line 7 (MATCH)" == clean_results[6]
+
+def test_scan_context(sample_file, tmp_path):
+    output = tmp_path / "output.txt"
+    scan_mode(
+        input_files=[str(sample_file)],
+        mapping_file=None,
+        ad_hoc=["MATCH:FIX"],
+        output_file=str(output),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        after_context=1,
+        line_numbers=True,
+        with_filename=True
+    )
+
+    results = output.read_text(encoding='utf-8').splitlines()
+    clean_results = [strip_ansi(r) for r in results]
+
+    fname = str(sample_file)
+    expected = [
+        f"{fname}:3: line 3 (MATCH)",
+        f"{fname}-4- line 4",
+        "--",
+        f"{fname}:7: line 7 (MATCH)",
+        f"{fname}-8- line 8"
+    ]
+
+    assert clean_results == expected


### PR DESCRIPTION
* **What:** Added `-B/--before-context`, `-A/--after-context`, and `-C/--context` flags to `search` and `scan` modes in `multitool.py`. This allows users to see surrounding lines of text for matches, similar to standard `grep`. Implementation includes a centralized `_format_search_line` helper for consistent prefix formatting and a two-pass matching strategy to correctly merge overlapping context blocks and insert `--` separators between non-contiguous matches.
* **Why:** The existing `search` and `scan` modes in `multitool` only provided the matching line itself. In a typo-hunting workflow, seeing the surrounding code or text is often critical for deciding if a match is actually a typo or a false positive. This addition brings `multitool` closer to standard Unix tools while maintaining its unique typo-aware matching capabilities.

---
*PR created automatically by Jules for task [4750865054279499758](https://jules.google.com/task/4750865054279499758) started by @RainRat*