### PR TITLE
[TEST] Fix min-length default bug and expand CLI coverage for multitool

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -6163,7 +6163,7 @@ def main() -> None:
         elif args.mode == 'count':
             # Count mode uses 3 for word extraction, but 1 for auditing or character counting
             if any([getattr(args, 'pairs', False), getattr(args, 'chars', False),
-                    getattr(args, 'mapping_file', None), getattr(args, 'ad_hoc', None)]):
+                    getattr(args, 'mapping', None), getattr(args, 'ad_hoc', None)]):
                 args.min_length = 1
             else:
                 args.min_length = 3

--- a/tests/test_multitool_count_min_length.py
+++ b/tests/test_multitool_count_min_length.py
@@ -1,0 +1,119 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+# Add repository root to path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import multitool
+
+def test_min_length_defaults_in_count_mode(tmp_path, monkeypatch):
+    """
+    Verify that --min-length correctly defaults to 1 or 3 in count mode
+    depending on the other flags.
+    """
+    dummy_input = tmp_path / "input.txt"
+    dummy_input.write_text("a b c d e")
+    dummy_mapping = tmp_path / "mapping.csv"
+    dummy_mapping.write_text("a,b")
+
+    # 1. Default (word extraction) should be 3
+    with patch("sys.argv", ["multitool.py", "count", str(dummy_input)]), \
+         patch("multitool.count_mode") as mock_count:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_count.call_args
+        assert kwargs["min_length"] == 3
+
+    # 2. With --pairs should be 1
+    with patch("sys.argv", ["multitool.py", "count", str(dummy_input), "--pairs"]), \
+         patch("multitool.count_mode") as mock_count:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_count.call_args
+        assert kwargs["min_length"] == 1
+
+    # 3. With --chars should be 1
+    with patch("sys.argv", ["multitool.py", "count", str(dummy_input), "--chars"]), \
+         patch("multitool.count_mode") as mock_count:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_count.call_args
+        assert kwargs["min_length"] == 1
+
+    # 4. With --add (ad_hoc) should be 1
+    with patch("sys.argv", ["multitool.py", "count", str(dummy_input), "--add", "a:b"]), \
+         patch("multitool.count_mode") as mock_count:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_count.call_args
+        assert kwargs["min_length"] == 1
+
+    # 5. With --mapping should be 1 (BUG: Currently it's 3 because of wrong attribute name)
+    with patch("sys.argv", ["multitool.py", "count", str(dummy_input), "--mapping", str(dummy_mapping)]), \
+         patch("multitool.count_mode") as mock_count:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_count.call_args
+        # This is expected to FAIL before the fix
+        assert kwargs["min_length"] == 1
+
+    # 6. Words mode should be 3
+    with patch("sys.argv", ["multitool.py", "words", str(dummy_input)]), \
+         patch("multitool.words_mode") as mock_mode:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_mode.call_args
+        assert kwargs["min_length"] == 3
+
+    # 7. Search mode should be 1
+    with patch("sys.argv", ["multitool.py", "search", str(dummy_input), "--query", "abc"]), \
+         patch("multitool.search_mode") as mock_mode:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_mode.call_args
+        assert kwargs["min_length"] == 1
+
+    # 8. ngrams mode should be 3
+    with patch("sys.argv", ["multitool.py", "ngrams", str(dummy_input)]), \
+         patch("multitool.ngrams_mode") as mock_mode:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_mode.call_args
+        assert kwargs["min_length"] == 3
+
+    # 9. stats mode should be 3
+    with patch("sys.argv", ["multitool.py", "stats", str(dummy_input)]), \
+         patch("multitool.stats_mode") as mock_mode:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_mode.call_args
+        assert kwargs["min_length"] == 3
+
+    # 10. Explicit min_length should be preserved
+    with patch("sys.argv", ["multitool.py", "count", str(dummy_input), "--min-length", "5"]), \
+         patch("multitool.count_mode") as mock_count:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_count.call_args
+        assert kwargs["min_length"] == 5


### PR DESCRIPTION
### User's Goal:
The goal was to improve test coverage and fix any identified bugs in the codebase.

### Changes Made:
1.  **Bug Fix in `multitool.py`**:
    *   Identified a bug in the `main()` function's `min_length` default logic.
    *   The code was attempting to check `getattr(args, 'mapping_file', None)`, but the CLI attribute is actually named `mapping`.
    *   This caused `count` mode with a mapping file to default to `min_length=3` (intended for word extraction) instead of `min_length=1` (intended for auditing), potentially leading to missed short typos.
    *   Corrected the attribute name to `mapping`.

2.  **New Test Suite**:
    *   Created `tests/test_multitool_count_min_length.py`.
    *   This test verifies that `min_length` defaults are correctly applied based on the mode and flags:
        *   `count` mode defaults to 3 (words).
        *   `count` mode with `--pairs`, `--chars`, `--mapping`, or `--add` defaults to 1.
        *   `words`, `ngrams`, and `stats` modes default to 3.
        *   `search` mode defaults to 1.
        *   Explicitly provided `--min-length` is preserved.

### Verification:
*   Ran the new test suite: `PYTHONPATH=. python3 -m pytest tests/test_multitool_count_min_length.py` (Passes).
*   Verified coverage of the affected logic block (100% statement coverage for the `min_length` default logic).
*   Ran the full test suite (708 tests) to ensure no regressions (All passed).

---
*PR created automatically by Jules for task [5181957428046218385](https://jules.google.com/task/5181957428046218385) started by @RainRat*