### PR TITLE
Fix CSV substitution loading logic in gentypos.py

### DIFF
--- a/gentypos.py
+++ b/gentypos.py
@@ -200,19 +200,28 @@ def _load_substitutions_file(path: str) -> dict[str, list[str]]:
                 else:
                     # Fallback: plain typo,correction CSV.
                     reader = csv.reader(f)
-                    header_keywords = {'typo', 'correction', 'before', 'after', 'correct', 'word', 'correct_char', 'typo_char'}
+                    typo_indicators = {'typo', 'typo_char', 'before'}
+                    correct_indicators = {'correction', 'correct', 'correct_char', 'after', 'word'}
+                    header_keywords = typo_indicators | correct_indicators
+
+                    idx_correct, idx_typo = 0, 1  # Default: correct,typo
 
                     for i, row in enumerate(reader):
                         if not row or len(row) < 2:
                             continue
-                        
+
                         # Skip header if first row matches keywords
                         if i == 0:
                             val1, val2 = row[0].lower(), row[1].lower()
                             if val1 in header_keywords and val2 in header_keywords:
+                                # Determine column order based on headers
+                                if val1 in typo_indicators and val2 in correct_indicators:
+                                    idx_correct, idx_typo = 1, 0
+                                elif val1 in correct_indicators and val2 in typo_indicators:
+                                    idx_correct, idx_typo = 0, 1
                                 continue
 
-                        subs[row[0]].append(row[1])
+                        subs[str(row[idx_correct])].append(str(row[idx_typo]))
         else:
             # Assume YAML
             if not _YAML_AVAILABLE:

--- a/tests/test_gentypos_coverage_final.py
+++ b/tests/test_gentypos_coverage_final.py
@@ -34,7 +34,8 @@ def test_load_substitutions_csv_empty_rows(tmp_path):
     path.write_text("typo,correction\n\nonly_one\ne,a\n")
 
     result = gentypos._load_substitutions_file(str(path))
-    assert result == {"e": ["a"]}
+    # 'a' is the correction, 'e' is the typo. Mapping should be correction -> [typo]
+    assert result == {"a": ["e"]}
 
 def test_main_output_header_file(tmp_path, monkeypatch):
     out_file = tmp_path / "out_with_header.txt"

--- a/tests/test_gentypos_substitutions_file.py
+++ b/tests/test_gentypos_substitutions_file.py
@@ -44,7 +44,8 @@ def test_load_substitutions_csv_plain_header(tmp_path):
     path = tmp_path / "subs.csv"
     path.write_text("typo,correction\ne,a\no,i\n")
     result = gentypos._load_substitutions_file(str(path))
-    assert result == {"e": ["a"], "o": ["i"]}
+    # 'a' is the correction, 'e' is the typo. Mapping should be correction -> [typo]
+    assert result == {"a": ["e"], "i": ["o"]}
 
 def test_load_substitutions_csv_plain_no_header(tmp_path):
     path = tmp_path / "subs.csv"


### PR DESCRIPTION
* **What:** Updated `_load_substitutions_file` in `gentypos.py` to detect column order in CSV files based on headers. It now recognizes keywords like 'typo', 'correction', 'correct', 'typo_char', and 'correct_char' to determine the mapping direction.
* **Why:** Previously, the tool rigidly assumed the first column was the correction and the second was the typo. This was incorrect for many typo datasets, including the output of its companion tool `typostats.py`, which defaults to `typo,correction`. This fix ensures `gentypos.py` can correctly load its own reports and other standard typo CSVs. The change is non-breaking as it falls back to the previous default behavior for files without recognized headers.

---
*PR created automatically by Jules for task [10389283746544575287](https://jules.google.com/task/10389283746544575287) started by @RainRat*