### PR TITLE
Fix min_length default logic in multitool count mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -6163,7 +6163,7 @@ def main() -> None:
         elif args.mode == 'count':
             # Count mode uses 3 for word extraction, but 1 for auditing or character counting
             if any([getattr(args, 'pairs', False), getattr(args, 'chars', False),
-                    getattr(args, 'mapping_file', None), getattr(args, 'ad_hoc', None)]):
+                    getattr(args, 'mapping', None), getattr(args, 'ad_hoc', None)]):
                 args.min_length = 1
             else:
                 args.min_length = 3


### PR DESCRIPTION
Fixed a logic bug in `multitool.py` where the default `min_length` for `count` mode was incorrectly determined when using the `--mapping` flag. The issue was caused by the code checking for a non-existent `args.mapping_file` attribute instead of the correct `args.mapping` attribute produced by the parser. This fix ensures that auditing modes correctly default to a `min_length` of 1, preserving short terms in the analysis.

---
*PR created automatically by Jules for task [7341909431483594531](https://jules.google.com/task/7341909431483594531) started by @RainRat*