### PR TITLE
Remove redundant dictionary file validation in diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -733,12 +733,7 @@ def main():
 
     # Load the large dictionary (words mapping) once.
     # If the file is missing, we don't exit. Instead we just warn and continue without filtering.
-    if args.dictionary_file == 'words.csv' and not os.path.exists(args.dictionary_file):
-        logging.warning("Default large dictionary file 'words.csv' not found. Skipping filtering.")
-        large_dictionary_mapping = {}
-    else:
-        # If it's NOT the default words.csv, it will also warn and continue if missing.
-        large_dictionary_mapping = read_words_mapping(args.dictionary_file, required=False)
+    large_dictionary_mapping = read_words_mapping(args.dictionary_file, required=False)
 
     try:
         allowed_words = read_allowed_words(args.allowed_file)

--- a/tests/test_diff2typo.py
+++ b/tests/test_diff2typo.py
@@ -473,8 +473,8 @@ def test_main_default_values_preserved(monkeypatch):
 
     # We mock read_words_mapping and read_allowed_words to avoid file not found errors
     # during this specific test of the argument parser defaults.
-    monkeypatch.setattr(diff2typo, 'read_words_mapping', lambda _: {})
-    monkeypatch.setattr(diff2typo, 'read_allowed_words', lambda _: set())
+    monkeypatch.setattr(diff2typo, 'read_words_mapping', lambda *args, **kwargs: {})
+    monkeypatch.setattr(diff2typo, 'read_allowed_words', lambda *args, **kwargs: set())
 
     # Use a dummy output to avoid writing to stdout during test
     monkeypatch.setattr(sys, 'stdout', io.StringIO())


### PR DESCRIPTION
This PR resolves a "Redundant Validation" issue in `diff2typo.py` where the code manually checked for the existence of the default `words.csv` file before calling a helper function that already performs this check and handles the missing file gracefully.

Changes:
- Simplified `main()` in `diff2typo.py` by removing the redundant `if/else` block.
- Updated `tests/test_diff2typo.py` to use `*args, **kwargs` in mocks for `read_words_mapping` and `read_allowed_words`, ensuring they handle the actual arguments passed by the production code.

These changes are non-breaking and improve code hygiene and test stability.

---
*PR created automatically by Jules for task [5714751330299749021](https://jules.google.com/task/5714751330299749021) started by @RainRat*