### PR TITLE
[FEAT] Add full TOML support to multitool.py

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -68,6 +68,10 @@ These modes help you pull specific data out of a messy file.
   - **What it does:** Gets values from a YAML file using a key path. Like JSON mode, it supports dot notation (for example, `config.items`). If you do not provide a key, it gets items from the top level.
   - **Example:** `python multitool.py yaml config.yaml --key config.items`
 
+- **`toml`**
+  - **What it does:** Gets values from a TOML file using a key path. Like JSON and YAML modes, it supports dot notation (for example, `tool.poetry.dependencies`). If you do not provide a key, it gets items from the top level. It automatically handles nested tables.
+  - **Example:** `python multitool.py toml pyproject.toml --key tool.poetry.dependencies`
+
 - **`line`**
   - **What it does:** Reads a file line by line. Use this to simply clean or filter a text file without special getting logic.
   - **Example:** `python multitool.py line raw_words.txt`
@@ -103,7 +107,7 @@ These modes help you transform or combine your data.
   - **Example:** `python multitool.py resolve mappings.csv`
 
 - **`align`**
-  - **What it does:** Extracts typo-correction pairs from any supported format (CSV, Arrow, Markdown lists/tables, JSON, YAML) and outputs them in perfectly aligned columns by automatically calculating the maximum width of the left column. This is the recommended way to "beautify" your typo lists for human readability.
+  - **What it does:** Extracts typo-correction pairs from any supported format (CSV, Arrow, Markdown lists/tables, JSON, YAML, TOML) and outputs them in perfectly aligned columns by automatically calculating the maximum width of the left column. This is the recommended way to "beautify" your typo lists for human readability.
   - **Options:** Use the `--sep` flag to customize the separator string between columns (default is ` -> `).
   - **Example:** `python multitool.py align typos.csv --sep ' | '`
 
@@ -126,7 +130,7 @@ These modes help you transform or combine your data.
   - **Example:** `python multitool.py filterfragments candidates.txt --file2 dictionary.txt`
 
 - **`map`**
-  - **What it does:** Changes items in your list using values from a mapping file or extra pairs. Supports CSV, Arrow, Table (`typo = "correction"`), JSON, and YAML formats. By default, it keeps items that are not in the mapping. The `--min-length` and `--max-length` filters are **re-applied** to items after they are changed. Use `--drop-missing` to remove unmatched items.
+  - **What it does:** Changes items in your list using values from a mapping file or extra pairs. Supports CSV, Arrow, Table (`typo = "correction"`), JSON, YAML, and TOML formats. By default, it keeps items that are not in the mapping. The `--min-length` and `--max-length` filters are **re-applied** to items after they are changed. Use `--drop-missing` to remove unmatched items.
   - **Options:**
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) directly on the command line.
   - **Example:** `python multitool.py map input.txt --add teh:the`
@@ -145,17 +149,17 @@ These modes help you transform or combine your data.
 
 - **`zip`**
   - **What it does:** Joins two files line-by-line into a paired format. It applies `--min-length` and `--max-length` filters to **both items in each pair**. If the files have a different number of lines, the output will stop at the end of the shortest file.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py zip typos.txt --file2 corrections.txt --output-format arrow`
 
 - **`swap`**
   - **What it does:** Flips the order of elements in paired data (for example, `typo -> correction` becomes `correction -> typo`).
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py swap mappings.csv --output-format arrow`
 
 - **`scrub`**
   - **What it does:** Fixes typos in your text files using a mapping file or extra pairs. It tries to keep the surrounding context (punctuation, whitespace) while fixing errors. It automatically handles compound words like `CamelCase` and `snake_case` variables.
-  - **Supported Formats:** Supports CSV, Arrow, Table, JSON, and YAML mapping formats.
+  - **Supported Formats:** Supports CSV, Arrow, Table, JSON, YAML, and TOML mapping formats.
   - **Options:**
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) directly on the command line.
   - **In-Place Editing:** Use the `--in-place` flag to modify files directly. If you provide an extension (for example, `--in-place .bak`), the tool will create a backup of each file before modifying it.
@@ -185,7 +189,7 @@ These modes help you transform or combine your data.
 
 - **`pairs`**
   - **What it does:** Works with and converts paired data (like `typo -> correction`) from any supported format and writes it to the specified output format. This is the primary way to convert between paired formats (for example, from JSON to CSV) while applying cleaning and length filters.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py pairs typos.json --output-format csv`
 
 ### 3. CHECKING DATA
@@ -199,12 +203,12 @@ These modes help you analyze your data.
 - **`classify`**
   - **What it does:** Groups typo corrections based on their error type. It labels each pair with a code like `[K]` (Keyboard), `[T]` (Transposition), `[D]` (Deletion), `[I]` (Insertion), `[R]` (Replacement), or `[M]` (Multiple letters).
   - **Options:** Use `--show-dist` to include the number of character changes in the output labels.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py classify typos.txt --show-dist --output labeled.txt`
 
 - **`conflict`**
   - **What it does:** Finds typos that are associated with more than one unique correction. Use this to find inconsistencies in your typo lists.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py conflict mappings.csv`
 
 - **`count`**
@@ -232,19 +236,19 @@ These modes help you analyze your data.
 - **`fuzzymatch`**
   - **What it does:** Finds words in your list that are similar to words in a second list (large dictionary). Use this to find likely corrections for typos.
   - **Options:** Use `--min-dist` and `--max-dist` to control the number of changes allowed, and `--show-dist` to see the number of changes in the output.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py fuzzymatch typos.txt words.csv --max-dist 1 --show-dist`
 
 - **`near_duplicates`**
   - **What it does:** Finds pairs of words in your list that are very similar (only a few characters are different). This is useful for finding potential typos or unintended duplicates.
   - **Options:** Use `--min-dist` and `--max-dist` to control the number of changes allowed, and `--show-dist` to see the number of changes in the output.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py near_duplicates words.txt --max-dist 1 --show-dist`
 
 - **`similarity`**
   - **What it does:** Filters paired data (like `typo -> correction`) based on the number of character changes needed to turn one word into another. Use this to remove extra data or find specific types of typos.
   - **Options:** Use `--min-dist` and `--max-dist` to set the range of allowed changes, and `--show-dist` to include the number of changes in the output.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py similarity typos.txt --max-dist 2 --show-dist`
 
 - **`stats`**
@@ -261,7 +265,7 @@ These modes help you analyze your data.
     - `--show-dist`: Include the number of character changes in the output.
     - `-d`, `--delimiter`: The character to split words by (default: whitespace).
     - `-S`, `--smart`: Split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py discovery code.py --smart --rare-max 2 --freq-min 10 --max-dist 1`
 
 - **`casing`**
@@ -269,7 +273,7 @@ These modes help you analyze your data.
   - **Options:**
     - `-d`, `--delimiter`: The character to split words by (default: whitespace).
     - `-S`, `--smart`: Split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py casing report.txt --smart --output-format arrow`
 
 - **`repeated`**
@@ -277,7 +281,7 @@ These modes help you analyze your data.
   - **Options:**
     - `-d`, `--delimiter`: The character to split words by (default: whitespace).
     - `-S`, `--smart`: Split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, and `yaml`.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py repeated report.txt --smart --output-format arrow`
 
 - **`search`**
@@ -312,7 +316,7 @@ These options work with most modes:
 
 - `[INPUT_FILES...]`: One or more files to read. Defaults to **standard input** if not provided.
 - `--output`: The file to write results to. Defaults to printing to the screen.
-- `--output-format`: The format of the output. Options include `line` (default), `json`, `yaml`, `csv`, `markdown`, `md-table`, `arrow`, and `table`.
+- `--output-format`: The format of the output. Options include `line` (default), `json`, `yaml`, `toml`, `csv`, `markdown`, `md-table`, `arrow`, and `table`.
 - `--min-length`: Skip items shorter than this length (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count').
 - `--max-length`: Skip words longer than this length (default: 1000).
 - `--process-output`: Sorts the final list and removes duplicates. Use this to organize your output or remove redundant entries.

--- a/multitool.py
+++ b/multitool.py
@@ -30,6 +30,17 @@ except ImportError:  # pragma: no cover - optional dependency
     chardet = None
     _CHARDET_AVAILABLE = False
 
+try:
+    import tomllib
+    _TOMLLIB_AVAILABLE = True
+except ImportError:
+    try:
+        import toml
+        _TOML_AVAILABLE = True
+    except ImportError:
+        _TOMLLIB_AVAILABLE = False
+        _TOML_AVAILABLE = False
+
 # Cache for standard input to allow multiple passes
 _STDIN_CACHE: List[str] | None = None
 
@@ -598,6 +609,10 @@ def write_output(
             except ImportError:
                 for item in items_list:
                     outfile.write(f"- {item}\n")
+        elif output_format == 'toml':
+            # Alias for table format for simple lists
+            for item in items_list:
+                outfile.write(f'{item} = ""\n')
         else:  # 'line' or fallback
             for item in items_list:
                 outfile.write(item + '\n')
@@ -654,6 +669,46 @@ def _extract_pairs(input_files: Sequence[str], quiet: bool = False) -> Iterable[
                 logging.error("PyYAML not installed.")
             except Exception as e:
                 logging.error(f"Failed to parse YAML in '{input_file}': {e}")
+            continue
+
+        if ext.endswith('.toml'):
+            if not _TOMLLIB_AVAILABLE and not _TOML_AVAILABLE:
+                logging.error("TOML support requires Python 3.11+ or the 'toml' package.")
+                continue
+            content = "".join(_read_file_lines_robust(input_file))
+            if content.strip():
+                try:
+                    if _TOMLLIB_AVAILABLE:
+                        data = tomllib.loads(content)
+                    else:
+                        import toml
+                        data = toml.loads(content)
+
+                    if isinstance(data, dict):
+                        if 'replacements' in data:
+                            repls = data['replacements']
+                            if isinstance(repls, list):
+                                for item in repls:
+                                    if isinstance(item, dict) and 'typo' in item:
+                                        correct = item.get('correct', item.get('correction'))
+                                        if correct is not None:
+                                            yield str(item['typo']), str(correct)
+                            elif isinstance(repls, dict):
+                                for k, v in repls.items():
+                                    if isinstance(v, list):
+                                        for item in v:
+                                            if isinstance(item, dict) and 'typo' in item:
+                                                correct = item.get('correct', item.get('correction'))
+                                                if correct is not None:
+                                                    yield str(item['typo']), str(correct)
+                                    elif not isinstance(v, dict):
+                                        yield str(k), str(v)
+                        else:
+                            for k, v in data.items():
+                                if not isinstance(v, (dict, list)):
+                                    yield str(k), str(v)
+                except Exception as e:
+                    logging.error(f"Failed to parse TOML in '{input_file}': {e}")
             continue
 
         # Text formats
@@ -797,7 +852,7 @@ def _write_paired_output(
             writer = csv.writer(out_file)
             for left, right in pairs_list:
                 writer.writerow([left, right])
-        elif output_format == 'table':
+        elif output_format in ('table', 'toml'):
             for left, right in pairs_list:
                 out_file.write(f'{left} = "{right}"\n')
         elif output_format == 'markdown':
@@ -1049,6 +1104,32 @@ def _extract_yaml_items(input_file: str, key_path: str, quiet: bool = False) -> 
             yield from _traverse_data(doc, path_parts)
     except yaml.YAMLError as e:
         logging.error(f"Failed to parse YAML in '{input_file}': {e}")
+        return
+
+
+def _extract_toml_items(input_file: str, key_path: str, quiet: bool = False) -> Iterable[str]:
+    """Yield values from TOML objects based on a dotted key path."""
+
+    if not _TOMLLIB_AVAILABLE and not _TOML_AVAILABLE:
+        logging.error("TOML support requires Python 3.11+ or the 'toml' package.")
+        sys.exit(1)
+
+    path_parts = key_path.split('.') if key_path else []
+
+    lines = _read_file_lines_robust(input_file)
+    content = "".join(lines)
+    try:
+        if not content.strip():
+            return
+        if _TOMLLIB_AVAILABLE:
+            data = tomllib.loads(content)
+        else:
+            # Fallback to third-party toml package
+            import toml
+            data = toml.loads(content)
+        yield from _traverse_data(data, path_parts)
+    except Exception as e:
+        logging.error(f"Failed to parse TOML in '{input_file}': {e}")
         return
 
 
@@ -1324,6 +1405,37 @@ def arrow_mode(
         process_output,
         'Arrow',
         'File(s) processed successfully.',
+        output_format,
+        quiet,
+        clean_items=clean_items,
+        limit=limit,
+    )
+
+
+def toml_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    key: str,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Wrapper for getting fields from TOML files."""
+    def extractor(f, quiet=False):
+        return _extract_toml_items(f, key, quiet=quiet)
+    _process_items(
+        extractor,
+        input_files,
+        output_file,
+        min_length,
+        max_length,
+        process_output,
+        'TOML',
+        'Successfully got TOML values.',
         output_format,
         quiet,
         clean_items=clean_items,
@@ -4653,10 +4765,10 @@ def _add_common_mode_arguments(
     io_group.add_argument(
         '-f', '--output-format', '--format',
         dest='output_format',
-        choices=['line', 'json', 'csv', 'markdown', 'md-table', 'arrow', 'table', 'yaml'],
+        choices=['line', 'json', 'csv', 'markdown', 'md-table', 'arrow', 'table', 'yaml', 'toml'],
         metavar='FORMAT',
         default=argparse.SUPPRESS,
-        help="Choose the format for the output (default: line). Choices: line, json, csv, markdown, md-table, arrow, table, yaml.",
+        help="Choose the format for the output (default: line). Choices: line, json, csv, markdown, md-table, arrow, table, yaml, toml.",
     )
     io_group.add_argument(
         '-q', '--quiet',
@@ -4924,6 +5036,12 @@ MODE_DETAILS = {
         "example": "python multitool.py yaml list.yaml -o items.txt",
         "flags": "[-k KEY]",
     },
+    "toml": {
+        "summary": "Extracts TOML values by key",
+        "description": "Finds values for a specific key in a TOML file. Use dots for nested keys (like 'tool.poetry.dependencies'). If no key is provided, it gets items from the top level. It automatically handles nested tables.",
+        "example": "python multitool.py toml pyproject.toml -k tool.poetry.dependencies --output-format toml",
+        "flags": "[-k KEY]",
+    },
     "line": {
         "summary": "Reads a file line by line",
         "description": "Reads every line from a file, cleans the text, and writes it to the output. Useful for simple cleaning and filtering.",
@@ -5128,7 +5246,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "line", "words", "ngrams", "regex"],
+        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "toml", "line", "words", "ngrams", "regex"],
         "CHANGING DATA": ["combine", "unique", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
         "AUDIT & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
@@ -5324,10 +5442,10 @@ def _build_parser() -> argparse.ArgumentParser:
     io_group.add_argument(
         '-f', '--output-format', '--format',
         dest='output_format',
-        choices=['line', 'json', 'csv', 'markdown', 'md-table', 'arrow', 'table', 'yaml'],
+        choices=['line', 'json', 'csv', 'markdown', 'md-table', 'arrow', 'table', 'yaml', 'toml'],
         metavar='FORMAT',
         default='line',
-        help="Choose the format for the output (default: line). Choices: line, json, csv, markdown, md-table, arrow, table, yaml.",
+        help="Choose the format for the output (default: line). Choices: line, json, csv, markdown, md-table, arrow, table, yaml, toml.",
     )
     io_group.add_argument(
         '-q', '--quiet',
@@ -5561,6 +5679,22 @@ def _build_parser() -> argparse.ArgumentParser:
         help="The key path to get (for example 'config.items'). If not provided, gets from the top level.",
     )
     _add_common_mode_arguments(yaml_parser)
+
+    toml_parser = subparsers.add_parser(
+        'toml',
+        help=MODE_DETAILS['toml']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['toml']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['toml']['example']}{RESET}",
+    )
+    toml_options = toml_parser.add_argument_group(f"{BLUE}TOML OPTIONS{RESET}")
+    toml_options.add_argument(
+        '-k', '--key',
+        type=str,
+        default='',
+        help="The key path to get (for example 'tool.poetry.dependencies'). If not provided, gets from the top level.",
+    )
+    _add_common_mode_arguments(toml_parser)
 
     combine_parser = subparsers.add_parser(
         'combine',
@@ -6767,6 +6901,14 @@ def main() -> None:
         ),
         'yaml': (
             yaml_mode,
+            {
+                **common_kwargs,
+                'key': getattr(args, 'key', ''),
+                'output_format': output_format,
+            },
+        ),
+        'toml': (
+            toml_mode,
             {
                 **common_kwargs,
                 'key': getattr(args, 'key', ''),

--- a/tests/test_multitool_toml.py
+++ b/tests/test_multitool_toml.py
@@ -1,0 +1,77 @@
+import multitool
+import pytest
+from unittest.mock import patch
+import io
+import os
+
+def test_toml_mode_extraction(tmp_path):
+    toml_content = """
+[tool.poetry.dependencies]
+python = "^3.10"
+tqdm = "*"
+
+[replacements]
+teh = "the"
+recieve = "receive"
+"""
+    toml_file = tmp_path / "test.toml"
+    toml_file.write_text(toml_content)
+
+    # Test extracting keys from a nested table
+    with patch('sys.stdout', new=io.StringIO()) as fake_out:
+        with patch('sys.argv', ['multitool.py', 'toml', str(toml_file), '-k', 'tool.poetry.dependencies', '-R']):
+            multitool.main()
+            output = fake_out.getvalue()
+            assert "python" in output
+            assert "tqdm" in output
+
+    # Test extracting from a flat table
+    with patch('sys.stdout', new=io.StringIO()) as fake_out:
+        with patch('sys.argv', ['multitool.py', 'toml', str(toml_file), '-k', 'replacements', '-R']):
+            multitool.main()
+            output = fake_out.getvalue()
+            assert "teh" in output
+            assert "recieve" in output
+
+def test_extract_pairs_from_toml(tmp_path):
+    toml_content = """
+[replacements]
+teh = "the"
+recieve = "receive"
+
+[[replacements.list]]
+typo = "andd"
+correct = "and"
+"""
+    toml_file = tmp_path / "test_pairs.toml"
+    toml_file.write_text(toml_content)
+
+    # Use pairs mode to verify extraction logic in _extract_pairs
+    with patch('sys.stdout', new=io.StringIO()) as fake_out:
+        with patch('sys.argv', ['multitool.py', 'pairs', str(toml_file), '-f', 'csv', '-R']):
+            multitool.main()
+            output = fake_out.getvalue()
+            assert "teh,the" in output
+            assert "recieve,receive" in output
+            assert "andd,and" in output
+
+def test_toml_output_format(tmp_path):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("word1\nword2\n")
+
+    # Test output-format=toml for simple list
+    with patch('sys.stdout', new=io.StringIO()) as fake_out:
+        with patch('sys.argv', ['multitool.py', 'line', str(input_file), '-f', 'toml', '-R']):
+            multitool.main()
+            output = fake_out.getvalue()
+            assert 'word1 = ""' in output
+            assert 'word2 = ""' in output
+
+    # Test output-format=toml for pairs
+    mapping_file = tmp_path / "map.csv"
+    mapping_file.write_text("teh,the\n")
+    with patch('sys.stdout', new=io.StringIO()) as fake_out:
+        with patch('sys.argv', ['multitool.py', 'pairs', str(mapping_file), '-f', 'toml', '-R']):
+            multitool.main()
+            output = fake_out.getvalue()
+            assert 'teh = "the"' in output


### PR DESCRIPTION
This PR adds full TOML support to the `multitool.py` utility, completing the trio of modern data formats alongside JSON and YAML.

### What:
- **TOML Extraction Mode**: A new `toml` subcommand that allows extracting values from TOML files using dotted key paths (e.g., `tool.poetry.dependencies`).
- **TOML Mapping Support**: The `_extract_pairs` function now supports `.toml` files, allowing them to be used as mapping sources in `map`, `scrub`, `scan`, `verify`, and `pairs` modes. It specifically looks for a `replacements` table or top-level key-value pairs.
- **TOML Output Format**: Added `toml` as a valid output format choice, enabling the creation of TOML-style typo lists (`key = "value"`).
- **Documentation**: Updated the internal CLI help and `docs/multitool.md` to include the new TOML functionality.
- **Tests**: Added a new test suite in `tests/test_multitool_toml.py`.

### Why:
The suite already supports JSON and YAML for both data extraction and mapping sources. Adding TOML provides symmetry and interoperability with modern Python project configurations (like `pyproject.toml`), which often contain the very project-specific vocabulary and mappings these tools are designed to manage. This creates immediate value by allowing users to feed their existing TOML configurations directly into the typo-checking workflow.

---
*PR created automatically by Jules for task [6296645533848956657](https://jules.google.com/task/6296645533848956657) started by @RainRat*