### PR TITLE
[DOCS] Simplify language and standardize terminology across documentation and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 The **diff2typo Suite** is a set of tools to help you find and fix typos in your code. It works with your Git history to learn from your past mistakes and helps you stop those typos from coming back.
 
 ## ✨ Key Features
-- **Learn from history:** Automatically find typos you've already fixed in your Git logs.
-- **Predict mistakes:** Generate lists of likely typos based on how keyboards are laid out.
-- **Clean your data:** Powerful text processing tools to filter, merge, and organize typo lists.
+- **Learn from history:** Automatically find typos you fixed in your Git logs.
+- **Predict mistakes:** Create lists of likely typos based on your keyboard layout.
+- **Clean your data:** Filter, merge, and organize typo lists.
 - **Find patterns:** See which keys you hit by mistake most often.
 
 ## 📋 Prerequisites
 
-- **Python 3.10 or newer:** The suite uses modern Python features.
+- **Python 3.10 or newer:** The suite uses recent Python features.
 - **Git:** Required to use `diff2typo.py` with your repository history.
 - **Dependencies:** The following Python packages are required and will be installed in step 2:
   - `PyYAML`: Handles configuration files.

--- a/multitool.py
+++ b/multitool.py
@@ -3702,7 +3702,7 @@ def standardize_mode(
                             if min_length <= len(sp_norm) <= max_length:
                                 variation_counts[sp_norm][sp] += 1
 
-    # Pass 2: Identify "winners" and build mapping
+    # Pass 2: Find "winners" and build mapping
     mapping = {}
 
     # 2a: Determine the best casing variation for each normalized word


### PR DESCRIPTION
Simplified language for a global audience by removing redundant words (e.g., "already"), using active voice, and replacing technical jargon (e.g., "Identify") with simpler verbs (e.g., "Find"). Standardized terminology to align with project-wide guidelines while maintaining clarity for common terms like "spell-checkers".

---
*PR created automatically by Jules for task [6963706964590912493](https://jules.google.com/task/6963706964590912493) started by @RainRat*