### PR TITLE
[FEAT] Add 'between' mode for arbitrary delimiter extraction

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -43,6 +43,11 @@ These modes help you pull specific data out of a messy file.
   - **What it does:** Gets text found inside double (`"`) or single (`'`) quotes. It handles backslash escaping (like `\"` or `\'`) to correctly extract strings from code or data files.
   - **Example:** `python multitool.py quoted source.py`
 
+- **`between`**
+  - **What it does:** Gets text found between two markers. It is useful for extracting data from templating languages, logs, or custom file formats. You can use the `--multi-line` flag to capture content that spans multiple lines.
+  - **Options:** Requires `--start` and `--end` to define the markers.
+  - **Example:** `python multitool.py between input.txt --start '{{' --end '}}'`
+
 - **`csv`**
   - **What it does:** Gets columns from a CSV file. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) followed by one or more numbers to get specific columns. Use `--delimiter` (or `-d`) to pick a different column separator (for example, `;`).
   - **Example:** `python multitool.py csv data.csv --column 2`

--- a/multitool.py
+++ b/multitool.py
@@ -935,6 +935,26 @@ def _extract_quoted_items(input_file: str, quiet: bool = False) -> Iterable[str]
             yield content
 
 
+def _extract_between_items(
+    input_file: str, start: str, end: str, multi_line: bool = False, quiet: bool = False
+) -> Iterable[str]:
+    """Yield text found between start and end markers."""
+    flags = re.DOTALL if multi_line else 0
+    # Escape markers for safe regex usage
+    pattern = re.compile(re.escape(start) + r'(.*?)' + re.escape(end), flags)
+
+    if multi_line:
+        lines = _read_file_lines_robust(input_file)
+        content = "".join(lines)
+        for match in pattern.finditer(content):
+            yield match.group(1)
+    else:
+        lines = _read_file_lines_robust(input_file)
+        for line in tqdm(lines, desc=f'Processing {input_file} (between)', unit=' lines', disable=quiet):
+            for match in pattern.finditer(line):
+                yield match.group(1)
+
+
 def _traverse_data(data: Any, path_parts: List[str]) -> Iterable[str]:
     """Recursively traverse a nested data structure (list/dict) to get values."""
     # If it's a list, apply the current path traversal to every item
@@ -1427,6 +1447,39 @@ def quoted_mode(
         process_output,
         'Quoted',
         'Successfully got quoted strings.',
+        output_format,
+        quiet,
+        clean_items=clean_items,
+        limit=limit,
+    )
+
+
+def between_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    start: str,
+    end: str,
+    multi_line: bool = False,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Wrapper for getting text between markers."""
+    def extractor(f, quiet=False):
+        return _extract_between_items(f, start, end, multi_line=multi_line, quiet=quiet)
+    _process_items(
+        extractor,
+        input_files,
+        output_file,
+        min_length,
+        max_length,
+        process_output,
+        'Between',
+        'Successfully got strings.',
         output_format,
         quiet,
         clean_items=clean_items,
@@ -4653,6 +4706,12 @@ MODE_DETAILS = {
         "example": "python multitool.py quoted source.py --output strings.txt",
         "flags": "",
     },
+    "between": {
+        "summary": "Gets text between markers.",
+        "description": "Finds text between a starting marker and an ending marker. It supports simple text markers and can work across multiple lines if the --multi-line flag is used.",
+        "example": "python multitool.py between input.txt --start '{{' --end '}}' --output items.txt",
+        "flags": "--start S --end E [--multi-line]",
+    },
     "csv": {
         "summary": "Gets specific columns from CSV.",
         "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, or --column to pick specific numbers.",
@@ -4881,7 +4940,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GETTING DATA": ["arrow", "table", "backtick", "quoted", "csv", "markdown", "md-table", "json", "yaml", "line", "words", "ngrams", "regex"],
+        "GETTING DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "line", "words", "ngrams", "regex"],
         "CHANGING DATA": ["combine", "unique", "diff", "highlight", "resolve", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECKING DATA": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
@@ -5151,6 +5210,33 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['quoted']['example']}{RESET}",
     )
     _add_common_mode_arguments(quoted_parser)
+
+    between_parser = subparsers.add_parser(
+        'between',
+        help=MODE_DETAILS['between']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['between']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['between']['example']}{RESET}",
+    )
+    between_options = between_parser.add_argument_group(f"{BLUE}BETWEEN OPTIONS{RESET}")
+    between_options.add_argument(
+        '--start',
+        type=str,
+        required=True,
+        help="The starting marker to find.",
+    )
+    between_options.add_argument(
+        '--end',
+        type=str,
+        required=True,
+        help="The ending marker to find.",
+    )
+    between_options.add_argument(
+        '--multi-line',
+        action='store_true',
+        help="Allow markers to span across multiple lines.",
+    )
+    _add_common_mode_arguments(between_parser)
 
     csv_parser = subparsers.add_parser(
         'csv',
@@ -6396,6 +6482,16 @@ def main() -> None:
         'quoted': (
             quoted_mode,
             {**common_kwargs, 'output_format': output_format},
+        ),
+        'between': (
+            between_mode,
+            {
+                **common_kwargs,
+                'start': getattr(args, 'start', ''),
+                'end': getattr(args, 'end', ''),
+                'multi_line': getattr(args, 'multi_line', False),
+                'output_format': output_format,
+            },
         ),
         'csv': (
             csv_mode,

--- a/tests/test_multitool_between.py
+++ b/tests/test_multitool_between.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Import the functions to be tested from multitool
+from multitool import _extract_between_items, between_mode
+
+class TestBetweenMode(unittest.TestCase):
+    def test_extract_between_items_single_line(self):
+        content = "The value is {{secret}} and {{another_one}} here."
+        with patch('multitool._read_file_lines_robust', return_value=[content]):
+            items = list(_extract_between_items('test.txt', start='{{', end='}}', quiet=True))
+            self.assertEqual(items, ['secret', 'another_one'])
+
+    def test_extract_between_items_multi_line(self):
+        content = ["Start here <!--\n", "This is a comment\n", "spanning multiple lines\n", "--> End here"]
+        # When multi_line is True, it joins the lines.
+        with patch('multitool._read_file_lines_robust', return_value=content):
+            items = list(_extract_between_items('test.txt', start='<!--', end='-->', multi_line=True, quiet=True))
+            self.assertEqual(items, ['\nThis is a comment\nspanning multiple lines\n'])
+
+    def test_extract_between_items_no_match(self):
+        content = "No markers here."
+        with patch('multitool._read_file_lines_robust', return_value=[content]):
+            items = list(_extract_between_items('test.txt', start='[[', end=']]', quiet=True))
+            self.assertEqual(items, [])
+
+    def test_extract_between_items_regex_escaping(self):
+        # Markers that contain regex special characters like dots, stars, parens
+        content = "Matching (start) content (end) and [more] markers."
+        with patch('multitool._read_file_lines_robust', return_value=[content]):
+            items = list(_extract_between_items('test.txt', start='(start)', end='(end)', quiet=True))
+            self.assertEqual(items, [' content '])
+
+    def test_between_mode_execution(self):
+        # Mocking _process_items to ensure between_mode calls it correctly
+        with patch('multitool._process_items') as mock_process:
+            between_mode(
+                input_files=['input.txt'],
+                output_file='output.txt',
+                min_length=1,
+                max_length=1000,
+                process_output=False,
+                start='[[',
+                end=']]',
+                multi_line=False,
+                output_format='line',
+                quiet=True,
+                clean_items=True,
+                limit=None
+            )
+            # Verify that the extractor passed to _process_items calls _extract_between_items correctly
+            args, kwargs = mock_process.call_args
+            extractor = args[0]
+
+            with patch('multitool._extract_between_items') as mock_extract:
+                extractor('some_file', quiet=True)
+                mock_extract.assert_called_once_with('some_file', '[[', ']]', multi_line=False, quiet=True)
+
+            self.assertEqual(args[1], ['input.txt'])
+            self.assertEqual(args[2], 'output.txt')
+            self.assertEqual(args[6], 'Between')
+            self.assertEqual(args[7], 'Successfully got strings.')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**What:** 
Implemented a new `between` mode for the `multitool.py` utility. This mode enables users to extract text situated between arbitrary starting and ending markers (e.g., `{{` and `}}` or `<!--` and `-->`). It includes a `--multi-line` flag to support matches that span across line boundaries.

**Why:** 
The tool already provided specialized extraction modes like `quoted` (for `"` or `'`) and `backtick` (for `` ` ``), but there was no way to handle custom delimiters. The `between` mode provides a generalized, flexible solution for extracting data from templating languages, log formats, or code comments, fulfilling the heuristics of symmetry and convenience.

---
*PR created automatically by Jules for task [16233659105713207857](https://jules.google.com/task/16233659105713207857) started by @RainRat*