### PR TITLE
[TEST] Refactor and expand align mode tests for 100% coverage

### DIFF
--- a/tests/test_multitool_align.py
+++ b/tests/test_multitool_align.py
@@ -1,6 +1,7 @@
-import os
-import subprocess
+import io
+from unittest.mock import patch
 import pytest
+import multitool
 
 def test_align_mode_default_separator(tmp_path):
     """Verify align mode with default separator."""
@@ -8,18 +9,17 @@ def test_align_mode_default_separator(tmp_path):
     input_file.write_text("teh,the\nabcde,abc\n", encoding="utf-8")
 
     # Run align mode
-    result = subprocess.run(
-        ["python3", "multitool.py", "align", str(input_file)],
-        capture_output=True,
-        text=True
-    )
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        with patch("sys.argv", ["multitool.py", "align", str(input_file)]):
+            multitool.main()
+        output = mock_stdout.getvalue()
 
     # Expected output (aligned)
     # teh   -> the
     # abcde -> abc
     # Max length of left column is 5 ('abcde')
     expected = "teh   -> the\nabcde -> abc\n"
-    assert result.stdout == expected
+    assert output == expected
 
 def test_align_mode_custom_separator(tmp_path):
     """Verify align mode with custom separator."""
@@ -27,15 +27,14 @@ def test_align_mode_custom_separator(tmp_path):
     input_file.write_text("teh,the\nabcde,abc\n", encoding="utf-8")
 
     # Run align mode with custom separator
-    result = subprocess.run(
-        ["python3", "multitool.py", "align", str(input_file), "--sep", " | "],
-        capture_output=True,
-        text=True
-    )
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        with patch("sys.argv", ["multitool.py", "align", str(input_file), "--sep", " | "]):
+            multitool.main()
+        output = mock_stdout.getvalue()
 
     # Expected output (aligned with custom separator)
     expected = "teh   | the\nabcde | abc\n"
-    assert result.stdout == expected
+    assert output == expected
 
 def test_align_mode_with_cleaning(tmp_path):
     """Verify align mode with default cleaning (filter_to_letters)."""
@@ -43,11 +42,83 @@ def test_align_mode_with_cleaning(tmp_path):
     # 'teh1' should become 'teh'
     input_file.write_text("teh1,the\n", encoding="utf-8")
 
-    result = subprocess.run(
-        ["python3", "multitool.py", "align", str(input_file)],
-        capture_output=True,
-        text=True
-    )
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        with patch("sys.argv", ["multitool.py", "align", str(input_file)]):
+            multitool.main()
+        output = mock_stdout.getvalue()
 
     expected = "teh -> the\n"
-    assert result.stdout == expected
+    assert output == expected
+
+def test_align_mode_min_max_length(tmp_path):
+    """Verify align mode with min and max length filtering."""
+    input_file = tmp_path / "typos.csv"
+    input_file.write_text("a,b\nab,cd\nabc,def\nabcde,fghij\n", encoding="utf-8")
+
+    # Test with min-length 3 and max-length 4
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        with patch("sys.argv", ["multitool.py", "align", str(input_file), "--min-length", "3", "--max-length", "4"]):
+            multitool.main()
+        output = mock_stdout.getvalue()
+
+    # Only 'abc,def' matches (length 3)
+    expected = "abc -> def\n"
+    assert output == expected
+
+def test_align_mode_process_output(tmp_path):
+    """Verify align mode with --process-output (sorting and deduplication)."""
+    input_file = tmp_path / "typos.csv"
+    # Duplicate and out of order
+    input_file.write_text("zzz,aaa\nabc,def\nabc,def\n", encoding="utf-8")
+
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        with patch("sys.argv", ["multitool.py", "align", str(input_file), "--process-output"]):
+            multitool.main()
+        output = mock_stdout.getvalue()
+
+    # Should be sorted and unique
+    expected = "abc -> def\nzzz -> aaa\n"
+    assert output == expected
+
+def test_align_mode_limit(tmp_path):
+    """Verify align mode with --limit."""
+    input_file = tmp_path / "typos.csv"
+    input_file.write_text("a,b\nc,d\ne,f\n", encoding="utf-8")
+
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        with patch("sys.argv", ["multitool.py", "align", str(input_file), "--limit", "2"]):
+            multitool.main()
+        output = mock_stdout.getvalue()
+
+    # Should only show first 2 pairs
+    expected = "a -> b\nc -> d\n"
+    assert output == expected
+
+def test_align_mode_raw(tmp_path):
+    """Verify align mode with --raw flag (skipping cleaning)."""
+    input_file = tmp_path / "typos.csv"
+    # 'teh1' should stay 'teh1' with --raw
+    input_file.write_text("teh1,the\n", encoding="utf-8")
+
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        with patch("sys.argv", ["multitool.py", "align", str(input_file), "--raw"]):
+            multitool.main()
+        output = mock_stdout.getvalue()
+
+    expected = "teh1 -> the\n"
+    assert output == expected
+
+def test_align_mode_empty_after_cleaning(tmp_path):
+    """Verify align mode skips items that are empty after cleaning."""
+    input_file = tmp_path / "typos.csv"
+    # '1' will become '' after cleaning, so it should be skipped
+    input_file.write_text("1,the\nabc,def\n", encoding="utf-8")
+
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        with patch("sys.argv", ["multitool.py", "align", str(input_file)]):
+            multitool.main()
+        output = mock_stdout.getvalue()
+
+    # '1' is skipped, only 'abc -> def' remains
+    expected = "abc -> def\n"
+    assert output == expected


### PR DESCRIPTION
I have refactored and expanded the test suite for the `align` mode in `multitool.py`. 

### Key Changes:
- **Refactoring:** Converted tests in `tests/test_multitool_align.py` from using `subprocess.run()` to direct `multitool.main()` calls with patched `sys.stdout` and `sys.argv`. This allows `pytest-cov` to accurately report coverage for the `align` logic.
- **Coverage Expansion:** Added five new test cases to verify:
    - Length filtering (`--min-length`, `--max-length`).
    - Sorting and deduplication (`--process-output`).
    - Output truncation (`--limit`).
    - Raw output (`--raw`) to skip the default cleaning process.
    - Robustness against items that become empty after cleaning.
- **Result:** Achieved 100% branch coverage for the `align_mode` function and the `aligned` format logic in `_write_paired_output`. All 739 tests in the full suite pass.

---
*PR created automatically by Jules for task [7567823532413160144](https://jules.google.com/task/7567823532413160144) started by @RainRat*