### PR TITLE
[FEAT] Add symmetric_difference to set_operation mode

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -130,7 +130,8 @@ These modes help you transform or combine your data.
     - `intersection`: Finds lines common to both files.
     - `union`: Combines all lines from both files.
     - `difference`: Finds lines in the first file that are not in the second.
-  - **Example:** `python multitool.py set_operation a.txt --file2 b.txt --operation difference`
+    - `symmetric_difference`: Finds lines that are unique to each file (items in either file, but not both).
+  - **Example:** `python multitool.py set_operation a.txt --file2 b.txt --operation symmetric_difference`
 
 - **`zip`**
   - **What it does:** Joins two files line-by-line into a paired format. It applies `--min-length` and `--max-length` filters to **both items in each pair**. If the files have a different number of lines, the output will stop at the end of the shortest file.

--- a/multitool.py
+++ b/multitool.py
@@ -4558,9 +4558,9 @@ def set_operation_mode(
     clean_items: bool = True,
     limit: int | None = None,
 ) -> None:
-    """Perform set operations (intersection, union, difference) between input files (merged) and a second file."""
+    """Perform set operations (intersection, union, difference, symmetric_difference) between input files (merged) and a second file."""
     start_time = time.perf_counter()
-    allowed_operations = {'intersection', 'union', 'difference'}
+    allowed_operations = {'intersection', 'union', 'difference', 'symmetric_difference'}
     if operation not in allowed_operations:
         raise ValueError(
             f"Invalid operation '{operation}'. Must be one of: {', '.join(sorted(allowed_operations))}."
@@ -4589,8 +4589,14 @@ def set_operation_mode(
         result_items = [item for item in unique_a if item in set_b]
     elif operation == 'union':
         result_items = list(dict.fromkeys(unique_a + unique_b))
-    else:  # difference
+    elif operation == 'difference':
         result_items = [item for item in unique_a if item not in set_b]
+    else:  # symmetric_difference
+        # Items in either set but not both
+        only_a = [item for item in unique_a if item not in set_b]
+        set_a = set(unique_a)
+        only_b = [item for item in unique_b if item not in set_a]
+        result_items = only_a + only_b
 
     if process_output:
         result_items = sorted(set(result_items))
@@ -4710,8 +4716,8 @@ MODE_DETAILS = {
     },
     "set_operation": {
         "summary": "Compares files using set logic.",
-        "description": "Compares two files to find shared lines (intersection), all lines (union), or lines unique to the first file (difference).",
-        "example": "python multitool.py set_operation fileA.txt fileB.txt --operation intersection --output shared.txt",
+        "description": "Compares two files to find shared lines (intersection), all lines (union), lines unique to the first file (difference), or lines unique to either file (symmetric_difference).",
+        "example": "python multitool.py set_operation fileA.txt fileB.txt --operation difference --output unique.txt",
         "flags": "[FILE2] --operation OP",
     },
     "sample": {
@@ -5655,7 +5661,7 @@ def _build_parser() -> argparse.ArgumentParser:
     set_options.add_argument(
         '--operation',
         type=str,
-        choices=['intersection', 'union', 'difference'],
+        choices=['intersection', 'union', 'difference', 'symmetric_difference'],
         required=True,
         help='Set operation to perform between the two files.',
     )

--- a/tests/test_multitool_set_symmetric_difference.py
+++ b/tests/test_multitool_set_symmetric_difference.py
@@ -1,0 +1,94 @@
+import pytest
+import os
+from multitool import main
+
+def test_set_operation_symmetric_difference(tmp_path, capsys):
+    file1 = tmp_path / "file1.txt"
+    file1.write_text("apple\nbanana\ncherry\n")
+
+    file2 = tmp_path / "file2.txt"
+    file2.write_text("banana\ncherry\ndate\n")
+
+    output = tmp_path / "output.txt"
+
+    # Run symmetric_difference
+    # apple is only in file1
+    # banana is in both
+    # cherry is in both
+    # date is only in file2
+    # Result should be apple, date
+
+    import sys
+    test_args = [
+        "multitool.py", "set_operation", str(file1),
+        "--file2", str(file2),
+        "--operation", "symmetric_difference",
+        "--output", str(output),
+        "--raw"
+    ]
+
+    import multitool
+    multitool._STDIN_CACHE = None
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(sys, "argv", test_args)
+        main()
+
+    content = output.read_text().splitlines()
+    assert sorted(content) == ["apple", "date"]
+
+def test_set_operation_symmetric_difference_no_overlap(tmp_path):
+    file1 = tmp_path / "file1.txt"
+    file1.write_text("apple\n")
+
+    file2 = tmp_path / "file2.txt"
+    file2.write_text("banana\n")
+
+    output = tmp_path / "output.txt"
+
+    import sys
+    test_args = [
+        "multitool.py", "set_operation", str(file1),
+        "--file2", str(file2),
+        "--operation", "symmetric_difference",
+        "--output", str(output),
+        "--raw"
+    ]
+
+    import multitool
+    multitool._STDIN_CACHE = None
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(sys, "argv", test_args)
+        main()
+
+    content = output.read_text().splitlines()
+    assert sorted(content) == ["apple", "banana"]
+
+def test_set_operation_symmetric_difference_full_overlap(tmp_path):
+    file1 = tmp_path / "file1.txt"
+    file1.write_text("apple\nbanana\n")
+
+    file2 = tmp_path / "file2.txt"
+    file2.write_text("apple\nbanana\n")
+
+    output = tmp_path / "output.txt"
+
+    import sys
+    test_args = [
+        "multitool.py", "set_operation", str(file1),
+        "--file2", str(file2),
+        "--operation", "symmetric_difference",
+        "--output", str(output),
+        "--raw"
+    ]
+
+    import multitool
+    multitool._STDIN_CACHE = None
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(sys, "argv", test_args)
+        main()
+
+    content = output.read_text().splitlines()
+    assert content == []


### PR DESCRIPTION
Added the `symmetric_difference` operation to the `set_operation` mode in `multitool.py`. This operation finds items that are present in either the input files or the second file, but not both. This completes the logical set of file comparison operations (Intersection, Union, Difference, and Symmetric Difference).

Optimized the implementation by hoisting set creation outside of list comprehensions to ensure $O(N+M)$ complexity. Updated the documentation and added a suite of tests to verify the behavior with various input scenarios.

---
*PR created automatically by Jules for task [14566943290917030197](https://jules.google.com/task/14566943290917030197) started by @RainRat*