### PR TITLE
Remove redundant logic in multitool.py count_mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -1656,18 +1656,13 @@ def count_mode(
                 # When the output is the console ('-'), we write the analysis summary and table
                 # header to stderr. This keeps stdout clean for piped data.
                 if output_file == '-':
-                    if not quiet:
-                        sys.stderr.write(summary_text)
-                        sys.stderr.write(header_block)
-                        sys.stderr.flush()
+                    sys.stderr.write(summary_text)
+                    sys.stderr.write(header_block)
+                    sys.stderr.flush()
                 else:
                     # When writing to a file, we include everything in the file.
                     out_file.write(summary_text)
                     out_file.write(header_block)
-            else:
-                # This branch is reached if quiet is True and output_file is '-'.
-                # In this case, we write nothing to stderr.
-                pass
 
             for i, (item, count) in enumerate(final_results):
                 percent = (count / total_count * 100) if total_count > 0 else 0


### PR DESCRIPTION
This PR improves code quality by removing redundant validation logic in `multitool.py`.

### Changes
*   In `count_mode`, an `if not quiet:` check was removed because it was nested within an `if output_file == '-':` block, which itself was inside a guard ensuring `not quiet or output_file != '-'`. This makes the inner check redundant.
*   A trailing `else: pass` block was removed from the same logical section.

### Benefit
Improves code readability and reduces noise without changing external behavior.

### Verification
Ran the full test suite (650 tests), including specific visual output tests for `count_mode`. All tests passed.

---
*PR created automatically by Jules for task [5088973647731085589](https://jules.google.com/task/5088973647731085589) started by @RainRat*