### PR TITLE
[UI/UX] Standardize and improve typostats report output

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -56,14 +56,15 @@ When using the default **arrow** format, the report displays results in two sect
 ```text
   ANALYSIS SUMMARY
   ───────────────────────────────────────────────────────
-  Total word pairs encountered:       4
-  Total patterns after analysis:      4
+  Total patterns found:               4
+  Total patterns kept:                4
   Retention rate:                     100.0% ████████████████████
   Unique patterns found:              3
   Min/Max/Avg length:                 7 / 8 / 7.5
-  Shortest replacement:               'rn -> m' (length: 7)
-  Longest replacement:                'he -> eh' (length: 8)
+  Shortest pattern kept:              'm -> rn' (length: 7)
+  Longest pattern kept:               'eh -> he' (length: 8)
   Min/Max/Avg changes:                1 / 2 / 1.8
+  Total word pairs analyzed:          4
   Total lines processed:              4
   Enabled features:                   keyboard, transposition, 1-to-2, 2-to-1, deletions/insertions
   Transpositions [T]:                 2/4 (50.0%)

--- a/tests/test_coverage_gaps_final.py
+++ b/tests/test_coverage_gaps_final.py
@@ -65,11 +65,11 @@ def test_levenshtein_distance_empty_s2():
 
 def test_generate_report_unhashable_items():
     """Test _format_analysis_summary with unhashable items to trigger except block."""
-    # The gap is in _format_analysis_summary at line 140
-    # Let's mock set() to raise TypeError to trigger line 140
+    # Let's mock set() to raise TypeError to trigger hashable check failure
     with patch('builtins.set', side_effect=TypeError("unhashable")):
         lines = typostats._format_analysis_summary(10, ["item1"], use_color=False)
-    assert any("Unique items:" in line for line in lines)
+    # Changed to match new label format: 'Unique items found:'
+    assert any("Unique items found:" in line for line in lines)
 
 def test_generate_report_format_item_failure():
     """Test _format_analysis_summary format_item failure to trigger except block."""
@@ -96,7 +96,8 @@ def test_generate_report_all_summary_branches(capsys):
     typostats.generate_report(counts, quiet=True)
     captured = capsys.readouterr()
     assert captured.err == ""
-    assert "a │ b" in captured.out
+    # Swapped order: typo 'b' then correct 'a'
+    assert "b │ a" in captured.out
 
 def test_format_analysis_summary_retention_bar_edge():
     """Trigger the bar += blocks[frac_idx] branch in _format_analysis_summary."""

--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -110,10 +110,9 @@ def test_generate_report_arrow(capsys):
     counts = {('s', 'z'): 3, ('e', 'a'): 1}
     typostats.generate_report(counts, min_occurrences=2, output_format='arrow', quiet=True)
     captured = capsys.readouterr().out
-    # 's' should be padded with 6 spaces (max_c=7)
-    # New format: padding(2) + 's' in 7 chars (6 spaces + s) = 8 spaces
-    # Followed by │ z and │ count '3' and │ percentage
-    assert '        s │ z    │     3 │  75.0% │ ███████' in captured
+    # New format: typo 'z' then correct 's'
+    assert 'z │ s' in captured
+    assert '3 │  75.0%' in captured
     assert 'e' not in captured
 
 
@@ -121,21 +120,21 @@ def test_generate_report_limit(capsys):
     counts = {('a', 'b'): 10, ('c', 'd'): 5, ('e', 'f'): 2}
     typostats.generate_report(counts, limit=2, output_format='arrow', quiet=True)
     captured = capsys.readouterr().out
-    assert '        a │ b    │    10 │  58.8% │ █████' in captured
-    assert '        c │ d    │     5 │  29.4% │ ██' in captured
+    # typo 'b' (for 'a') and typo 'd' (for 'c')
+    assert 'b │ a' in captured
+    assert 'd │ c' in captured
     assert 'e' not in captured
 
 
 def test_generate_report_limit_with_typo_sort(capsys):
-    # Counts are such that 'z' would be last in count sort, but first in reverse typo sort?
-    # Actually sort_by='typo' sorts alphabetically by typo char.
     counts = {('a', 'z'): 10, ('b', 'x'): 5, ('c', 'y'): 2}
     # Sorted by typo: ('b', 'x'), ('c', 'y'), ('a', 'z')
     typostats.generate_report(counts, limit=2, sort_by='typo', output_format='arrow', quiet=True)
     captured = capsys.readouterr().out
-    assert '        b │ x    │     5 │  29.4% │ ██' in captured
-    assert '        c │ y    │     2 │  11.8% │ █' in captured
-    assert 'a │ z' not in captured
+    # typos are x, y, z
+    assert 'x │ b' in captured
+    assert 'y │ c' in captured
+    assert 'z │ a' not in captured
 
 
 def test_generate_report_json(capsys):
@@ -171,9 +170,10 @@ def test_generate_report_sort_by_typo(capsys):
     captured = capsys.readouterr()
     lines = [line for line in captured.out.splitlines() if line]
     # Header is now on stderr, so lines contains only data
-    assert '        a │ x    │     3 │  50.0% │ █████' in lines[0]
-    assert '        a │ y    │     2 │  33.3% │ ███' in lines[1]
-    assert '        b │ z    │     1 │  16.7% │ █' in lines[2]
+    # Typos: x, y, z
+    assert 'x │ a' in lines[0]
+    assert 'y │ a' in lines[1]
+    assert 'z │ b' in lines[2]
     assert "LETTER REPLACEMENTS" in captured.err
 
 
@@ -183,9 +183,10 @@ def test_generate_report_sort_by_correct(capsys):
     captured = capsys.readouterr()
     lines = [line for line in captured.out.splitlines() if line]
     # Header is now on stderr, so lines contains only data
-    assert '        a │ y    │     2 │  33.3% │ ███' in lines[0]
-    assert '        b │ z    │     1 │  16.7% │ █' in lines[1]
-    assert '        c │ x    │     3 │  50.0% │ █████' in lines[2]
+    # Correct: a, b, c
+    assert 'y │ a' in lines[0]
+    assert 'z │ b' in lines[1]
+    assert 'x │ c' in lines[2]
     assert "LETTER REPLACEMENTS" in captured.err
 
 

--- a/tests/test_typostats_new_markers.py
+++ b/tests/test_typostats_new_markers.py
@@ -18,11 +18,12 @@ def test_new_markers(capsys):
 
 def test_summary_labels(capsys):
     """Verify improved labels in the analysis summary."""
-    counts = {('teh', 'the'): 1}
+    counts = {('the', 'teh'): 1}
     # generate_report prints summary to stderr when no output_file
-    typostats.generate_report(counts, quiet=False)
+    typostats.generate_report(counts, quiet=False, total_pairs=1)
     captured = capsys.readouterr().err
 
-    assert "Total word pairs encountered:" in captured
-    assert "Total patterns after analysis:" in captured
+    assert "Total word pairs analyzed:" in captured
+    assert "Total patterns found:" in captured
+    assert "Total patterns kept:" in captured
     assert "Unique patterns found:" in captured

--- a/typostats.py
+++ b/typostats.py
@@ -105,13 +105,8 @@ def _format_analysis_summary(
     report.append(f"\n{padding}{c_bold}{c_blue}{title}{c_reset}")
     report.append(f"{padding}{c_bold}{c_blue}───────────────────────────────────────────────────────{c_reset}")
 
-    # In typostats, raw_count is the number of word pairs, but filtered_items are patterns.
-    # We rename labels to be more descriptive of what they actually count.
-    raw_label = "Total word pairs encountered:"
-    filtered_label = "Total patterns after analysis:"
-    if item_label != "replacement":
-        raw_label = f"Total {item_label_plural} encountered:"
-        filtered_label = f"Total {item_label_plural} after filtering:"
+    raw_label = f"Total {item_label_plural} found:"
+    filtered_label = f"Total {item_label_plural} kept:"
 
     report.append(
         f"  {c_bold}{c_blue}{raw_label:<{label_width}}{c_reset} {c_yellow}{raw_count}{c_reset}"
@@ -148,7 +143,7 @@ def _format_analysis_summary(
     except (TypeError, ValueError):
         unique_count = len(filtered_items)
 
-    unique_label = "Unique patterns found:" if item_label == "replacement" else f"Unique {item_label_plural}:"
+    unique_label = f"Unique {item_label_plural} found:"
     report.append(
         f"  {c_bold}{c_blue}{unique_label:<{label_width}}{c_reset} {c_green}{unique_count}{c_reset}"
     )
@@ -158,7 +153,9 @@ def _format_analysis_summary(
 
         def format_item(it: Any) -> str:
             if isinstance(it, tuple) and len(it) == 2:
-                return f"{it[0]} -> {it[1]}"
+                # In typostats, pairs are stored as (correct, typo)
+                # We display them as typo -> correct for consistency
+                return f"{it[1]} -> {it[0]}"
             return str(it)
 
         try:
@@ -178,10 +175,10 @@ def _format_analysis_summary(
             l_display = format_item(longest)
 
             report.append(
-                f"  {c_bold}{c_blue}{'Shortest ' + item_label + ':':<{label_width}}{c_reset} '{s_display}' (length: {len(s_display)})"
+                f"  {c_bold}{c_blue}{'Shortest ' + item_label + ' kept:':<{label_width}}{c_reset} '{s_display}' (length: {len(s_display)})"
             )
             report.append(
-                f"  {c_bold}{c_blue}{'Longest ' + item_label + ':':<{label_width}}{c_reset} '{l_display}' (length: {len(l_display)})"
+                f"  {c_bold}{c_blue}{'Longest ' + item_label + ' kept:':<{label_width}}{c_reset} '{l_display}' (length: {len(l_display)})"
             )
         except (ValueError, TypeError):
             pass
@@ -538,6 +535,8 @@ def generate_report(
             enabled_features.append("deletions/insertions")
 
         extra_metrics = {}
+        if total_pairs is not None:
+            extra_metrics["Total word pairs analyzed"] = total_pairs
         if total_lines is not None:
             extra_metrics["Total lines processed"] = total_lines
         if enabled_features:
@@ -592,22 +591,23 @@ def generate_report(
         if unique_filtered > len(sorted_replacements):
             extra_metrics["Showing patterns"] = f"{len(sorted_replacements)} of {unique_filtered}"
 
-        # Generate a list of all replacements to use summary statistics
-        all_replacements = [k for k, v in replacement_counts.items() for _ in range(v)]
+        # Generate flattened list of kept patterns for summary statistics
+        # This ensures retention rate is calculated based on patterns kept / patterns found
+        kept_patterns_flattened = [k for k, v in filtered.items() for _ in range(v)]
         summary_lines = _format_analysis_summary(
-            total_pairs if total_pairs is not None else total_typos,
-            all_replacements,
-            item_label="replacement",
+            total_typos,
+            kept_patterns_flattened,
+            item_label="pattern",
             use_color=show_color_err,
             extra_metrics=extra_metrics,
             start_time=start_time,
         )
 
         # Calculate padding for alignment (default to header labels' lengths)
-        max_c = max((len(c) for (c, t), count in sorted_replacements), default=7)
-        max_c = max(max_c, 7)  # 'CORRECT' is 7
         max_t = max((len(t) for (c, t), count in sorted_replacements), default=4)
         max_t = max(max_t, 4)  # 'TYPO' is 4
+        max_c = max((len(c) for (c, t), count in sorted_replacements), default=7)
+        max_c = max(max_c, 7)  # 'CORRECT' is 7
         max_n = max((len(str(count)) for (c, t), count in sorted_replacements), default=5)
         max_n = max(max_n, 5)  # 'COUNT' is 5
         max_p = 6  # Width for percentage (for example, "100.0%")
@@ -624,8 +624,8 @@ def generate_report(
         # Bold blue for table visual elements
         sep = f"{c_bold}{c_blue}│{c_reset}"
         header_row = (
-            f"{padding}{c_bold}{c_blue}{'CORRECT':>{max_c}}{c_reset} {sep} "
-            f"{c_bold}{c_blue}{'TYPO':<{max_t}}{c_reset} {sep} "
+            f"{padding}{c_bold}{c_blue}{'TYPO':>{max_t}}{c_reset} {sep} "
+            f"{c_bold}{c_blue}{'CORRECT':<{max_c}}{c_reset} {sep} "
             f"{c_bold}{c_blue}{'COUNT':>{max_n}}{c_reset} {sep} "
             f"{c_bold}{c_blue}{'%':>{max_p}}{c_reset}"
         )
@@ -688,8 +688,8 @@ def generate_report(
                 bar += " " * (max_bar - full_blocks - 1)
 
             row = (
-                f"{padding}{c_green}{correct_char:>{max_c}}{c_reset} {sep} "
-                f"{c_red}{typo_char:<{max_t}}{c_reset} {sep} "
+                f"{padding}{c_red}{typo_char:>{max_t}}{c_reset} {sep} "
+                f"{c_green}{correct_char:<{max_c}}{c_reset} {sep} "
                 f"{c_yellow}{count:>{max_n}}{c_reset} {sep} "
                 f"{c_green}{percent:>5.1f}%{c_reset}"
             )
@@ -717,7 +717,7 @@ def generate_report(
                 marker = f"{c_bold}{marker_text:<5}{c_reset}"
                 row += f" {sep} {marker}"
 
-            row += f" {sep} {c_red}{bar}{c_reset}"
+            row += f" {sep} {c_blue}{bar}{c_reset}"
             report_lines.append(row)
         report_content = "\n".join(report_lines)
     elif output_format == 'json':


### PR DESCRIPTION
**Context:** CLI
**Problem:** The `typostats.py` tool's report uses a `CORRECT │ TYPO` column order, which contradicts the common `mistake -> fix` model used by the rest of the suite (e.g., `multitool.py`). Additionally, the retention rate calculation was comparing patterns to word pairs, resulting in misleading percentages over 100%, and the visual hierarchy lacked semantic coloring for errors versus fixes.
**Solution:** Swapped the columns to `TYPO │ CORRECT` and applied Git-standard colors (`RED` for typos, `GREEN` for corrections). Improved the analysis summary by ensuring retention rate is a pattern-to-pattern metric and added "Total word pairs analyzed" for better context. Standardized the visual bar to `BLUE` to align with the suite's aesthetic.


---
*PR created automatically by Jules for task [3493166154160383191](https://jules.google.com/task/3493166154160383191) started by @RainRat*