### PR TITLE
Fix min-length defaults and redundancy in multitool count mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -1610,10 +1610,6 @@ def count_mode(
         mapping = _resolve_full_mapping(mapping_file, ad_hoc, clean_items, quiet=quiet)
         pairs = True  # Automatically enable pairs for mapping audit
 
-    if chars and min_length == 3:
-        # Adjust default min_length for character counting
-        min_length = 1
-
     if mapping:
         # Audit mode: Count matches of mapped typos in input files
         for input_file in input_files:
@@ -6374,8 +6370,8 @@ def main() -> None:
         if args.mode in ('words', 'ngrams', 'stats'):
             args.min_length = 3
         elif args.mode == 'count':
-            # Count mode uses 3 for word extraction, but 1 for auditing or character counting
-            if any([getattr(args, 'pairs', False), getattr(args, 'chars', False),
+            # Count mode uses 3 for word extraction, but 1 for auditing, lines, or character counting
+            if any([getattr(args, 'pairs', False), getattr(args, 'chars', False), getattr(args, 'lines', False),
                     getattr(args, 'mapping', None), getattr(args, 'ad_hoc', None)]):
                 args.min_length = 1
             else:

--- a/tests/test_multitool_count_min_length.py
+++ b/tests/test_multitool_count_min_length.py
@@ -47,6 +47,16 @@ def test_min_length_defaults_in_count_mode(tmp_path, monkeypatch):
         _, kwargs = mock_count.call_args
         assert kwargs["min_length"] == 1
 
+    # 3b. With --lines should be 1
+    with patch("sys.argv", ["multitool.py", "count", str(dummy_input), "--lines"]), \
+         patch("multitool.count_mode") as mock_count:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_count.call_args
+        assert kwargs["min_length"] == 1
+
     # 4. With --add (ad_hoc) should be 1
     with patch("sys.argv", ["multitool.py", "count", str(dummy_input), "--add", "a:b"]), \
          patch("multitool.count_mode") as mock_count:
@@ -117,3 +127,13 @@ def test_min_length_defaults_in_count_mode(tmp_path, monkeypatch):
             pass
         _, kwargs = mock_count.call_args
         assert kwargs["min_length"] == 5
+
+    # 11. Explicit min_length for --chars should be preserved (NOT overridden by 1)
+    with patch("sys.argv", ["multitool.py", "count", str(dummy_input), "--chars", "--min-length", "3"]), \
+         patch("multitool.count_mode") as mock_count:
+        try:
+            multitool.main()
+        except SystemExit:
+            pass
+        _, kwargs = mock_count.call_args
+        assert kwargs["min_length"] == 3


### PR DESCRIPTION
This PR fixes inconsistent and redundant logic regarding default values for the `--min-length` parameter in `count` mode within `multitool.py`.

### Changes:
- **Centralized Defaults:** Added the `--lines` flag to the list of conditions in `main()` that trigger a default `min_length` of 1. This ensures consistency with other item-based counting modes like `--chars` and `--pairs`.
- **Bug Fix:** Removed a hardcoded `min_length = 1` override inside `count_mode()`. This legacy block previously forced the minimum length to 1 whenever `--chars` was used and the value was 3 (the old default). This prevented users from explicitly setting a higher minimum length for character counts (e.g., `-m 3`).
- **Test Coverage:** Updated `tests/test_multitool_count_min_length.py` with new test cases to verify the `--lines` default and ensure that explicit user-provided minimum lengths are no longer overridden.

These changes improve the tool's reliability and respect for user configuration while simplifying the internal logic. No breaking changes were introduced to existing documented behavior.

---
*PR created automatically by Jules for task [13095712744280243196](https://jules.google.com/task/13095712744280243196) started by @RainRat*