### PR TITLE
Fix logic bug in multitool.py setting default min_length for count mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -6163,7 +6163,7 @@ def main() -> None:
         elif args.mode == 'count':
             # Count mode uses 3 for word extraction, but 1 for auditing or character counting
             if any([getattr(args, 'pairs', False), getattr(args, 'chars', False),
-                    getattr(args, 'mapping_file', None), getattr(args, 'ad_hoc', None)]):
+                    getattr(args, 'mapping', None), getattr(args, 'ad_hoc', None)]):
                 args.min_length = 1
             else:
                 args.min_length = 3


### PR DESCRIPTION
**PR Title:** Fix logic bug in multitool.py setting default min_length for count mode 
 
**Description:** 
* **What:** Updated the attribute check in `multitool.py`'s `main()` function to use the correct attribute name `mapping` instead of the non-existent `mapping_file` when determining context-sensitive defaults for the `--min-length` flag.
* **Why:** This fixes a logic bug where providing a mapping file to the `count` mode (for auditing purposes) would incorrectly default the minimum word length to 3 instead of 1. This caused short typos (e.g., "teh" -> "the" or 2-letter words) to be silently skipped during analysis unless the user manually specified `-m 1`. This change improves the accuracy of the tool's auditing capabilities and reduces user friction by providing more intuitive defaults. No breaking changes were introduced, and all existing tests pass.

---
*PR created automatically by Jules for task [467144483987708855](https://jules.google.com/task/467144483987708855) started by @RainRat*