### PR TITLE
[UI/UX] Improve `typostats.py` report clarity and consistency

### DIFF
--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -110,10 +110,9 @@ def test_generate_report_arrow(capsys):
     counts = {('s', 'z'): 3, ('e', 'a'): 1}
     typostats.generate_report(counts, min_occurrences=2, output_format='arrow', quiet=True)
     captured = capsys.readouterr().out
-    # 's' should be padded with 6 spaces (max_c=7)
-    # New format: padding(2) + 's' in 7 chars (6 spaces + s) = 8 spaces
-    # Followed by │ z and │ count '3' and │ percentage
-    assert '        s │ z    │     3 │  75.0% │ ███████' in captured
+    # Typo 'z' (width 4) -> '     z'
+    # Correct 's' (width 7) -> 's       '
+    assert '     z │ s       │     3 │  75.0% │ ███████████' in captured
     assert 'e' not in captured
 
 
@@ -121,8 +120,8 @@ def test_generate_report_limit(capsys):
     counts = {('a', 'b'): 10, ('c', 'd'): 5, ('e', 'f'): 2}
     typostats.generate_report(counts, limit=2, output_format='arrow', quiet=True)
     captured = capsys.readouterr().out
-    assert '        a │ b    │    10 │  58.8% │ █████' in captured
-    assert '        c │ d    │     5 │  29.4% │ ██' in captured
+    assert '     b │ a       │    10 │  58.8% │ ████████' in captured
+    assert '     d │ c       │     5 │  29.4% │ ████' in captured
     assert 'e' not in captured
 
 
@@ -133,9 +132,9 @@ def test_generate_report_limit_with_typo_sort(capsys):
     # Sorted by typo: ('b', 'x'), ('c', 'y'), ('a', 'z')
     typostats.generate_report(counts, limit=2, sort_by='typo', output_format='arrow', quiet=True)
     captured = capsys.readouterr().out
-    assert '        b │ x    │     5 │  29.4% │ ██' in captured
-    assert '        c │ y    │     2 │  11.8% │ █' in captured
-    assert 'a │ z' not in captured
+    assert '     x │ b       │     5 │  29.4% │ ████' in captured
+    assert '     y │ c       │     2 │  11.8% │ █' in captured
+    assert 'z │ a' not in captured
 
 
 def test_generate_report_json(capsys):
@@ -171,9 +170,9 @@ def test_generate_report_sort_by_typo(capsys):
     captured = capsys.readouterr()
     lines = [line for line in captured.out.splitlines() if line]
     # Header is now on stderr, so lines contains only data
-    assert '        a │ x    │     3 │  50.0% │ █████' in lines[0]
-    assert '        a │ y    │     2 │  33.3% │ ███' in lines[1]
-    assert '        b │ z    │     1 │  16.7% │ █' in lines[2]
+    assert '     x │ a       │     3 │  50.0% │ ███████' in lines[0]
+    assert '     y │ a       │     2 │  33.3% │ ████▉' in lines[1]
+    assert '     z │ b       │     1 │  16.7% │ ██▍' in lines[2]
     assert "LETTER REPLACEMENTS" in captured.err
 
 
@@ -183,9 +182,9 @@ def test_generate_report_sort_by_correct(capsys):
     captured = capsys.readouterr()
     lines = [line for line in captured.out.splitlines() if line]
     # Header is now on stderr, so lines contains only data
-    assert '        a │ y    │     2 │  33.3% │ ███' in lines[0]
-    assert '        b │ z    │     1 │  16.7% │ █' in lines[1]
-    assert '        c │ x    │     3 │  50.0% │ █████' in lines[2]
+    assert '     y │ a       │     2 │  33.3% │ ████▉' in lines[0]
+    assert '     z │ b       │     1 │  16.7% │ ██▍' in lines[1]
+    assert '     x │ c       │     3 │  50.0% │ ███████' in lines[2]
     assert "LETTER REPLACEMENTS" in captured.err
 
 

--- a/tests/test_typostats_new_markers.py
+++ b/tests/test_typostats_new_markers.py
@@ -23,6 +23,6 @@ def test_summary_labels(capsys):
     typostats.generate_report(counts, quiet=False)
     captured = capsys.readouterr().err
 
-    assert "Total word pairs encountered:" in captured
-    assert "Total patterns after analysis:" in captured
+    assert "Total patterns found:" in captured
+    assert "Total patterns kept:" in captured
     assert "Unique patterns found:" in captured

--- a/typostats.py
+++ b/typostats.py
@@ -86,6 +86,7 @@ def _format_analysis_summary(
     use_color: bool = False,
     extra_metrics: Mapping[str, Any] | None = None,
     title: str = "ANALYSIS SUMMARY",
+    total_input_items: int | None = None,
 ) -> List[str]:
     """
     Standardizes the "ANALYSIS SUMMARY" block with consistent colors and a visual retention bar.
@@ -105,13 +106,15 @@ def _format_analysis_summary(
     report.append(f"\n{padding}{c_bold}{c_blue}{title}{c_reset}")
     report.append(f"{padding}{c_bold}{c_blue}───────────────────────────────────────────────────────{c_reset}")
 
-    # In typostats, raw_count is the number of word pairs, but filtered_items are patterns.
+    if total_input_items is not None:
+        report.append(
+            f"  {c_bold}{c_blue}{'Total word pairs analyzed:':<{label_width}}{c_reset} {c_yellow}{total_input_items}{c_reset}"
+        )
+
+    # In typostats, raw_count is the total number of patterns found, but filtered_items are patterns kept.
     # We rename labels to be more descriptive of what they actually count.
-    raw_label = "Total word pairs encountered:"
-    filtered_label = "Total patterns after analysis:"
-    if item_label != "replacement":
-        raw_label = f"Total {item_label_plural} encountered:"
-        filtered_label = f"Total {item_label_plural} after filtering:"
+    raw_label = f"Total {item_label_plural} found:"
+    filtered_label = f"Total {item_label_plural} kept:"
 
     report.append(
         f"  {c_bold}{c_blue}{raw_label:<{label_width}}{c_reset} {c_yellow}{raw_count}{c_reset}"
@@ -148,7 +151,7 @@ def _format_analysis_summary(
     except (TypeError, ValueError):
         unique_count = len(filtered_items)
 
-    unique_label = "Unique patterns found:" if item_label == "replacement" else f"Unique {item_label_plural}:"
+    unique_label = "Unique patterns found:" if item_label in ("replacement", "pattern") else f"Unique {item_label_plural}:"
     report.append(
         f"  {c_bold}{c_blue}{unique_label:<{label_width}}{c_reset} {c_green}{unique_count}{c_reset}"
     )
@@ -593,14 +596,15 @@ def generate_report(
             extra_metrics["Showing patterns"] = f"{len(sorted_replacements)} of {unique_filtered}"
 
         # Generate a list of all replacements to use summary statistics
-        all_replacements = [k for k, v in replacement_counts.items() for _ in range(v)]
+        all_replacements = [k for k, v in filtered.items() for _ in range(v)]
         summary_lines = _format_analysis_summary(
-            total_pairs if total_pairs is not None else total_typos,
+            total_typos,
             all_replacements,
-            item_label="replacement",
+            item_label="pattern",
             use_color=show_color_err,
             extra_metrics=extra_metrics,
             start_time=start_time,
+            total_input_items=total_pairs,
         )
 
         # Calculate padding for alignment (default to header labels' lengths)
@@ -624,8 +628,8 @@ def generate_report(
         # Bold blue for table visual elements
         sep = f"{c_bold}{c_blue}│{c_reset}"
         header_row = (
-            f"{padding}{c_bold}{c_blue}{'CORRECT':>{max_c}}{c_reset} {sep} "
-            f"{c_bold}{c_blue}{'TYPO':<{max_t}}{c_reset} {sep} "
+            f"{padding}{c_bold}{c_blue}{'TYPO':>{max_t}}{c_reset} {sep} "
+            f"{c_bold}{c_blue}{'CORRECT':<{max_c}}{c_reset} {sep} "
             f"{c_bold}{c_blue}{'COUNT':>{max_n}}{c_reset} {sep} "
             f"{c_bold}{c_blue}{'%':>{max_p}}{c_reset}"
         )
@@ -635,8 +639,8 @@ def generate_report(
         show_attr = any([keyboard, kwargs.get('allow_transposition'), kwargs.get('allow_1to2'), kwargs.get('allow_2to1'), kwargs.get('include_deletions'), kwargs.get('all')])
 
         if show_attr:
-            header_row += f" {sep} {c_bold}{c_blue}{'ATTR':<4}{c_reset}"
-            visible_header_len += 7
+            header_row += f" {sep} {c_bold}{c_blue}{'ATTR':<5}{c_reset}"
+            visible_header_len += 8
 
         # Add Visual column header
         max_bar = 15
@@ -688,8 +692,8 @@ def generate_report(
                 bar += " " * (max_bar - full_blocks - 1)
 
             row = (
-                f"{padding}{c_green}{correct_char:>{max_c}}{c_reset} {sep} "
-                f"{c_red}{typo_char:<{max_t}}{c_reset} {sep} "
+                f"{padding}{c_red}{typo_char:>{max_t}}{c_reset} {sep} "
+                f"{c_green}{correct_char:<{max_c}}{c_reset} {sep} "
                 f"{c_yellow}{count:>{max_n}}{c_reset} {sep} "
                 f"{c_green}{percent:>5.1f}%{c_reset}"
             )
@@ -717,7 +721,7 @@ def generate_report(
                 marker = f"{c_bold}{marker_text:<5}{c_reset}"
                 row += f" {sep} {marker}"
 
-            row += f" {sep} {c_red}{bar}{c_reset}"
+            row += f" {sep} {c_blue}{bar}{c_reset}"
             report_lines.append(row)
         report_content = "\n".join(report_lines)
     elif output_format == 'json':


### PR DESCRIPTION
This improvement refines the `typostats.py` command-line report to align with project-wide UI/UX standards and improve information clarity.

### Changes:
1.  **Column Order Swap:** Changed the table layout from `CORRECT │ TYPO` to `TYPO │ CORRECT`. This follows the natural "mistake -> correction" flow and matches the `multitool.py` conventions.
2.  **Color Standardization:** Typos are now highlighted in **RED** and corrections in **GREEN**, following Git diff metaphors. The visual frequency bars were changed from red to **BLUE** to reduce visual fatigue and improve contrast.
3.  **Statistical Precision:**
    *   Added **"Total word pairs analyzed"** to the summary to provide context on input volume.
    *   Renamed vague summary labels (e.g., "encountered", "after analysis") to **"found"** and **"kept"**.
    *   Fixed a logic bug where **"Retention rate"** compared the number of patterns to the number of word pairs, leading to rates > 100%. It now correctly reflects the percentage of patterns kept after filtering.
4.  **Alignment Fixes:** Increased the `ATTR` column header width to ensure that 5-character markers like `[1:2]` or `[Del]` are properly aligned and do not overflow.
5.  **Test Updates:** Updated the comprehensive test suite (`tests/test_typostats.py`, etc.) to verify the new layout, color codes, and terminology.

---
*PR created automatically by Jules for task [14008971269505520109](https://jules.google.com/task/14008971269505520109) started by @RainRat*