### PR TITLE
[FEAT] Add `align` mode to `multitool.py` for pretty-printing paired data

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -102,6 +102,11 @@ These modes help you transform or combine your data.
   - **What it does:** Finds and shortens chains of typo corrections. For example, if your mapping file contains `A -> B` and `B -> C`, this mode will resolve them to `A -> C` and `B -> C`. This ensures that your mappings always point directly to the final correct word, making them more efficient for fixing typos and analysis.
   - **Example:** `python multitool.py resolve mappings.csv`
 
+- **`align`**
+  - **What it does:** Extracts typo-correction pairs from any supported format (CSV, Arrow, Markdown lists/tables, JSON, YAML) and outputs them in perfectly aligned columns by automatically calculating the maximum width of the left column. This is the recommended way to "beautify" your typo lists for human readability.
+  - **Options:** Use the `--sep` flag to customize the separator string between columns (default is ` -> `).
+  - **Example:** `python multitool.py align typos.csv --sep ' | '`
+
 - **`rename`**
   - **What it does:** Changes file and folder names using a mapping file or extra pairs. It is useful for fixing typos in filenames across your entire project. It handles nested renames by processing files before their parent folders.
   - **Options:**

--- a/multitool.py
+++ b/multitool.py
@@ -733,6 +733,7 @@ def _write_paired_output(
     mode_label: str,
     quiet: bool = False,
     limit: int | None = None,
+    separator: str = " -> ",
 ) -> None:
     """
     Writes a collection of paired strings to the output file in the specified format.
@@ -740,10 +741,11 @@ def _write_paired_output(
     Args:
         pairs: Collection of (left, right) tuples.
         output_file: Path to the output file or '-' for the main output.
-        output_format: Format (arrow, table, csv, markdown, md-table, json, yaml).
+        output_format: Format (arrow, table, csv, markdown, md-table, json, yaml, aligned).
         mode_label: Label for the current mode (used for headers).
         quiet: If True, suppress informational output.
         limit: If provided, limit the output to the first N pairs.
+        separator: The separator to use for 'aligned' format.
     """
     pairs_list = list(pairs)
     if limit is not None:
@@ -807,6 +809,12 @@ def _write_paired_output(
                 out_file.write("| :--- | :--- |\n")
                 for left, right in pairs_list:
                     out_file.write(f"| {left} | {right} |\n")
+        elif output_format == 'aligned':
+            if pairs_list:
+                # Calculate the maximum width of the left column for alignment
+                max_left = max((len(str(left)) for left, _ in pairs_list), default=0)
+                for left, right in pairs_list:
+                    out_file.write(f"{left:<{max_left}}{separator}{right}\n")
         elif output_format == 'arrow':
             if pairs_list:
                 # Dynamic column width calculation for aligned table
@@ -3438,6 +3446,58 @@ def pairs_mode(
     )
 
 
+def align_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    separator: str = " -> ",
+    output_format: str = 'aligned',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Extracts pairs from any supported format and outputs them in aligned columns."""
+    start_time = time.perf_counter()
+
+    raw_pairs = _extract_pairs(input_files, quiet=quiet)
+
+    filtered_pairs = []
+    raw_count = 0
+    for left, right in raw_pairs:
+        raw_count += 1
+        # Clean if requested
+        if clean_items:
+            left = filter_to_letters(left)
+            right = filter_to_letters(right)
+
+        # Skip if either side is empty after cleaning
+        if not left or not right:
+            continue
+
+        # Apply length filtering to both sides to ensure valid data pairs
+        if min_length <= len(left) <= max_length and min_length <= len(right) <= max_length:
+            filtered_pairs.append((left, right))
+
+    if process_output:
+        filtered_pairs = sorted(set(filtered_pairs))
+
+    _write_paired_output(
+        filtered_pairs,
+        output_file,
+        output_format,
+        "Align",
+        quiet,
+        limit=limit,
+        separator=separator
+    )
+
+    print_processing_stats(
+        raw_count, filtered_pairs, item_label="pair", start_time=start_time
+    )
+
+
 def swap_mode(
     input_files: Sequence[str],
     output_file: str,
@@ -5032,6 +5092,12 @@ MODE_DETAILS = {
         "example": "python multitool.py scrub input.txt --add teh:the --diff",
         "flags": "MAPPING [FILES...] [-a K:V] [--diff]",
     },
+    "align": {
+        "summary": "Aligns typo-correction pairs.",
+        "description": "Extracts typo-correction pairs from any supported format (CSV, arrow, Markdown lists/tables) and outputs them in perfectly aligned columns by automatically calculating the maximum width of the left column. It supports a custom separator string via the --sep flag.",
+        "example": "python multitool.py align typos.csv --sep ' -> ' --output-format aligned",
+        "flags": "[--sep S]",
+    },
     "rename": {
         "summary": "Batch rename files and folders.",
         "description": "Renames files or directories based on a typo mapping or extra pairs provided via --add. It preserves the directory structure and can automatically handle CamelCase or snake_case names using --smart-case. It handles nested renames by processing files before their parent directories.",
@@ -5063,7 +5129,7 @@ def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
         "GETTING DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "line", "words", "ngrams", "regex"],
-        "CHANGING DATA": ["combine", "unique", "diff", "highlight", "resolve", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
+        "CHANGING DATA": ["combine", "unique", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECKING DATA": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
 
@@ -6324,6 +6390,22 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_common_mode_arguments(resolve_parser)
 
+    align_parser = subparsers.add_parser(
+        'align',
+        help=MODE_DETAILS['align']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['align']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['align']['example']}{RESET}",
+    )
+    align_options = align_parser.add_argument_group(f"{BLUE}ALIGN OPTIONS{RESET}")
+    align_options.add_argument(
+        '--sep',
+        type=str,
+        default=" -> ",
+        help="The separator string to use between aligned columns (default: ' -> ').",
+    )
+    _add_common_mode_arguments(align_parser)
+
 
     return parser
 
@@ -6534,6 +6616,14 @@ def main() -> None:
     }
 
     handler_map = {
+        'align': (
+            align_mode,
+            {
+                **common_kwargs,
+                'separator': getattr(args, 'sep', " -> "),
+                'output_format': output_format if output_format != 'line' else 'aligned',
+            },
+        ),
         'arrow': (
             arrow_mode,
             {

--- a/tests/test_multitool_align.py
+++ b/tests/test_multitool_align.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+import pytest
+
+def test_align_mode_default_separator(tmp_path):
+    """Verify align mode with default separator."""
+    input_file = tmp_path / "typos.csv"
+    input_file.write_text("teh,the\nabcde,abc\n", encoding="utf-8")
+
+    # Run align mode
+    result = subprocess.run(
+        ["python3", "multitool.py", "align", str(input_file)],
+        capture_output=True,
+        text=True
+    )
+
+    # Expected output (aligned)
+    # teh   -> the
+    # abcde -> abc
+    # Max length of left column is 5 ('abcde')
+    expected = "teh   -> the\nabcde -> abc\n"
+    assert result.stdout == expected
+
+def test_align_mode_custom_separator(tmp_path):
+    """Verify align mode with custom separator."""
+    input_file = tmp_path / "typos.csv"
+    input_file.write_text("teh,the\nabcde,abc\n", encoding="utf-8")
+
+    # Run align mode with custom separator
+    result = subprocess.run(
+        ["python3", "multitool.py", "align", str(input_file), "--sep", " | "],
+        capture_output=True,
+        text=True
+    )
+
+    # Expected output (aligned with custom separator)
+    expected = "teh   | the\nabcde | abc\n"
+    assert result.stdout == expected
+
+def test_align_mode_with_cleaning(tmp_path):
+    """Verify align mode with default cleaning (filter_to_letters)."""
+    input_file = tmp_path / "typos.csv"
+    # 'teh1' should become 'teh'
+    input_file.write_text("teh1,the\n", encoding="utf-8")
+
+    result = subprocess.run(
+        ["python3", "multitool.py", "align", str(input_file)],
+        capture_output=True,
+        text=True
+    )
+
+    expected = "teh -> the\n"
+    assert result.stdout == expected


### PR DESCRIPTION
This PR introduces a new `align` mode to the `multitool.py` utility.

### What
The `align` mode extracts typo-correction pairs from any supported input format (CSV, JSON, YAML, Markdown lists/tables, etc.) and outputs them as a plain-text list with perfectly aligned columns.
- Added a new `--sep` flag to customize the separator between the left and right columns (defaults to ` -> `).
- Leverages the central `_write_paired_output` helper by introducing a new `aligned` format.
- Integrated into the existing CLI structure with full support for standard flags like `--min-length`, `--process-output`, and `--raw`.

### Why
The suite currently lacks a way to generate clean, aligned mapping files for human consumption or repository maintenance. While the `arrow` format provides a beautiful terminal dashboard, it is not suitable for plain-text mapping files. The `align` mode fills this gap, making it easy to "beautify" typo lists and ensure consistent formatting across a project's documentation and configuration files.

### Verification
- **Unit Tests:** Created `tests/test_multitool_align.py` covering default/custom separators and data cleaning.
- **Regression Testing:** Confirmed that all 476 existing tests for `multitool.py` pass.
- **Manual Verification:** Verified help output (`python3 multitool.py help align`) and CLI execution with various separators.

---
*PR created automatically by Jules for task [12638244845510582222](https://jules.google.com/task/12638244845510582222) started by @RainRat*