### PR TITLE
[DOCS] Standardize report terminology to 'analyzed'

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -57,7 +57,7 @@ When using the default **arrow** format, the report displays results in two sect
   ANALYSIS SUMMARY
   ───────────────────────────────────────────────────────
   Total word pairs analyzed:          4
-  Total patterns encountered:         4
+  Total patterns analyzed:            4
   Total patterns after filtering:     4
   Retention rate:                     100.0% ████████████████████
   Unique patterns:                    3
@@ -84,7 +84,7 @@ When using the default **arrow** format, the report displays results in two sect
 ### Analysis Summary
 The dashboard at the top gives you an overview of your typo history:
 - **Total word pairs analyzed:** The number of typo-correction pairs found in the input.
-- **Total patterns encountered:** The total number of character-level replacements extracted.
+- **Total patterns analyzed:** The total number of character-level replacements extracted.
 - **Total patterns after filtering:** The number of patterns that remain after applying filters (like `--min`).
 - **Retention rate:** A visual bar showing the percentage of items kept after filtering.
 - **Unique patterns:** The number of distinct character-level mistakes found.

--- a/multitool.py
+++ b/multitool.py
@@ -413,7 +413,7 @@ def _format_analysis_summary(
     report.append(f"{padding}{c_bold}{c_blue}───────────────────────────────────────────────────────{c_reset}")
 
     report.append(
-        f"  {c_bold}{c_blue}{'Total ' + item_label_plural + ' encountered:':<{label_width}}{c_reset} {c_yellow}{raw_count}{c_reset}"
+        f"  {c_bold}{c_blue}{'Total ' + item_label_plural + ' analyzed:':<{label_width}}{c_reset} {c_yellow}{raw_count}{c_reset}"
     )
 
     filtered_count = len(filtered_items)
@@ -1992,7 +1992,7 @@ def stats_mode(
 
     stats = {
         "items": {
-            "total_encountered": raw_item_count,
+            "total_analyzed": raw_item_count,
             "total_filtered": len(filtered_items),
             "unique_count": unique_count,
         }
@@ -2076,7 +2076,7 @@ def stats_mode(
             f.write("### ANALYSIS SUMMARY\n\n")
             f.write("| Metric | Value |\n")
             f.write("| :--- | :--- |\n")
-            f.write(f"| Total items encountered | {stats['items']['total_encountered']} |\n")
+            f.write(f"| Total items analyzed | {stats['items']['total_analyzed']} |\n")
             f.write(f"| Total items after filtering | {stats['items']['total_filtered']} |\n")
             f.write(f"| Unique items | {stats['items']['unique_count']} |\n")
             if "min_length" in stats["items"]:
@@ -2105,7 +2105,7 @@ def stats_mode(
 
             # In stats_mode, filtered_items is the primary list of items collected
             report = _format_analysis_summary(
-                stats['items']['total_encountered'],
+                stats['items']['total_analyzed'],
                 filtered_items,
                 "item",
                 start_time,
@@ -3519,7 +3519,7 @@ def resolve_mode(
             continue
 
         if min_length <= len(left) <= max_length and min_length <= len(right) <= max_length:
-            # We take the first mapping encountered for each typo if there are conflicts.
+            # We take the first mapping analyzed for each typo if there are conflicts.
             # Using dict.setdefault ensures the first entry wins.
             mapping.setdefault(left, right)
 

--- a/tests/test_multitool_count_enhanced_visual.py
+++ b/tests/test_multitool_count_enhanced_visual.py
@@ -48,7 +48,7 @@ def test_count_mode_visual_report_content(tmp_path, monkeypatch):
     content = output_file.read_text()
 
     assert "ANALYSIS SUMMARY" in content
-    assert "Total words encountered" in content
+    assert "Total words analyzed" in content
     assert "Retention rate" in content
     assert "Word" in content
     assert "Count" in content

--- a/tests/test_multitool_count_lines_chars.py
+++ b/tests/test_multitool_count_lines_chars.py
@@ -34,7 +34,7 @@ def test_count_mode_lines(tmp_path):
     content = output_file.read_text()
     assert "Line" in content # Header
     assert "line one" in content
-    assert "Total lines encountered" in content
+    assert "Total lines analyzed" in content
 
     # Test non-arrow format for item_label
     output_file_2 = tmp_path / "output2.txt"
@@ -74,7 +74,7 @@ def test_count_mode_chars(tmp_path):
     content = output_file.read_text()
     assert "Character" in content # Header
     assert "a" in content
-    assert "Total characters encountered" in content
+    assert "Total characters analyzed" in content
 
     # Test non-arrow format for item_label
     output_file_2 = tmp_path / "output2.txt"

--- a/tests/test_multitool_repeated.py
+++ b/tests/test_multitool_repeated.py
@@ -145,7 +145,7 @@ def test_repeated_mode_stats_output(tmp_path, caplog):
         multitool.repeated_mode([str(f)], str(out), 1, 100, False)
 
     assert "ANALYSIS SUMMARY" in caplog.text
-    assert "Total repeated-words encountered:   2" in caplog.text
+    assert "Total repeated-words analyzed:      2" in caplog.text
 
 def test_extract_repeated_items_stdin(reset_stdin_cache):
     input_text = "the the quick quick"

--- a/tests/test_multitool_stats.py
+++ b/tests/test_multitool_stats.py
@@ -29,7 +29,7 @@ def test_stats_mode_items_json(tmp_path):
     with open(out) as j:
         stats = json.load(j)
 
-    assert stats["items"]["total_encountered"] == 4
+    assert stats["items"]["total_analyzed"] == 4
     assert stats["items"]["total_filtered"] == 4
     assert stats["items"]["unique_count"] == 3
     assert stats["items"]["min_length"] == 5
@@ -63,7 +63,7 @@ def test_stats_mode_yaml(tmp_path):
     # Test with yaml module if available
     multitool.stats_mode([str(f)], str(out), min_length=1, max_length=100, process_output=False, output_format='yaml')
     content = out.read_text()
-    assert "total_encountered: 1" in content
+    assert "total_analyzed: 1" in content
 
 def test_stats_mode_yaml_no_module(tmp_path, monkeypatch):
     # Mock ImportError for yaml
@@ -83,7 +83,7 @@ def test_stats_mode_yaml_no_module(tmp_path, monkeypatch):
     multitool.stats_mode([str(f)], str(out), min_length=1, max_length=100, process_output=False, include_pairs=True, output_format='yaml')
     content = out.read_text()
     assert "items:" in content
-    assert "total_encountered: 1" in content
+    assert "total_analyzed: 1" in content
     assert "pairs:" in content
 
 def test_stats_mode_markdown(tmp_path):
@@ -95,7 +95,7 @@ def test_stats_mode_markdown(tmp_path):
     content = out.read_text()
     assert "### ANALYSIS SUMMARY" in content
     assert "### PAIRED DATA STATISTICS" in content
-    assert "| Total items encountered | 1 |" in content
+    assert "| Total items analyzed | 1 |" in content
 
 def test_stats_mode_human_readable(tmp_path):
     f = tmp_path / "input.txt"
@@ -147,7 +147,7 @@ def test_stats_mode_empty_input(tmp_path):
 
     with open(out) as j:
         stats = json.load(j)
-    assert stats["items"]["total_encountered"] == 0
+    assert stats["items"]["total_analyzed"] == 0
     assert "min_length" not in stats["items"]
 
 def test_stats_mode_filtering(tmp_path):
@@ -160,7 +160,7 @@ def test_stats_mode_filtering(tmp_path):
 
     with open(out) as j:
         stats = json.load(j)
-    assert stats["items"]["total_encountered"] == 3
+    assert stats["items"]["total_analyzed"] == 3
     assert stats["items"]["total_filtered"] == 1
     assert stats["items"]["unique_count"] == 1
 

--- a/tests/test_multitool_stdin.py
+++ b/tests/test_multitool_stdin.py
@@ -79,5 +79,5 @@ def test_stdin_multi_pass(monkeypatch, capsys):
     # but item count and pairs count should be in the report.
     # Actually multitool.stats_mode writes the report to output_file, which defaults to '-' (stdout)
 
-    assert "Total items encountered:            3" in captured.out
-    assert "Total pairs encountered:            1" in captured.out
+    assert "Total items analyzed:               3" in captured.out
+    assert "Total pairs analyzed:               1" in captured.out

--- a/typostats.py
+++ b/typostats.py
@@ -120,8 +120,8 @@ def _format_analysis_summary(
             f"  {c_bold}{c_blue}{'Total word pairs analyzed:':<{label_width}}{c_reset} {c_yellow}{total_input_items}{c_reset}"
         )
 
-    # In typostats, raw_count is the total number of patterns encountered, but filtered_items are patterns after filtering.
-    raw_label = f"Total {item_label_plural} encountered:"
+    # In typostats, raw_count is the total number of patterns analyzed, but filtered_items are patterns after filtering.
+    raw_label = f"Total {item_label_plural} analyzed:"
     filtered_label = f"Total {item_label_plural} after filtering:"
 
     report.append(


### PR DESCRIPTION
Standardized the terminology in reports and documentation by replacing "encountered" with "analyzed" for better clarity and professionalism. This involved updating labels in `multitool.py` and `typostats.py`, renaming internal data keys in stats mode, updating the documentation in `docs/typostats.md`, and adjusting the corresponding assertions in the test suite. All tests passed after the changes.

---
*PR created automatically by Jules for task [6211789891059715440](https://jules.google.com/task/6211789891059715440) started by @RainRat*