### PR TITLE
[DOCS] Standardize typo generation terminology and improve help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The **diff2typo Suite** is a set of tools to help you find and fix typos in your
 | Tool | What it does | Documentation |
 | :--- | :--- | :--- |
 | **diff2typo** | Finds typos you fixed in your Git history. | [Read Docs](docs/diff2typo.md) |
-| **gentypos** | Creates lists of "fake" typos based on common typing errors. | [Read Docs](docs/gentypos.md) |
+| **gentypos** | Creates lists of likely typos based on common typing errors. | [Read Docs](docs/gentypos.md) |
 | **multitool** | A multipurpose tool for cleaning, getting, and analyzing text files. | [Read Docs](docs/multitool.md) |
 | **cmdrunner** | Runs commands across many folders at once. | [Read Docs](docs/cmdrunner.md) |
 | **typostats** | Analyzes your typos to find common finger-slips. | [Read Docs](docs/typostats.md) |

--- a/diff2typo.py
+++ b/diff2typo.py
@@ -161,7 +161,7 @@ def split_into_subwords(word: str) -> List[str]:
 
 def read_words_mapping(file_path: str, required: bool = True) -> Dict[str, Set[str]]:
     """
-    Reads a CSV file of typo fixes and returns a list:
+    Reads a CSV file of typo fixes and returns a mapping:
          incorrect_word -> corrections
 
     Each row should be in the form:
@@ -563,7 +563,7 @@ def process_corrections_mode(candidates, words_mapping, quiet=False):
 def process_audit_typos(candidates, args, large_dictionary, allowed_words):
     """
     Find cases where a correct word was changed into a typo.
-    Identifies cases where a word that used to be valid
+    Finds cases where a word that used to be valid
     was changed to a word that is not in the large dictionary.
     """
     audit_candidates = []

--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -1,6 +1,6 @@
 # gentypos.py
 
-**Purpose:** Generates fake typos from a list of words. It mimics common mistakes like hitting the wrong key, skipping a letter, swapping two letters, or typing a letter twice.
+**Purpose:** Generates likely typos from a list of words. It mimics common mistakes like hitting the wrong key, skipping a letter, swapping two letters, or typing a letter twice.
 
 ## Usage
 
@@ -93,5 +93,5 @@ Supported formats:
 ## How it Works
 
 1.  **Generation:** The tool applies the selected mistake types to every word in your input.
-2.  **Filtering:** It checks the new "typos" against your `dictionary_file` (the large dictionary). If a generated typo is actually a real word (like "form" instead of "from"), it is removed. This prevents the tool from flagging correct words as typos.
+2.  **Filtering:** It checks the "typos" against your `dictionary_file` (the large dictionary). If a generated typo is actually a real word (like "form" instead of "from"), it is removed. This prevents the tool from flagging correct words as typos.
 3.  **Saving:** The final list is formatted and saved to your output file or printed to the screen.

--- a/gentypos.py
+++ b/gentypos.py
@@ -700,7 +700,7 @@ def _run_typo_generation(
 ) -> dict[str, str]:
     """Generate, filter, and sort typos based on the provided settings."""
 
-    logging.info("Generating fake typos...")
+    logging.info("Generating likely typos...")
     typo_to_correct_word = defaultdict(list)
 
     for word in tqdm(word_list, desc="Processing words", disable=quiet):
@@ -733,7 +733,7 @@ def _run_typo_generation(
 
     total_typos_generated = len(typo_to_correct_word)
     logging.info(
-        "Generated %d unique fake typos before filtering.", total_typos_generated
+        "Generated %d unique likely typos before filtering.", total_typos_generated
     )
 
     filtered_typo_to_correct_word = {}
@@ -772,11 +772,11 @@ def _run_typo_generation(
 
 def main() -> None:
     """
-    Main function to generate fake typos and save them to a file based on YAML configuration.
+    Main function to generate likely typos and save them to a file based on YAML configuration.
     """
     # Parse command-line arguments
     parser = argparse.ArgumentParser(
-        description=f"{BOLD}Fake Typo Generator: Create lists of common typing mistakes.{RESET}",
+        description=f"{BOLD}Likely Typo Generator: Create lists of common typing mistakes.{RESET}",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=f"""{BLUE}Examples:{RESET}
   {GREEN}python gentypos.py "hello" "world"{RESET}
@@ -991,7 +991,7 @@ def main() -> None:
                 for typo in formatted_typos:
                     file.write(f"{typo}\n")
             logging.info(
-                "Successfully generated %d fake typos and saved to '%s'.",
+                "Successfully generated %d likely typos and saved to '%s'.",
                 len(formatted_typos),
                 output_target,
             )


### PR DESCRIPTION
Standardized "fake typos" to "likely typos" for professional clarity, corrected technical inaccuracies in API docstrings, and simplified terminology to follow Plain English guidelines.

---
*PR created automatically by Jules for task [16073082668298795702](https://jules.google.com/task/16073082668298795702) started by @RainRat*