### PR TITLE
Deduplicate context rendering logic in multitool.py

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2940,6 +2940,46 @@ def _format_search_line(
     return line_content
 
 
+def _render_context_to_lines(
+    match_indices: Mapping[int, str],
+    file_contents: Sequence[str],
+    before_context: int,
+    after_context: int,
+    filename: str,
+    show_filename: bool,
+    line_numbers: bool,
+    use_color: bool,
+) -> List[str]:
+    """Renders match lines and their surrounding context lines into a list of strings."""
+    accumulated_lines = []
+    sorted_indices = sorted(match_indices.keys())
+    last_rendered_idx = -1
+
+    for idx in sorted_indices:
+        # Determine block start and end
+        start = max(0, idx - before_context)
+        end = min(len(file_contents), idx + after_context + 1)
+
+        # If there's a gap between blocks, add separator
+        if last_rendered_idx != -1 and start > last_rendered_idx:
+            separator = f"{BLUE}--{RESET}" if use_color else "--"
+            accumulated_lines.append(separator)
+
+        # Render lines in the window that haven't been rendered yet
+        current_start = max(start, last_rendered_idx)
+        for j in range(current_start, end):
+            is_match = j in match_indices
+            content = match_indices[j] if is_match else file_contents[j]
+            accumulated_lines.append(
+                _format_search_line(
+                    filename, j, content, is_match, show_filename, line_numbers, use_color
+                )
+            )
+
+        last_rendered_idx = end
+    return accumulated_lines
+
+
 def search_mode(
     input_files: Sequence[str],
     query: str,
@@ -3086,31 +3126,18 @@ def search_mode(
         total_matches += len(match_indices)
 
         # Collect context blocks
-        sorted_indices = sorted(match_indices.keys())
-        last_rendered_idx = -1
-
-        for idx in sorted_indices:
-            # Determine block start and end
-            start = max(0, idx - before_context)
-            end = min(len(file_contents), idx + after_context + 1)
-
-            # If there's a gap between blocks, add separator
-            if last_rendered_idx != -1 and start > last_rendered_idx:
-                separator = f"{BLUE}--{RESET}" if use_color else "--"
-                accumulated_lines.append(separator)
-
-            # Render lines in the window that haven't been rendered yet
-            current_start = max(start, last_rendered_idx)
-            for j in range(current_start, end):
-                is_match = j in match_indices
-                content = match_indices[j] if is_match else file_contents[j]
-                accumulated_lines.append(
-                    _format_search_line(
-                        input_file, j, content, is_match, show_filename, line_numbers, use_color
-                    )
-                )
-
-            last_rendered_idx = end
+        accumulated_lines.extend(
+            _render_context_to_lines(
+                match_indices,
+                file_contents,
+                before_context,
+                after_context,
+                input_file,
+                show_filename,
+                line_numbers,
+                use_color,
+            )
+        )
 
     if process_output:
         accumulated_lines = sorted(set(accumulated_lines))
@@ -4286,28 +4313,18 @@ def scan_mode(
         total_matches += len(match_indices)
 
         # Collect context blocks
-        sorted_indices = sorted(match_indices.keys())
-        last_rendered_idx = -1
-
-        for idx in sorted_indices:
-            start = max(0, idx - before_context)
-            end = min(len(file_contents), idx + after_context + 1)
-
-            if last_rendered_idx != -1 and start > last_rendered_idx:
-                separator = f"{BLUE}--{RESET}" if use_color else "--"
-                accumulated_lines.append(separator)
-
-            current_start = max(start, last_rendered_idx)
-            for j in range(current_start, end):
-                is_match = j in match_indices
-                content = match_indices[j] if is_match else file_contents[j]
-                accumulated_lines.append(
-                    _format_search_line(
-                        input_file, j, content, is_match, show_filename, line_numbers, use_color
-                    )
-                )
-
-            last_rendered_idx = end
+        accumulated_lines.extend(
+            _render_context_to_lines(
+                match_indices,
+                file_contents,
+                before_context,
+                after_context,
+                input_file,
+                show_filename,
+                line_numbers,
+                use_color,
+            )
+        )
 
     if process_output:
         accumulated_lines = sorted(set(accumulated_lines))


### PR DESCRIPTION
* **What:** Extracted identical context block rendering logic from `search_mode` and `scan_mode` into a new internal helper function `_render_context_to_lines`.
* **Why:** Reduces code duplication and improves maintainability. The external behavior remains identical as verified by existing tests.

---
*PR created automatically by Jules for task [10194939411451609526](https://jules.google.com/task/10194939411451609526) started by @RainRat*