### PR TITLE
Refactor map_mode to remove redundant wrapper loop

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -3904,22 +3904,21 @@ def map_mode(
                 continue
 
             # Default behavior of map_mode is processing the whole line item.
-            parts = [line_content]
-            for part in parts:
-                raw_item_count += 1
-                match_key = filter_to_letters(part) if clean_items else part
+            part = line_content
+            raw_item_count += 1
+            match_key = filter_to_letters(part) if clean_items else part
 
-                if match_key in mapping:
-                    transformed = mapping[match_key]
-                    if smart_case:
-                        transformed = _apply_smart_case(part, transformed)
+            if match_key in mapping:
+                transformed = mapping[match_key]
+                if smart_case:
+                    transformed = _apply_smart_case(part, transformed)
 
-                    # Re-apply length filtering to the result of the mapping
-                    if transformed and min_length <= len(transformed) <= max_length:
-                        results.append((part, transformed) if pairs else transformed)
-                elif not drop_missing:
-                    if part and min_length <= len(part) <= max_length:
-                        results.append((part, part) if pairs else part)
+                # Re-apply length filtering to the result of the mapping
+                if transformed and min_length <= len(transformed) <= max_length:
+                    results.append((part, transformed) if pairs else transformed)
+            elif not drop_missing:
+                if part and min_length <= len(part) <= max_length:
+                    results.append((part, part) if pairs else part)
 
     if process_output:
         results = sorted(set(results))


### PR DESCRIPTION
This PR simplifies the `map_mode` function in `multitool.py` by removing a redundant wrapper loop. Previously, the code was creating a list with a single element (`parts = [line_content]`) and then immediately iterating over it. This refactor removes that extra step, making the code more direct and readable.

The change is purely internal and does not affect the external behavior or API of the `map` command. All existing tests for `map_mode` pass correctly after the change.

---
*PR created automatically by Jules for task [6372678317640091802](https://jules.google.com/task/6372678317640091802) started by @RainRat*