### PR TITLE
[DOCS] Use plain English in multitool count help string

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -5621,7 +5621,7 @@ def _build_parser() -> argparse.ArgumentParser:
     count_options.add_argument(
         '-B', '--by-file',
         action='store_true',
-        help='Count how many files contain each item instead of total occurrences.',
+        help='Count how many files contain each item instead of total matches.',
     )
     unit_group = count_options.add_mutually_exclusive_group()
     unit_group.add_argument(


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** The help string for the `--by-file` flag in `multitool.py` count mode.
* **Why:** Replaced the jargon word "occurrences" with "matches" to make the tool easier to understand for all users.

---
*PR created automatically by Jules for task [7142492019153393205](https://jules.google.com/task/7142492019153393205) started by @RainRat*