### PR TITLE
Fix logic bug in typostats.py deletions detection

### DIFF
--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -438,3 +438,56 @@ def test_get_adjacent_keys_no_diagonals():
     assert 'w' in adj['q']
     assert 'a' in adj['q']
     assert 's' not in adj['q']
+
+
+def test_is_one_letter_replacement_logic_fix():
+    # Test that include_deletions=True works independently of allow_1to2/allow_2to1
+    # Deletion: 'receive' -> 'receve' (actually multiple potential deletions, but let's test one)
+    # is_one_letter_replacement returns a list of potential replacements
+
+    # 1. Deletion case (typo is shorter)
+    # 'a' in 'aa' -> deletion of 'a'
+    res = typostats.is_one_letter_replacement('a', 'aa', include_deletions=True)
+    assert ('aa', 'a') in res
+
+    res = typostats.is_one_letter_replacement('a', 'aa', include_deletions=False)
+    assert ('aa', 'a') not in res
+
+    # 2. Insertion case (typo is longer)
+    # 'a' in 'aa' -> insertion of 'a'
+    res = typostats.is_one_letter_replacement('aa', 'a', include_deletions=True)
+    assert ('a', 'aa') in res
+
+    res = typostats.is_one_letter_replacement('aa', 'a', include_deletions=False)
+    assert ('a', 'aa') not in res
+
+    # 3. 1-to-2 replacement (not an insertion)
+    res = typostats.is_one_letter_replacement('rn', 'm', allow_1to2=True)
+    assert ('m', 'rn') in res
+
+    res = typostats.is_one_letter_replacement('rn', 'm', allow_1to2=False)
+    assert ('m', 'rn') not in res
+
+    # 4. 2-to-1 replacement (not a deletion)
+    res = typostats.is_one_letter_replacement('f', 'ph', allow_2to1=True)
+    assert ('ph', 'f') in res
+
+    res = typostats.is_one_letter_replacement('f', 'ph', allow_2to1=False)
+    assert ('ph', 'f') not in res
+
+def test_process_typos_logic_fix():
+    # Test process_typos with the new logic
+    pairs = [("receve", "receive")]
+    counts, _ = typostats.process_typos(pairs, include_deletions=True)
+    assert ('ei', 'e') in counts
+    assert ('iv', 'v') in counts
+
+    counts, _ = typostats.process_typos(pairs, include_deletions=False)
+    assert not counts
+
+    pairs = [("aa", "a")]
+    counts, _ = typostats.process_typos(pairs, include_deletions=True)
+    assert ('a', 'aa') in counts
+
+    counts, _ = typostats.process_typos(pairs, include_deletions=False)
+    assert not counts

--- a/typostats.py
+++ b/typostats.py
@@ -533,7 +533,7 @@ def is_one_letter_replacement(
         return differences if len(differences) == 1 else []
 
     # One-to-two replacement scenario allowed only if difference in length is 1
-    if allow_1to2 and len(typo) == len(correction) + 1:
+    if (allow_1to2 or include_deletions) and len(typo) == len(correction) + 1:
         # Find all positions i where correction[i] is replaced by typo[i:i+2].
         # We use a set to avoid counting identical interpretations (for example for doubled letters) multiple times.
         replacements = set()
@@ -545,17 +545,19 @@ def is_one_letter_replacement(
                 repl_correction = correction[i]
                 repl_typo = typo[i:i+2]
 
-                # Filter out insertions unless requested
-                if not include_deletions:
-                    # It's an insertion if the correction character is one of the two typo characters
-                    if repl_correction in repl_typo:
+                is_insertion = repl_correction in repl_typo
+                if is_insertion:
+                    if not include_deletions:
+                        continue
+                else:  # It's a 1-to-2 replacement
+                    if not allow_1to2:
                         continue
 
                 replacements.add((repl_correction, repl_typo))
         return sorted(replacements)
 
     # Two-to-one replacement scenario (for example 'ph' -> 'f')
-    if allow_2to1 and len(typo) == len(correction) - 1:
+    if (allow_2to1 or include_deletions) and len(typo) == len(correction) - 1:
         replacements = set()
         for i in range(len(typo)):
             # To be a replacement of correction[i:i+2] with typo[i],
@@ -565,10 +567,12 @@ def is_one_letter_replacement(
                 repl_correction = correction[i:i+2]
                 repl_typo = typo[i]
 
-                # Filter out deletions unless requested
-                if not include_deletions:
-                    # It's a deletion if the typo character is one of the two correction characters
-                    if repl_typo in repl_correction:
+                is_deletion = repl_typo in repl_correction
+                if is_deletion:
+                    if not include_deletions:
+                        continue
+                else:  # It's a 2-to-1 replacement
+                    if not allow_2to1:
                         continue
 
                 replacements.add((repl_correction, repl_typo))


### PR DESCRIPTION
* **What:** Fixed a logic bug in `is_one_letter_replacement` within `typostats.py` that coupled the `include_deletions` flag with `allow_1to2` and `allow_2to1` flags. Added corresponding unit tests.
* **Why:** This ensures that users can track simple insertions and deletions (e.g., 'a' -> 'aa') even when phonetic replacements are not being analyzed. It improves the accuracy and usability of the tool's statistics. No breaking changes were introduced.

---
*PR created automatically by Jules for task [15799763463377561169](https://jules.google.com/task/15799763463377561169) started by @RainRat*