### PR TITLE
Fix statistics reporting bug in similarity_mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2236,7 +2236,9 @@ def similarity_mode(
 
     filtered_results = []
     stats_items = []
+    raw_count = 0
     for left, right in raw_pairs:
+        raw_count += 1
         if clean_items:
             left = filter_to_letters(left)
             right = filter_to_letters(right)
@@ -2277,7 +2279,7 @@ def similarity_mode(
     )
 
     print_processing_stats(
-        len(filtered_results), stats_items, item_label="similar-pair", start_time=start_time
+        raw_count, stats_items, item_label="similar-pair", start_time=start_time
     )
 
 


### PR DESCRIPTION
* **What:** Updated `similarity_mode` in `multitool.py` to track the actual number of typo-correction pairs encountered during processing. This count is now correctly passed to the `print_processing_stats` function.
* **Why:** Previously, `similarity_mode` incorrectly used the count of *filtered* results as the raw input count when reporting statistics. This resulted in an inaccurate "Retention rate" (always 100%) and misleading "Total similar-pairs encountered" metrics in the analysis summary. This non-breaking change ensures that users receive accurate feedback on how many items were excluded by distance or length filters.

---
*PR created automatically by Jules for task [14286998092024303181](https://jules.google.com/task/14286998092024303181) started by @RainRat*