### PR TITLE
[UI/UX] Standardize typostats report formatting with multitool

### DIFF
--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -735,7 +735,7 @@ def test_generate_report_with_file_variants(tmp_path, capsys):
     counts = {("correct", "typo"): 1}
     typostats.generate_report(counts, output_file=str(out_file), quiet=True)
     assert out_file.exists()
-    assert "CORRECT" in out_file.read_text()
+    assert "Correction" in out_file.read_text()
 
     out_file_empty = tmp_path / "empty.txt"
     typostats.generate_report({}, output_file=str(out_file_empty), quiet=True)

--- a/typostats.py
+++ b/typostats.py
@@ -789,12 +789,12 @@ def generate_report(
         )
 
         # Calculate padding for alignment (default to header labels' lengths)
-        max_c = max((len(c) for (c, t), count in sorted_replacements), default=7)
-        max_c = max(max_c, 7)  # 'CORRECT' is 7
+        max_c = max((len(c) for (c, t), count in sorted_replacements), default=10)
+        max_c = max(max_c, 10)  # 'Correction' is 10
         max_t = max((len(t) for (c, t), count in sorted_replacements), default=4)
-        max_t = max(max_t, 4)  # 'TYPO' is 4
+        max_t = max(max_t, 4)  # 'Typo' is 4
         max_n = max((len(str(count)) for (c, t), count in sorted_replacements), default=5)
-        max_n = max(max_n, 5)  # 'COUNT' is 5
+        max_n = max(max_n, 5)  # 'Count' is 5
         max_p = 6  # Width for percentage (for example, "100.0%")
 
         # Colors for table
@@ -808,9 +808,9 @@ def generate_report(
         # Bold blue for table visual elements
         sep = f"{c_bold}{c_blue}│{c_reset}"
         header_row = (
-            f"{padding}{c_bold}{c_blue}{'TYPO':<{max_t}}{c_reset} {sep} "
-            f"{c_bold}{c_blue}{'CORRECT':<{max_c}}{c_reset} {sep} "
-            f"{c_bold}{c_blue}{'COUNT':>{max_n}}{c_reset} {sep} "
+            f"{padding}{c_bold}{c_blue}{'Typo':<{max_t}}{c_reset} {sep} "
+            f"{c_bold}{c_blue}{'Correction':<{max_c}}{c_reset} {sep} "
+            f"{c_bold}{c_blue}{'Count':>{max_n}}{c_reset} {sep} "
             f"{c_bold}{c_blue}{'%':>{max_p}}{c_reset}"
         )
         visible_header_len = max_t + max_c + max_n + max_p + 9
@@ -818,12 +818,12 @@ def generate_report(
         show_attr = any([keyboard, kwargs.get('allow_transposition'), kwargs.get('allow_1to2'), kwargs.get('allow_2to1'), kwargs.get('include_deletions'), kwargs.get('all')])
 
         if show_attr:
-            header_row += f" {sep} {c_bold}{c_blue}{'ATTR':<5}{c_reset}"
+            header_row += f" {sep} {c_bold}{c_blue}{'Attr':<5}{c_reset}"
             visible_header_len += 8
 
         # Add Visual column header
-        max_bar = 15
-        header_row += f" {sep} {c_bold}{c_blue}{'VISUAL':<{max_bar}}{c_reset}"
+        max_bar = 20
+        header_row += f" {sep} {c_bold}{c_blue}{'Visual':<{max_bar}}{c_reset}"
         visible_header_len += 3 + max_bar
 
         divider = f"{padding}{c_bold}{c_blue}{'─' * visible_header_len}{c_reset}"


### PR DESCRIPTION
### Context
CLI (Command Line Interface)

### Problem
The `typostats.py` tool used ALL CAPS for table headers and a smaller visual bar width compared to the main `multitool.py` script. This created visual inconsistency and made the reports slightly harder to read due to the shouting headers and low-resolution bars.

### Solution
Standardized the visual report formatting in `typostats.py` to align with `multitool.py`:
1.  **Title Case Headers:** Changed 'TYPO', 'CORRECT', 'COUNT', 'ATTR', and 'VISUAL' to 'Typo', 'Correction', 'Count', 'Attr', and 'Visual'.
2.  **Higher Resolution Bars:** Increased the default visual bar width from 15 to 20 characters, matching the standard established in the rest of the suite.
3.  **Improved Alignment:** Updated the minimum column width for the "Correction" column (formerly "CORRECT") to 10 characters to ensure perfect alignment even with short words.

These changes improve clarity and ensure a consistent "stock" feel across all tools in the suite.

### Changes
- Modified `typostats.py` report generation logic.
- Updated `tests/test_typostats.py` to verify the new Title Case headers.

---
*PR created automatically by Jules for task [10496776955029730444](https://jules.google.com/task/10496776955029730444) started by @RainRat*