### PR TITLE
[DOCS] Synchronize --min-length help text and documentation

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -301,7 +301,7 @@ These options work with most modes:
 - `[INPUT_FILES...]`: One or more files to read. Defaults to **standard input** if not provided.
 - `--output`: The file to write results to. Defaults to printing to the screen.
 - `--output-format`: The format of the output. Options include `line` (default), `json`, `yaml`, `csv`, `markdown`, `md-table`, `arrow`, and `table`.
-- `--min-length`: Skip words shorter than this length (default: 3).
+- `--min-length`: Skip items shorter than this length (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count').
 - `--max-length`: Skip words longer than this length (default: 1000).
 - `--process-output`: Sorts the final list and removes duplicates. Use this to organize your output or remove redundant entries.
 - `--limit`, `-L`: Limit the number of items in the output.

--- a/multitool.py
+++ b/multitool.py
@@ -4501,7 +4501,7 @@ def _add_common_mode_arguments(
         '-m', '--min-length',
         type=int,
         default=argparse.SUPPRESS,
-        help="Skip items shorter than this (default: 3).",
+        help="Skip items shorter than this (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count').",
     )
     proc_group.add_argument(
         '-M', '--max-length',


### PR DESCRIPTION
Synchronized the help text and documentation for the `--min-length` flag in `multitool.py` to accurately describe its context-sensitive defaults (1 for most modes, 3 for word extraction modes like 'words' and 'count'). This ensures users have correct information regardless of which mode they are using.

---
*PR created automatically by Jules for task [15933147299665712519](https://jules.google.com/task/15933147299665712519) started by @RainRat*