### PR TITLE
[UI/UX] Enhance visual hierarchy of search and scan outputs

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -38,13 +38,15 @@ BLUE = "\033[1;34m"
 GREEN = "\033[1;32m"
 RED = "\033[1;31m"
 YELLOW = "\033[1;33m"
+MAGENTA = "\033[1;35m"
+CYAN = "\033[1;36m"
 RESET = "\033[0m"
 BOLD = "\033[1m"
 
 # Disable colors if not running in a terminal or if NO_COLOR is set
 # We check the main output and error output as help goes to the main output and logging/stats to error output
 if (not sys.stdout.isatty() and 'FORCE_COLOR' not in os.environ) or 'NO_COLOR' in os.environ:
-    BLUE = GREEN = RED = YELLOW = RESET = BOLD = ""
+    BLUE = GREEN = RED = YELLOW = MAGENTA = CYAN = RESET = BOLD = ""
 # Note: we use the main output's status for the global constants, but individual
 # functions might still check the error output if they specifically log to it.
 
@@ -2924,20 +2926,30 @@ def _format_search_line(
     use_color: bool,
 ) -> str:
     """Formats a single line for search/scan output with optional filename and line number."""
-    sep = ":" if is_match else "-"
-    prefix_parts = []
-    if show_filename:
-        prefix_parts.append(filename)
-    if line_numbers:
-        prefix_parts.append(str(line_idx + 1))
+    sep_char = ":" if is_match else "-"
 
-    if prefix_parts:
-        raw_prefix = sep.join(prefix_parts) + sep
-        if use_color:
-            style = (BOLD + BLUE) if is_match else BLUE
-            return f"{style}{raw_prefix}{RESET} {line_content}"
+    if not show_filename and not line_numbers:
+        return line_content
+
+    if use_color:
+        sep_style = (BOLD + BLUE) if is_match else BLUE
+        sep = f"{sep_style}{sep_char}{RESET}"
+
+        parts = []
+        if show_filename:
+            parts.append(f"{MAGENTA}{filename}{RESET}")
+        if line_numbers:
+            parts.append(f"{CYAN}{line_idx + 1}{RESET}")
+
+        return f"{sep.join(parts)}{sep} {line_content}"
+    else:
+        prefix_parts = []
+        if show_filename:
+            prefix_parts.append(filename)
+        if line_numbers:
+            prefix_parts.append(str(line_idx + 1))
+        raw_prefix = sep_char.join(prefix_parts) + sep_char
         return f"{raw_prefix} {line_content}"
-    return line_content
 
 
 def search_mode(
@@ -3096,7 +3108,7 @@ def search_mode(
 
             # If there's a gap between blocks, add separator
             if last_rendered_idx != -1 and start > last_rendered_idx:
-                separator = f"{BLUE}--{RESET}" if use_color else "--"
+                separator = f"{BOLD + BLUE}--{RESET}" if use_color else "--"
                 accumulated_lines.append(separator)
 
             # Render lines in the window that haven't been rendered yet
@@ -4294,7 +4306,7 @@ def scan_mode(
             end = min(len(file_contents), idx + after_context + 1)
 
             if last_rendered_idx != -1 and start > last_rendered_idx:
-                separator = f"{BLUE}--{RESET}" if use_color else "--"
+                separator = f"{BOLD + BLUE}--{RESET}" if use_color else "--"
                 accumulated_lines.append(separator)
 
             current_start = max(start, last_rendered_idx)


### PR DESCRIPTION
### Context
CLI (multitool.py)

### Problem
The search and scan modes previously used a monochromatic blue prefix for both filenames and line numbers. This made it difficult for users to quickly scan results and distinguish between metadata (where the match is) and the content itself.

### Solution
I have enhanced the visual hierarchy of the search/scan output by introducing distinct colors for different metadata fields:
- **Filenames:** Now displayed in **MAGENTA**.
- **Line Numbers:** Now displayed in **CYAN**.
- **Separators:** The `:` (match) and `-` (context) separators now use **BOLD BLUE** and **BLUE** respectively to further distinguish match lines from context lines.
- **Block Separators:** The `--` context block separator is now **BOLD BLUE** for better visibility.

These changes follow industry standards (similar to `grep` or `ripgrep`) and significantly reduce the cognitive load when parsing search results.

### Changes
- Added `MAGENTA` and `CYAN` constants to `multitool.py`.
- Updated `_format_search_line` to handle field-specific coloring.
- Enhanced context block separator styling in `search_mode` and `scan_mode`.

---
*PR created automatically by Jules for task [9359751070839728399](https://jules.google.com/task/9359751070839728399) started by @RainRat*