### PR TITLE
[DOCS] Improve docstring accuracy and simplicity in diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -161,7 +161,7 @@ def split_into_subwords(word: str) -> List[str]:
 
 def read_words_mapping(file_path: str, required: bool = True) -> Dict[str, Set[str]]:
     """
-    Reads a CSV file of typo fixes and returns a list:
+    Reads a CSV file of typo fixes and returns a mapping:
          incorrect_word -> corrections
 
     Each row should be in the form:
@@ -563,7 +563,7 @@ def process_corrections_mode(candidates, words_mapping, quiet=False):
 def process_audit_typos(candidates, args, large_dictionary, allowed_words):
     """
     Find cases where a correct word was changed into a typo.
-    Identifies cases where a word that used to be valid
+    Finds cases where a word that used to be valid
     was changed to a word that is not in the large dictionary.
     """
     audit_candidates = []


### PR DESCRIPTION
**PR Title:** [DOCS] Improve docstring accuracy and simplicity in diff2typo.py

**Description:**
* **Type:** Internal Help (Docstrings)
* **What:** Updated `read_words_mapping` and `process_audit_typos` functions in `diff2typo.py`.
* **Why:** Corrected the return type description in `read_words_mapping` from "list" to "mapping" to accurately reflect the code's behavior (Truth First). Simplified the technical verb "Identifies" to "Finds" in `process_audit_typos` to align with the project's plain English and simplicity standards.

---
*PR created automatically by Jules for task [4374035340474416898](https://jules.google.com/task/4374035340474416898) started by @RainRat*