### PR TITLE
Fix double-counting of typos in typostats.py

### DIFF
--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -59,18 +59,17 @@ def test_is_one_letter_replacement_one_to_two():
 
 def test_is_one_letter_replacement_multiple_two_char():
     assert typostats.is_one_letter_replacement('cabt', 'cat', allow_1to2=True) == []
+    # Returns only the first valid interpretation to avoid double-counting
     assert typostats.is_one_letter_replacement('cabt', 'cat', allow_1to2=True, include_deletions=True) == [
         ('a', 'ab'),
-        ('t', 'bt'),
     ]
 
 
 def test_is_one_letter_replacement_doubled_letter():
     assert typostats.is_one_letter_replacement('caat', 'cat', allow_1to2=True) == []
+    # Returns only the first valid interpretation to avoid double-counting
     assert typostats.is_one_letter_replacement('caat', 'cat', allow_1to2=True, include_deletions=True) == [
-        ('a', 'aa'),
         ('c', 'ca'),
-        ('t', 'at'),
     ]
 
 
@@ -490,8 +489,8 @@ def test_process_typos_logic_fix():
     # Test process_typos with the new logic
     pairs = [("receve", "receive")]
     counts, _ = typostats.process_typos(pairs, include_deletions=True)
+    # With early return, only the first possible match is counted
     assert ('ei', 'e') in counts
-    assert ('iv', 'v') in counts
 
     counts, _ = typostats.process_typos(pairs, include_deletions=False)
     assert not counts

--- a/typostats.py
+++ b/typostats.py
@@ -534,9 +534,7 @@ def is_one_letter_replacement(
 
     # One-to-two replacement scenario allowed only if difference in length is 1
     if (allow_1to2 or include_deletions) and len(typo) == len(correction) + 1:
-        # Find all positions i where correction[i] is replaced by typo[i:i+2].
-        # We use a set to avoid counting identical interpretations (for example for doubled letters) multiple times.
-        replacements = set()
+        # Find the first position i where correction[i] is replaced by typo[i:i+2].
         for i in range(len(correction)):
             # To be a replacement of correction[i] with typo[i:i+2],
             # the prefix correction[:i] must match typo[:i], and
@@ -553,12 +551,10 @@ def is_one_letter_replacement(
                     if not allow_1to2:
                         continue
 
-                replacements.add((repl_correction, repl_typo))
-        return sorted(replacements)
+                return [(repl_correction, repl_typo)]
 
     # Two-to-one replacement scenario (for example 'ph' -> 'f')
     if (allow_2to1 or include_deletions) and len(typo) == len(correction) - 1:
-        replacements = set()
         for i in range(len(typo)):
             # To be a replacement of correction[i:i+2] with typo[i],
             # the prefix correction[:i] must match typo[:i], and
@@ -575,8 +571,7 @@ def is_one_letter_replacement(
                     if not allow_2to1:
                         continue
 
-                replacements.add((repl_correction, repl_typo))
-        return sorted(replacements)
+                return [(repl_correction, repl_typo)]
 
     return []
 


### PR DESCRIPTION
This PR resolves a logic bug in `typostats.py` where specific typo pairs (notably those involving doubled letters like "caat" -> "cat") were contributing multiple entries to the character replacement frequency tables.

**What:**
- Changed the implementation of `is_one_letter_replacement` to use early returns for 1-to-2 and 2-to-1 matching loops.
- Removed unnecessary `set` and `sorted` logic that previously aggregated all possible interpretations.
- Updated `tests/test_typostats.py` to expect single-entry results for previously ambiguous test cases.

**Why:**
- Accurate statistics: Each typo pair should represent exactly one typing error event. The previous behavior skewed reports by over-representing specific patterns.
- Efficiency: Returning as soon as a match is found is slightly more performant than collecting all possible interpretations.
- No breaking changes: The function signature remains identical, and the change only affects internal disambiguation of ambiguous typo patterns.

---
*PR created automatically by Jules for task [12044138585598943692](https://jules.google.com/task/12044138585598943692) started by @RainRat*