### PR TITLE
[FEAT] Automatic output format detection based on file extension

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -88,6 +88,35 @@ def filter_to_letters(text: str) -> str:
     return re.sub("[^a-z]", "", text.lower())
 
 
+def _detect_format_from_extension(path: str, allowed: Sequence[str], default: str) -> str:
+    """
+    Detect the output format based on the file extension.
+    Returns the default if no match is found or no extension is present.
+    """
+    if not path or path == '-':
+        return default
+
+    ext = os.path.splitext(path)[1].lower().lstrip('.')
+    if not ext:
+        return default
+
+    # Map common extensions to tool-supported formats
+    mapping = {
+        'txt': 'arrow',
+        'csv': 'csv',
+        'table': 'table',
+        'toml': 'table',
+        'list': 'list',
+        'arrow': 'arrow',
+    }
+
+    detected = mapping.get(ext)
+    if detected in allowed:
+        return detected
+
+    return default
+
+
 def levenshtein_distance(s1: str, s2: str) -> int:
     """Calculate the number of character changes needed to turn one word into another."""
     if len(s1) < len(s2):
@@ -635,8 +664,8 @@ def main():
         dest='output_format',
         type=str,
         choices=['arrow', 'csv', 'table', 'list'],
-        default='arrow',
-        help='Format of the output typos. Choices are: arrow (typo -> correction), csv (typo,correction), table (typo = "correction"), list (typo). Default is arrow.',
+        default=None,
+        help='Format of the output typos. If not provided, it is automatically detected from the output file extension. Choices are: arrow (typo -> correction), csv (typo,correction), table (typo = "correction"), list (typo). Default is arrow.',
     )
     # Hidden alias for backward compatibility
     parser.add_argument('--output_format', type=str, choices=['arrow', 'csv', 'table', 'list'], help=argparse.SUPPRESS, default=argparse.SUPPRESS)
@@ -712,6 +741,11 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Resolve output format if not provided
+    if args.output_format is None:
+        allowed_formats = ['arrow', 'csv', 'table', 'list']
+        args.output_format = _detect_format_from_extension(args.output_file, allowed_formats, 'arrow')
 
     log_level = logging.WARNING if args.quiet else logging.INFO
     # Use a custom handler and formatter to keep output clean

--- a/gentypos.py
+++ b/gentypos.py
@@ -112,6 +112,35 @@ def _merge_defaults(
                 logging.debug(f"Applying default for '{dotted_path}': {default_value}")
             config.setdefault(key, default_value)
 
+def _detect_format_from_extension(path: str, allowed: Sequence[str], default: str) -> str:
+    """
+    Detect the output format based on the file extension.
+    Returns the default if no match is found or no extension is present.
+    """
+    if not path or path == '-':
+        return default
+
+    ext = os.path.splitext(path)[1].lower().lstrip('.')
+    if not ext:
+        return default
+
+    # Map common extensions to tool-supported formats
+    mapping = {
+        'txt': 'arrow',
+        'csv': 'csv',
+        'table': 'table',
+        'toml': 'table',
+        'list': 'list',
+        'arrow': 'arrow',
+    }
+
+    detected = mapping.get(ext)
+    if detected in allowed:
+        return detected
+
+    return default
+
+
 def get_adjacent_keys(include_diagonals: bool = True) -> dict[str, set[str]]:
     """
     Returns a dictionary of adjacent keys on a QWERTY keyboard.
@@ -505,7 +534,7 @@ def parse_yaml_config(config_path: str) -> dict[str, Any]:
         with open(config_path, 'r', encoding='utf-8') as file:
             config = yaml.safe_load(file)
             logging.debug(f"Parsed YAML configuration from '{config_path}'.")
-            return config
+            return config or {}
     except FileNotFoundError:
         logging.error(f"Configuration file '{config_path}' not found.")
         sys.exit(1)
@@ -817,7 +846,8 @@ def main() -> None:
         '-f', '--format',
         choices=['arrow', 'csv', 'table', 'list'],
         metavar='FMT',
-        help="Choose an output format (default: arrow).",
+        default=None,
+        help="Choose an output format. If not provided, it is automatically detected from the output file extension. (default: arrow).",
     )
     io_group.add_argument(
         '-s', '--substitutions',
@@ -907,8 +937,7 @@ def main() -> None:
         # This overrides any persistent settings in the configuration file.
         if not args.output:
             config['output_file'] = '-'
-        if not args.format:
-            config['output_format'] = 'arrow'
+        # output_format default is now handled via extension detection
         # Ensure extra words aren't filtered out by default project-wide min_length settings.
         if args.min_length is None:
             if 'word_length' not in config:
@@ -920,6 +949,9 @@ def main() -> None:
         config['output_file'] = args.output
     if args.format:
         config['output_format'] = args.format
+    elif config.get('output_format') is None:
+        allowed_formats = ['arrow', 'csv', 'table', 'list']
+        config['output_format'] = _detect_format_from_extension(config.get('output_file'), allowed_formats, 'arrow')
     if args.substitutions:
         config['substitutions_file'] = args.substitutions
     if args.no_filter:

--- a/multitool.py
+++ b/multitool.py
@@ -108,6 +108,38 @@ def filter_to_letters(text: str) -> str:
     return re.sub("[^a-z]", "", text.lower())
 
 
+def _detect_format_from_extension(path: str, allowed: Sequence[str], default: str) -> str:
+    """
+    Detect the output format based on the file extension.
+    Returns the default if no match is found or no extension is present.
+    """
+    if not path or path == '-':
+        return default
+
+    ext = os.path.splitext(path)[1].lower().lstrip('.')
+    if not ext:
+        return default
+
+    # Map common extensions to tool-supported formats
+    mapping = {
+        'txt': 'line',
+        'json': 'json',
+        'csv': 'csv',
+        'md': 'markdown',
+        'yaml': 'yaml',
+        'yml': 'yaml',
+        'toml': 'toml',
+        'arrow': 'arrow',
+        'table': 'table',
+    }
+
+    detected = mapping.get(ext)
+    if detected in allowed:
+        return detected
+
+    return default
+
+
 def _apply_smart_case(original: str, replacement: str) -> str:
     """
     Applies the casing of the original string to the replacement string.
@@ -4769,7 +4801,7 @@ def _add_common_mode_arguments(
         choices=['line', 'json', 'csv', 'markdown', 'md-table', 'arrow', 'table', 'yaml', 'toml'],
         metavar='FORMAT',
         default=argparse.SUPPRESS,
-        help="Choose the format for the output (default: line). Choices: line, json, csv, markdown, md-table, arrow, table, yaml, toml.",
+        help="Choose the format for the output. If not provided, it is automatically detected from the output file extension. Choices: line, json, csv, markdown, md-table, arrow, table, yaml, toml.",
     )
     io_group.add_argument(
         '-q', '--quiet',
@@ -5451,8 +5483,8 @@ def _build_parser() -> argparse.ArgumentParser:
         dest='output_format',
         choices=['line', 'json', 'csv', 'markdown', 'md-table', 'arrow', 'table', 'yaml', 'toml'],
         metavar='FORMAT',
-        default='line',
-        help="Choose the format for the output (default: line). Choices: line, json, csv, markdown, md-table, arrow, table, yaml, toml.",
+        default=None,
+        help="Choose the format for the output. If not provided, it is automatically detected from the output file extension. Choices: line, json, csv, markdown, md-table, arrow, table, yaml, toml.",
     )
     io_group.add_argument(
         '-q', '--quiet',
@@ -6777,8 +6809,10 @@ def main() -> None:
     sample_count = getattr(args, 'sample_count', None)
     sample_percent = getattr(args, 'sample_percent', None)
     limit = getattr(args, 'limit', None)
-    output_format = getattr(args, 'output_format', 'line')
-
+    output_format = getattr(args, 'output_format', None)
+    if output_format is None:
+        allowed_formats = ['line', 'json', 'csv', 'markdown', 'md-table', 'arrow', 'table', 'yaml', 'toml']
+        output_format = _detect_format_from_extension(args.output, allowed_formats, 'line')
 
     clean_items = not getattr(args, 'raw', False)
 

--- a/typostats.py
+++ b/typostats.py
@@ -82,6 +82,35 @@ def _should_enable_color(stream: Any) -> bool:
     return hasattr(stream, 'isatty') and stream.isatty()
 
 
+def _detect_format_from_extension(path: str, allowed: Sequence[str], default: str) -> str:
+    """
+    Detect the output format based on the file extension.
+    Returns the default if no match is found or no extension is present.
+    """
+    if not path or path == '-':
+        return default
+
+    ext = os.path.splitext(path)[1].lower().lstrip('.')
+    if not ext:
+        return default
+
+    # Map common extensions to tool-supported formats
+    mapping = {
+        'txt': 'arrow',
+        'json': 'json',
+        'csv': 'csv',
+        'yaml': 'yaml',
+        'yml': 'yaml',
+        'arrow': 'arrow',
+    }
+
+    detected = mapping.get(ext)
+    if detected in allowed:
+        return detected
+
+    return default
+
+
 def levenshtein_distance(s1: str, s2: str) -> int:
     """Calculate the number of character changes needed to turn one string into another."""
     if len(s1) < len(s2):
@@ -1025,8 +1054,8 @@ def main() -> None:
         '--format',
         choices=['arrow', 'yaml', 'json', 'csv'],
         metavar='FMT',
-        default='arrow',
-        help="The format of the report (default: arrow).",
+        default=None,
+        help="The format of the report. If not provided, it is automatically detected from the output file extension. (default: arrow).",
     )
     io_group.add_argument('-q', '--quiet', action='store_true', help="Suppress informational log output.")
 
@@ -1113,6 +1142,9 @@ def main() -> None:
     min_occurrences = args.min
     sort_by = args.sort
     output_format = args.format
+    if output_format is None:
+        allowed_formats = ['arrow', 'yaml', 'json', 'csv']
+        output_format = _detect_format_from_extension(output_file, allowed_formats, 'arrow')
     allow_1to2 = args.allow_1to2
     allow_2to1 = args.allow_2to1
     include_deletions = args.include_deletions


### PR DESCRIPTION
This PR implements automatic output format detection across the core tools in the diff2typo suite.

Key changes:
- Added `_detect_format_from_extension` helper to `multitool.py`, `typostats.py`, `gentypos.py`, and `diff2typo.py`.
- Updated `argparse` definitions to allow `None` as a default for format flags.
- Updated `main()` routines to resolve the format using the new helper when an output file is specified.
- Supported extensions include `.json`, `.csv`, `.yaml`, `.toml`, `.arrow`, and `.table`.
- Hardened `gentypos.py` to handle empty configuration files.
- Updated help strings to reflect the new automatic detection behavior.

All 742 existing tests passed. Manual verification confirmed that tools now correctly output JSON, CSV, and other formats based solely on the file extension provided via the output flag.

---
*PR created automatically by Jules for task [7519506193696422883](https://jules.google.com/task/7519506193696422883) started by @RainRat*