### PR TITLE
[UI/UX] Standardize `typostats.py` report table and improve visual hierarchy

### DIFF
--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -110,10 +110,8 @@ def test_generate_report_arrow(capsys):
     counts = {('s', 'z'): 3, ('e', 'a'): 1}
     typostats.generate_report(counts, min_occurrences=2, output_format='arrow', quiet=True)
     captured = capsys.readouterr().out
-    # 's' should be padded with 6 spaces (max_c=7)
-    # New format: padding(2) + 's' in 7 chars (6 spaces + s) = 8 spaces
-    # Followed by │ z and │ count '3' and │ percentage
-    assert '        s │ z    │     3 │  75.0% │ ███████' in captured
+    # TYPO (z) │ CORRECT (s)
+    assert '  z    │ s       │     3 │  75.0% │ ███████████' in captured
     assert 'e' not in captured
 
 
@@ -121,8 +119,9 @@ def test_generate_report_limit(capsys):
     counts = {('a', 'b'): 10, ('c', 'd'): 5, ('e', 'f'): 2}
     typostats.generate_report(counts, limit=2, output_format='arrow', quiet=True)
     captured = capsys.readouterr().out
-    assert '        a │ b    │    10 │  58.8% │ █████' in captured
-    assert '        c │ d    │     5 │  29.4% │ ██' in captured
+    # TYPO (b) │ CORRECT (a)
+    assert '  b    │ a       │    10 │  58.8% │ ████████' in captured
+    assert '  d    │ c       │     5 │  29.4% │ ████' in captured
     assert 'e' not in captured
 
 
@@ -133,9 +132,10 @@ def test_generate_report_limit_with_typo_sort(capsys):
     # Sorted by typo: ('b', 'x'), ('c', 'y'), ('a', 'z')
     typostats.generate_report(counts, limit=2, sort_by='typo', output_format='arrow', quiet=True)
     captured = capsys.readouterr().out
-    assert '        b │ x    │     5 │  29.4% │ ██' in captured
-    assert '        c │ y    │     2 │  11.8% │ █' in captured
-    assert 'a │ z' not in captured
+    # TYPO (x) │ CORRECT (b)
+    assert '  x    │ b       │     5 │  29.4% │ ████' in captured
+    assert '  y    │ c       │     2 │  11.8% │ █' in captured
+    assert 'z    │ a' not in captured
 
 
 def test_generate_report_json(capsys):
@@ -171,9 +171,10 @@ def test_generate_report_sort_by_typo(capsys):
     captured = capsys.readouterr()
     lines = [line for line in captured.out.splitlines() if line]
     # Header is now on stderr, so lines contains only data
-    assert '        a │ x    │     3 │  50.0% │ █████' in lines[0]
-    assert '        a │ y    │     2 │  33.3% │ ███' in lines[1]
-    assert '        b │ z    │     1 │  16.7% │ █' in lines[2]
+    # TYPO (x) │ CORRECT (a)
+    assert '  x    │ a       │     3 │  50.0% │ ███████' in lines[0]
+    assert '  y    │ a       │     2 │  33.3% │ ████' in lines[1]
+    assert '  z    │ b       │     1 │  16.7% │ ██' in lines[2]
     assert "LETTER REPLACEMENTS" in captured.err
 
 
@@ -183,9 +184,10 @@ def test_generate_report_sort_by_correct(capsys):
     captured = capsys.readouterr()
     lines = [line for line in captured.out.splitlines() if line]
     # Header is now on stderr, so lines contains only data
-    assert '        a │ y    │     2 │  33.3% │ ███' in lines[0]
-    assert '        b │ z    │     1 │  16.7% │ █' in lines[1]
-    assert '        c │ x    │     3 │  50.0% │ █████' in lines[2]
+    # TYPO (y) │ CORRECT (a)
+    assert '  y    │ a       │     2 │  33.3% │ ████' in lines[0]
+    assert '  z    │ b       │     1 │  16.7% │ ██' in lines[1]
+    assert '  x    │ c       │     3 │  50.0% │ ███████' in lines[2]
     assert "LETTER REPLACEMENTS" in captured.err
 
 

--- a/typostats.py
+++ b/typostats.py
@@ -624,19 +624,19 @@ def generate_report(
         # Bold blue for table visual elements
         sep = f"{c_bold}{c_blue}│{c_reset}"
         header_row = (
-            f"{padding}{c_bold}{c_blue}{'CORRECT':>{max_c}}{c_reset} {sep} "
-            f"{c_bold}{c_blue}{'TYPO':<{max_t}}{c_reset} {sep} "
+            f"{padding}{c_bold}{c_blue}{'TYPO':<{max_t}}{c_reset} {sep} "
+            f"{c_bold}{c_blue}{'CORRECT':<{max_c}}{c_reset} {sep} "
             f"{c_bold}{c_blue}{'COUNT':>{max_n}}{c_reset} {sep} "
             f"{c_bold}{c_blue}{'%':>{max_p}}{c_reset}"
         )
         # 3 chars for each " │ " (total 3 * 3 = 9)
-        visible_header_len = max_c + max_t + max_n + max_p + 9
+        visible_header_len = max_t + max_c + max_n + max_p + 9
 
         show_attr = any([keyboard, kwargs.get('allow_transposition'), kwargs.get('allow_1to2'), kwargs.get('allow_2to1'), kwargs.get('include_deletions'), kwargs.get('all')])
 
         if show_attr:
-            header_row += f" {sep} {c_bold}{c_blue}{'ATTR':<4}{c_reset}"
-            visible_header_len += 7
+            header_row += f" {sep} {c_bold}{c_blue}{'ATTR':<5}{c_reset}"
+            visible_header_len += 8
 
         # Add Visual column header
         max_bar = 15
@@ -688,8 +688,8 @@ def generate_report(
                 bar += " " * (max_bar - full_blocks - 1)
 
             row = (
-                f"{padding}{c_green}{correct_char:>{max_c}}{c_reset} {sep} "
-                f"{c_red}{typo_char:<{max_t}}{c_reset} {sep} "
+                f"{padding}{c_red}{typo_char:<{max_t}}{c_reset} {sep} "
+                f"{c_green}{correct_char:<{max_c}}{c_reset} {sep} "
                 f"{c_yellow}{count:>{max_n}}{c_reset} {sep} "
                 f"{c_green}{percent:>5.1f}%{c_reset}"
             )
@@ -717,7 +717,7 @@ def generate_report(
                 marker = f"{c_bold}{marker_text:<5}{c_reset}"
                 row += f" {sep} {marker}"
 
-            row += f" {sep} {c_red}{bar}{c_reset}"
+            row += f" {sep} {c_blue}{bar}{c_reset}"
             report_lines.append(row)
         report_content = "\n".join(report_lines)
     elif output_format == 'json':


### PR DESCRIPTION
### PR Title: [UI/UX] Standardize `typostats.py` report table and improve visual hierarchy

**Description:**
* **Context:** CLI
* **Problem:** The `typostats.py` report table used a "CORRECT | TYPO" column order, which contradicted the natural "mistake -> fix" mental model. Additionally, the columns had inconsistent alignment (right-aligned CORRECT, left-aligned TYPO), and the `ATTR` column header was too narrow (width 4) for its multi-character markers (width 5), leading to visual misalignment.
* **Solution:** 
    - Swapped the columns to follow the `TYPO │ CORRECT` order, aligning with `multitool.py` and providing a more intuitive logical flow.
    - Standardized both `TYPO` and `CORRECT` columns to be left-aligned, significantly improving scannability for tabular string data.
    - Increased the `ATTR` header width to 5 and updated the divider length calculation to ensure perfect table alignment.
    - Changed the visual bar color from Red to Blue to improve visual hierarchy and better distinguish the data visualization from the red-highlighted typos.
    - Updated the test suite in `tests/test_typostats.py` to reflect these formatting and alignment improvements.

**Changes:**
- Modified `typostats.py`:
    - Updated `header_row` construction in `generate_report`.
    - Updated `visible_header_len` calculation.
    - Updated `row` construction in the report loop.
    - Changed bar color to `c_blue`.
- Modified `tests/test_typostats.py`:
    - Updated assertions for `test_generate_report_arrow`, `test_generate_report_limit`, `test_generate_report_limit_with_typo_sort`, `test_generate_report_sort_by_typo`, and `test_generate_report_sort_by_correct`.

---
*PR created automatically by Jules for task [313543250720884783](https://jules.google.com/task/313543250720884783) started by @RainRat*