### PR TITLE
[DOCS] Synchronize typostats report labels and ordering

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -56,13 +56,14 @@ When using the default **arrow** format, the report displays results in two sect
 ```text
   ANALYSIS SUMMARY
   ───────────────────────────────────────────────────────
-  Total word pairs encountered:       4
-  Total patterns after analysis:      4
+  Total word pairs analyzed:          4
+  Total patterns encountered:         4
+  Total patterns after filtering:     4
   Retention rate:                     100.0% ████████████████████
-  Unique patterns found:              3
+  Unique patterns:                    3
   Min/Max/Avg length:                 7 / 8 / 7.5
-  Shortest replacement:               'rn -> m' (length: 7)
-  Longest replacement:                'he -> eh' (length: 8)
+  Shortest pattern:                   'm -> rn' (length: 7)
+  Longest pattern:                    'eh -> he' (length: 8)
   Min/Max/Avg changes:                1 / 2 / 1.8
   Total lines processed:              4
   Enabled features:                   keyboard, transposition, 1-to-2, 2-to-1, deletions/insertions
@@ -73,33 +74,34 @@ When using the default **arrow** format, the report displays results in two sect
 
   LETTER REPLACEMENTS
   ───────────────────────────────────────────────────────
-  CORRECT │ TYPO │ COUNT │      % │ ATTR │ VISUAL
+  TYPO │ CORRECT │ COUNT │      % │ ATTR  │ VISUAL
   ───────────────────────────────────────────────────────
-       he │ eh   │     2 │  50.0% │ [T]   │ ███████▌
-       rn │ m    │     1 │  25.0% │ [2:1] │ ███▊
-        h │ he   │     1 │  25.0% │ [Ins] │ ███▊
+  eh   │ he      │     2 │  50.0% │ [T]   │ ███████▌
+  m    │ rn      │     1 │  25.0% │ [2:1] │ ███▊
+  he   │ h       │     1 │  25.0% │ [Ins] │ ███▊
 ```
 
 ### Analysis Summary
 The dashboard at the top gives you an overview of your typo history:
-- **Total word pairs encountered:** The number of typo-correction pairs found in the input.
-- **Total patterns after analysis:** The number of character-level replacements extracted.
+- **Total word pairs analyzed:** The number of typo-correction pairs found in the input.
+- **Total patterns encountered:** The total number of character-level replacements extracted.
+- **Total patterns after filtering:** The number of patterns that remain after applying filters (like `--min`).
 - **Retention rate:** A visual bar showing the percentage of items kept after filtering.
-- **Unique patterns found:** The number of distinct character-level mistakes found.
+- **Unique patterns:** The number of distinct character-level mistakes found.
 - **Min/Max/Avg length:** Statistics on the length of the extracted patterns.
 - **Min/Max/Avg changes:** Statistics on the number of character changes (edit distance) per typo.
 - **Enabled features:** Which analysis modes (like keyboard adjacency or transpositions) were active.
 
 ### Letter Replacements Table
 This section breaks down every mistake:
-- **CORRECT:** The character you intended to type.
 - **TYPO:** The mistake you actually made.
+- **CORRECT:** The character you intended to type.
 - **COUNT:** How many times this specific mistake happened.
 - **%:** What percentage of all found replacements this mistake represents.
 - **ATTR:** Special markers showing the type of mistake (for example, `[K]` for keyboard slip).
 - **VISUAL:** A high-resolution bar chart for quick comparison.
 
-For example, a row showing `he │ eh` means you swapped the letters `h` and `e`.
+For example, a row showing `eh │ he` means you swapped the letters `h` and `e`.
 
 ### Typo Attributes (ATTR)
 When you enable analysis features, the tool finds specific patterns in the **ATTR** column:

--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -124,7 +124,7 @@ def test_generate_report_formats(capsys, tmp_path):
     typostats.generate_report(counts, output_format='json')
     assert len(json.loads(capsys.readouterr().out)["replacements"]) == 2
     typostats.generate_report(counts, output_format='csv')
-    assert "correct_char,typo_char,count" in capsys.readouterr().out
+    assert "typo,correction,count" in capsys.readouterr().out
     typostats.generate_report(counts, output_format='yaml')
     assert "  s:" in capsys.readouterr().out
     out_file = tmp_path / "report.txt"
@@ -143,7 +143,7 @@ def test_generate_report_formats_extra():
     # CSV explicit
     with patch('sys.stdout', new=io.StringIO()) as out:
         typostats.generate_report(counts, output_format='csv')
-        assert "q,w,1" in out.getvalue()
+        assert "w,q,1" in out.getvalue()
 
     # Generic YAML fallback
     with patch('sys.stdout', new=io.StringIO()) as out:

--- a/typostats.py
+++ b/typostats.py
@@ -111,10 +111,9 @@ def _format_analysis_summary(
             f"  {c_bold}{c_blue}{'Total word pairs analyzed:':<{label_width}}{c_reset} {c_yellow}{total_input_items}{c_reset}"
         )
 
-    # In typostats, raw_count is the total number of patterns found, but filtered_items are patterns kept.
-    # We rename labels to be more descriptive of what they actually count.
-    raw_label = f"Total {item_label_plural} found:"
-    filtered_label = f"Total {item_label_plural} kept:"
+    # In typostats, raw_count is the total number of patterns encountered, but filtered_items are patterns after filtering.
+    raw_label = f"Total {item_label_plural} encountered:"
+    filtered_label = f"Total {item_label_plural} after filtering:"
 
     report.append(
         f"  {c_bold}{c_blue}{raw_label:<{label_width}}{c_reset} {c_yellow}{raw_count}{c_reset}"
@@ -151,7 +150,7 @@ def _format_analysis_summary(
     except (TypeError, ValueError):
         unique_count = len(filtered_items)
 
-    unique_label = "Unique patterns found:" if item_label in ("replacement", "pattern") else f"Unique {item_label_plural}:"
+    unique_label = "Unique patterns:" if item_label in ("replacement", "pattern") else f"Unique {item_label_plural}:"
     report.append(
         f"  {c_bold}{c_blue}{unique_label:<{label_width}}{c_reset} {c_green}{unique_count}{c_reset}"
     )
@@ -161,7 +160,7 @@ def _format_analysis_summary(
 
         def format_item(it: Any) -> str:
             if isinstance(it, tuple) and len(it) == 2:
-                return f"{it[0]} -> {it[1]}"
+                return f"{it[1]} -> {it[0]}"
             return str(it)
 
         try:
@@ -728,8 +727,8 @@ def generate_report(
         replacements = []
         for (correct_char, typo_char), count in sorted_replacements:
             item = {
-                "correct": correct_char,
                 "typo": typo_char,
+                "correct": correct_char,
                 "count": count,
             }
             if keyboard:
@@ -744,9 +743,9 @@ def generate_report(
     elif output_format == 'csv':
         output = io.StringIO()
         writer = csv.writer(output)
-        writer.writerow(['correct_char', 'typo_char', 'count'])
+        writer.writerow(['typo', 'correction', 'count'])
         for (correct_char, typo_char), count in sorted_replacements:
-            writer.writerow([correct_char, typo_char, count])
+            writer.writerow([typo_char, correct_char, count])
         report_content = output.getvalue()
     else:
         # YAML-like


### PR DESCRIPTION
Synchronized `typostats.py` analysis labels and column ordering with the rest of the diff2typo suite. Updated documentation in `docs/typostats.md` to reflect these changes accurately, ensuring "Truth First" compliance. All 33 unit tests for typostats now pass with the new standardized output formats.

---
*PR created automatically by Jules for task [16089036386425093990](https://jules.google.com/task/16089036386425093990) started by @RainRat*