### PR TITLE
[DOCS] Standardize terminology and simplify jargon in Multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -99,7 +99,7 @@ These modes help you transform or combine your data.
   - **Example:** `python multitool.py unique raw_typos.txt`
 
 - **`resolve`**
-  - **What it does:** Finds and flattens chains of typo corrections. For example, if your mapping file contains `A -> B` and `B -> C`, this mode will resolve them to `A -> C` and `B -> C`. This ensures that your mappings always point directly to the final correct word, making them more efficient for scrubbing and analysis.
+  - **What it does:** Finds and shortens chains of typo corrections. For example, if your mapping file contains `A -> B` and `B -> C`, this mode will resolve them to `A -> C` and `B -> C`. This ensures that your mappings always point directly to the final correct word, making them more efficient for fixing typos and analysis.
   - **Example:** `python multitool.py resolve mappings.csv`
 
 - **`rename`**

--- a/multitool.py
+++ b/multitool.py
@@ -170,7 +170,7 @@ def get_adjacent_keys(include_diagonals: bool = True) -> dict[str, set[str]]:
 
 def classify_typo(typo: str, correction: str, adj_keys: dict[str, set[str]]) -> str:
     """
-    Categorizes a typo based on its relationship to the correction.
+    Groups a typo based on its relationship to the correction.
     Returns a code: [K] Keyboard, [T] Transposition, [D] Deletion, [I] Insertion, [R] Replacement, [M] Multiple letters.
     """
     if not typo or not correction or typo == correction:
@@ -1596,7 +1596,7 @@ def count_mode(
         min_length = 1
 
     if mapping:
-        # Audit mode: Count occurrences of mapped typos in input files
+        # Audit mode: Count matches of mapped typos in input files
         for input_file in input_files:
             words_gen = _extract_words_items(input_file, delimiter=delimiter, quiet=quiet, smart=smart)
             for word in words_gen:
@@ -1850,7 +1850,7 @@ def classify_mode(
     limit: int | None = None,
 ) -> None:
     """
-    Categorizes typo corrections based on their error type.
+    Groups typo corrections based on their error type.
     """
     start_time = time.perf_counter()
     raw_pairs = _extract_pairs(input_files, quiet=quiet)
@@ -3434,7 +3434,7 @@ def resolve_mode(
     limit: int | None = None,
 ) -> None:
     """
-    Finds and flattens chains of typo corrections. For example, if a list
+    Finds and shortens chains of typo corrections. For example, if a list
     contains A -> B and B -> C, this mode will update it to A -> C and B -> C.
     """
     start_time = time.perf_counter()
@@ -3987,7 +3987,7 @@ def scrub_mode(
             modified_lines = []
             file_replacements = 0
 
-            for line in tqdm(file_lines, desc=f"Scrubbing {input_file}", unit=" lines", disable=quiet):
+            for line in tqdm(file_lines, desc=f"Fixing typos in {input_file}", unit=" lines", disable=quiet):
                 modified_line, replacements = _scrub_line(
                     line, mapping, pattern, clean_items, smart_case
                 )
@@ -4045,13 +4045,13 @@ def scrub_mode(
                         out.write('\n')
 
             logging.info(
-                f"[Scrub Mode] Completed scrubbing {len(input_files)} file(s) using '{mapping_file}'. "
+                f"[Scrub Mode] Completed fixing typos in {len(input_files)} file(s) using '{mapping_file}'. "
                 f"Made {total_replacements} replacements. Output written to '{output_file}'. "
                 f"Processing time: {duration:.3f}s"
             )
         else:
             logging.info(
-                f"[Scrub Mode] Completed scrubbing {len(input_files)} file(s) using '{mapping_file}'. "
+                f"[Scrub Mode] Completed fixing typos in {len(input_files)} file(s) using '{mapping_file}'. "
                 f"Made {total_replacements} replacements. Diff report written to '{output_file}'. "
                 f"Processing time: {duration:.3f}s"
             )
@@ -4242,7 +4242,7 @@ def scan_mode(
     after_context: int = 0,
 ) -> None:
     """
-    Scans files for occurrences of words from a mapping file or extra pairs, providing context.
+    Scans files for matches of words from a mapping file or extra pairs, providing context.
     """
     start_time = time.perf_counter()
     # Load and merge mappings
@@ -4801,7 +4801,7 @@ MODE_DETAILS = {
     },
     "count": {
         "summary": "Counts how often items appear.",
-        "description": "Counts how often each word, pair, line, or character appears and sorts the list by frequency. Use -f arrow for a rich visual report with bar charts. Use --pairs to count word pairs, --lines to count raw lines, or --chars to count individual characters. You can also provide a mapping (via --mapping or --add) to count occurrences of specific typos across your files.",
+        "description": "Counts how often each word, pair, line, or character appears and sorts the list by frequency. Use -f arrow for a rich visual report with bar charts. Use --pairs to count word pairs, --lines to count raw lines, or --chars to count individual characters. You can also provide a mapping (via --mapping or --add) to count matches of specific typos across your files.",
         "example": "python multitool.py count . --lines --min-count 5 -f arrow",
         "flags": "[-s S] [-a K:V] [-d D] [-S] [-p] [-l] [-c]",
     },
@@ -4890,7 +4890,7 @@ MODE_DETAILS = {
         "flags": "[-p]",
     },
     "classify": {
-        "summary": "Categorizes typos by error type.",
+        "summary": "Groups typos by error type.",
         "description": "Labels typo pairs with error codes like [K] Keyboard, [T] Transposition, [D] Deletion, [I] Insertion, [R] Replacement, and [M] Multiple letters. Use --show-dist to include the number of character changes.",
         "example": "python multitool.py classify typos.txt --show-dist --output labeled.txt",
         "flags": "[--show-dist]",
@@ -4909,7 +4909,7 @@ MODE_DETAILS = {
     },
     "cycles": {
         "summary": "Finds loops in typo pairs.",
-        "description": "Detects cycles in your typo mappings (for example, 'A' maps to 'B' and 'B' maps back to 'A'). Repeated loops can cause issues during automated scrubbing and represent logic errors in your data.",
+        "description": "Detects cycles in your typo mappings (for example, 'A' maps to 'B' and 'B' maps back to 'A'). Repeated loops can cause issues when automatically fixing typos and represent logic errors in your data.",
         "example": "python multitool.py cycles typos.csv --output-format arrow",
         "flags": "",
     },
@@ -4963,13 +4963,13 @@ MODE_DETAILS = {
     },
     "highlight": {
         "summary": "Color-code words from a list.",
-        "description": "Searches for words from a mapping file or extra pairs provided via --add and highlights them with color in the output. Useful as a non-destructive preview before using 'scrub'. Supports the same smart word detection as the scrubbing tool.",
+        "description": "Searches for words from a mapping file or extra pairs provided via --add and highlights them with color in the output. Useful as a non-destructive preview before using 'scrub'. Supports the same smart word detection as the typo-fixing tool.",
         "example": "python multitool.py highlight input.txt --add teh:the",
         "flags": "MAPPING [FILES...] [-a K:V] [-S]",
     },
     "resolve": {
-        "summary": "Flatten typo correction chains.",
-        "description": "Finds and flattens chains of corrections (for example, 'A' -> 'B' and 'B' -> 'C' becomes 'A' -> 'C'). This ensures that your mapping files always point directly to the final correct word, which improves the efficiency of scrubbing and analysis.",
+        "summary": "Shorten typo correction chains.",
+        "description": "Finds and shortens chains of corrections (for example, 'A' -> 'B' and 'B' -> 'C' becomes 'A' -> 'C'). This ensures that your mapping files always point directly to the final correct word, which improves the efficiency of fixing typos and analysis.",
         "example": "python multitool.py resolve mappings.csv --output resolved.csv",
         "flags": "",
     },
@@ -5102,7 +5102,7 @@ class ModeHelpAction(argparse.Action):
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    # Build a categorized mode summary for the epilog
+    # Build a grouped mode summary for the epilog
     mode_summary = get_mode_summary_text()
 
     parser = argparse.ArgumentParser(
@@ -5415,12 +5415,12 @@ def _build_parser() -> argparse.ArgumentParser:
         '--min-count',
         type=int,
         default=1,
-        help="Minimum occurrence count to include an item in the output (default: 1).",
+        help="Minimum match count to include an item in the output (default: 1).",
     )
     count_options.add_argument(
         '--max-count',
         type=int,
-        help="Maximum occurrence count to include an item in the output.",
+        help="Maximum match count to include an item in the output.",
     )
     count_options.add_argument(
         '-d', '--delimiter',


### PR DESCRIPTION
Standardized terminology and simplified jargon in `multitool.py` and `docs/multitool.md`.

Technical jargon like "scrubbing," "flatten," and "categorize" was replaced with plain English alternatives ("fixing typos," "shorten," "group"). User-facing strings now use "match" instead of "occurrence" for better clarity. These changes ensure the tool is more accessible to a global audience while maintaining professional documentation standards. All tests passed after the changes.

---
*PR created automatically by Jules for task [15639677044729410952](https://jules.google.com/task/15639677044729410952) started by @RainRat*