### PR TITLE
[UI/UX] Enhance search and scan output scannability with distinct prefix colors

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2989,15 +2989,19 @@ def _format_search_line(
         return line_content
 
     if use_color:
-        style = (BOLD + BLUE) if is_match else BLUE
+        style = BOLD if is_match else ""
+        c_sep = style + CYAN
         parts = []
         if show_filename:
-            parts.append(filename)
+            parts.append(f"{style}{MAGENTA}{filename}{RESET}")
         if line_numbers:
-            parts.append(str(line_idx + 1))
-        
-        prefix = sep_char.join(parts) + sep_char
-        return f"{style}{prefix}{RESET} {line_content}"
+            parts.append(f"{style}{GREEN}{line_idx + 1}{RESET}")
+
+        if not parts:
+            return line_content
+
+        prefix = f"{c_sep}{sep_char}{RESET}".join(parts) + f"{c_sep}{sep_char}{RESET}"
+        return f"{prefix} {line_content}"
     else:
         prefix_parts = []
         if show_filename:
@@ -3030,7 +3034,7 @@ def _render_context_to_lines(
 
         # If there's a gap between blocks, add separator
         if last_rendered_idx != -1 and start > last_rendered_idx:
-            separator = f"{BLUE}--{RESET}" if use_color else "--"
+            separator = f"{BOLD}{BLUE}--{RESET}" if use_color else "--"
             accumulated_lines.append(separator)
 
         # Render lines in the window that haven't been rendered yet

--- a/tests/test_multitool_extra_pairs.py
+++ b/tests/test_multitool_extra_pairs.py
@@ -70,6 +70,9 @@ def test_scan_extra(tmp_path, monkeypatch):
     monkeypatch.setattr(multitool, "RESET", "[R]")
     monkeypatch.setattr(multitool, "BOLD", "[B]")
     monkeypatch.setattr(multitool, "BLUE", "[C]")
+    monkeypatch.setattr(multitool, "CYAN", "[Cy]")
+    monkeypatch.setattr(multitool, "GREEN", "[G]")
+    monkeypatch.setattr(multitool, "MAGENTA", "[M]")
     monkeypatch.setenv("FORCE_COLOR", "1")
 
     # Scan with line numbers and extra
@@ -85,7 +88,8 @@ def test_scan_extra(tmp_path, monkeypatch):
 
     # Output should include line number and highlighted match
     # Since only 1 file, filename might not be shown by default unless forced or multiple files
-    assert "[B][C]1:[R] [B][Y]teh[R] cat" in captured_output.getvalue()
+    # The new format for line 1 match is: [B][G]1[R][B][Cy]:[R] [B][Y]teh[R] cat
+    assert "[B][G]1[R][B][Cy]:[R] [B][Y]teh[R] cat" in captured_output.getvalue()
 
 def test_map_file_and_extra(tmp_path):
     mapping_file = tmp_path / "map.csv"


### PR DESCRIPTION
**PR Title:** [UI/UX] Enhance search and scan output scannability with distinct prefix colors 
 
**Description:** 
* **Context:** CLI 
* **Problem:** Search and scan results used a uniform blue color for all metadata (filename, line number, separator). This lack of visual hierarchy made it difficult for users to quickly scan and distinguish between different parts of the output, especially when dealing with large results or context lines. 
* **Solution:** Introduced a multi-color prefix scheme for search and scan outputs. Filenames are now displayed in `MAGENTA`, line numbers in `GREEN`, and separators (`:` for matches, `-` for context) in `CYAN`. Additionally, match lines are now `BOLD` to clearly distinguish them from surrounding context lines. The context block separator (`--`) was also updated to `BOLD + BLUE` for better visual grouping. This improvement enhances information density and readability, allowing power users to parse results faster. 
 
**Changes:** 
`multitool.py` and `tests/test_multitool_extra_pairs.py` were modified.

---
*PR created automatically by Jules for task [9981515683433915738](https://jules.google.com/task/9981515683433915738) started by @RainRat*