### PR TITLE
Add Quoted Extraction Mode to Multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -39,6 +39,10 @@ These modes help you pull specific data out of a messy file.
   - **What it does:** Gets text found inside backticks (for example, \`code\`). It picks items near words like 'error' or 'warning' to find the most useful data.
   - **Example:** `python multitool.py backtick build.log`
 
+- **`quoted`**
+  - **What it does:** Gets text found inside double (`"`) or single (`'`) quotes. It handles backslash escaping (like `\"` or `\'`) to correctly extract strings from code or data files.
+  - **Example:** `python multitool.py quoted source.py`
+
 - **`csv`**
   - **What it does:** Gets columns from a CSV file. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) followed by one or more numbers to get specific columns. Use `--delimiter` (or `-d`) to pick a different column separator (for example, `;`).
   - **Example:** `python multitool.py csv data.csv --column 2`

--- a/multitool.py
+++ b/multitool.py
@@ -916,6 +916,18 @@ def _extract_backtick_items(input_file: str, quiet: bool = False) -> Iterable[st
             yield from candidates
 
 
+def _extract_quoted_items(input_file: str, quiet: bool = False) -> Iterable[str]:
+    """Yield text found between double or single quotes."""
+    # Matches "..." or '...' and handles backslash escaping
+    pattern = re.compile(r'"((?:[^"\\]|\\.)*)"|\'((?:[^\'\\]|\\.)*)\'')
+
+    lines = _read_file_lines_robust(input_file)
+    for line in tqdm(lines, desc=f'Processing {input_file} (quoted)', unit=' lines', disable=quiet):
+        for match in pattern.finditer(line):
+            content = match.group(1) if match.group(1) is not None else match.group(2)
+            yield content
+
+
 def _traverse_data(data: Any, path_parts: List[str]) -> Iterable[str]:
     """Recursively traverse a nested data structure (list/dict) to get values."""
     # If it's a list, apply the current path traversal to every item
@@ -1380,6 +1392,34 @@ def backtick_mode(
         process_output,
         'Backtick',
         'Successfully got strings.',
+        output_format,
+        quiet,
+        clean_items=clean_items,
+        limit=limit,
+    )
+
+
+def quoted_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Wrapper for getting text between quotes."""
+    _process_items(
+        _extract_quoted_items,
+        input_files,
+        output_file,
+        min_length,
+        max_length,
+        process_output,
+        'Quoted',
+        'Successfully got quoted strings.',
         output_format,
         quiet,
         clean_items=clean_items,
@@ -4537,6 +4577,12 @@ MODE_DETAILS = {
         "example": "python multitool.py backtick build.log --output suspects.txt",
         "flags": "",
     },
+    "quoted": {
+        "summary": "Gets text found inside quotes.",
+        "description": "Finds text inside double (\") or single (') quotes. It handles backslash escaping (like \\\" or \\') to correctly extract strings from code or data files.",
+        "example": "python multitool.py quoted source.py --output strings.txt",
+        "flags": "",
+    },
     "csv": {
         "summary": "Gets specific columns from CSV.",
         "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, or --column to pick specific numbers.",
@@ -4765,7 +4811,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GETTING DATA": ["arrow", "table", "backtick", "csv", "markdown", "md-table", "json", "yaml", "line", "words", "ngrams", "regex"],
+        "GETTING DATA": ["arrow", "table", "backtick", "quoted", "csv", "markdown", "md-table", "json", "yaml", "line", "words", "ngrams", "regex"],
         "CHANGING DATA": ["combine", "unique", "diff", "highlight", "resolve", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECKING DATA": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
@@ -5028,6 +5074,15 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['backtick']['example']}{RESET}",
     )
     _add_common_mode_arguments(backtick_parser)
+
+    quoted_parser = subparsers.add_parser(
+        'quoted',
+        help=MODE_DETAILS['quoted']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['quoted']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['quoted']['example']}{RESET}",
+    )
+    _add_common_mode_arguments(quoted_parser)
 
     csv_parser = subparsers.add_parser(
         'csv',
@@ -6209,6 +6264,10 @@ def main() -> None:
         ),
         'backtick': (
             backtick_mode,
+            {**common_kwargs, 'output_format': output_format},
+        ),
+        'quoted': (
+            quoted_mode,
             {**common_kwargs, 'output_format': output_format},
         ),
         'csv': (

--- a/tests/test_multitool_quoted.py
+++ b/tests/test_multitool_quoted.py
@@ -1,0 +1,80 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+import io
+
+# Import the functions to be tested from multitool
+from multitool import _extract_quoted_items, quoted_mode
+
+class TestQuotedMode(unittest.TestCase):
+    def test_extract_quoted_items_double_quotes(self):
+        # Create a temporary file with double-quoted strings
+        content = 'This is a "double-quoted" string and another "one here".\n'
+        with patch('multitool._read_file_lines_robust', return_value=[content]):
+            items = list(_extract_quoted_items('test.txt', quiet=True))
+            self.assertEqual(items, ['double-quoted', 'one here'])
+
+    def test_extract_quoted_items_single_quotes(self):
+        # Create a temporary file with single-quoted strings
+        content = "This is a 'single-quoted' string and 'another' one.\n"
+        with patch('multitool._read_file_lines_robust', return_value=[content]):
+            items = list(_extract_quoted_items('test.txt', quiet=True))
+            self.assertEqual(items, ['single-quoted', 'another'])
+
+    def test_extract_quoted_items_mixed_quotes(self):
+        content = 'Mixed "double" and \'single\' quotes on "the same" line.\n'
+        with patch('multitool._read_file_lines_robust', return_value=[content]):
+            items = list(_extract_quoted_items('test.txt', quiet=True))
+            self.assertEqual(items, ['double', 'single', 'the same'])
+
+    def test_extract_quoted_items_escaped_quotes(self):
+        # Escaped double quotes inside double quotes
+        content = 'Text with "escaped \\"quotes\\" inside" it.\n'
+        with patch('multitool._read_file_lines_robust', return_value=[content]):
+            items = list(_extract_quoted_items('test.txt', quiet=True))
+            self.assertEqual(items, ['escaped \\"quotes\\" inside'])
+
+        # Escaped single quotes inside single quotes
+        content = "Text with 'escaped \\'quotes\\' inside' it.\n"
+        with patch('multitool._read_file_lines_robust', return_value=[content]):
+            items = list(_extract_quoted_items('test.txt', quiet=True))
+            self.assertEqual(items, ["escaped \\'quotes\\' inside"])
+
+    def test_extract_quoted_items_empty_quotes(self):
+        content = 'Empty "" and \'\' quotes.\n'
+        with patch('multitool._read_file_lines_robust', return_value=[content]):
+            items = list(_extract_quoted_items('test.txt', quiet=True))
+            self.assertEqual(items, ['', ''])
+
+    def test_quoted_mode_execution(self):
+        # Mocking _process_items to ensure quoted_mode calls it correctly
+        with patch('multitool._process_items') as mock_process:
+            quoted_mode(
+                input_files=['input.txt'],
+                output_file='output.txt',
+                min_length=3,
+                max_length=100,
+                process_output=True,
+                output_format='line',
+                quiet=True,
+                clean_items=True,
+                limit=10
+            )
+            mock_process.assert_called_once_with(
+                _extract_quoted_items,
+                ['input.txt'],
+                'output_file' if 'output_file' == 'output.txt' else 'output.txt', # Handle potential name mapping if any
+                3,
+                100,
+                True,
+                'Quoted',
+                'Successfully got quoted strings.',
+                'line',
+                True,
+                clean_items=True,
+                limit=10
+            )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a new `quoted` mode to the `multitool.py` utility, providing a symmetrical companion to the existing `backtick` mode.

### What:
- **`quoted` Mode**: Extracts strings contained within double (`"`) or single (`'`) quotes.
- **Escaping Support**: Correct handles backslash-escaped quotes (e.g., `\"` or `\'`) within strings.
- **CLI Integration**: Full integration into the subcommand structure, documentation, and summary tables.
- **Tests**: A new test file `tests/test_multitool_quoted.py` covers single/double quotes, mixed quotes, escaped quotes, and empty strings.

### Why:
Extracting quoted strings is a common requirement in log analysis and code processing workflows. While `multitool.py` previously supported backticks, it lacked a general-purpose quote extractor. This addition follows the repository's pattern of providing high-utility, single-file text processing tools.

### Verification:
- All new tests in `tests/test_multitool_quoted.py` passed.
- All 433 existing tests in the suite passed.
- Documentation updated in `docs/multitool.md`.

---
*PR created automatically by Jules for task [14527989259663094656](https://jules.google.com/task/14527989259663094656) started by @RainRat*