### PR TITLE
[DOCS] Add --git flag and example to diff2typo.md

### DIFF
--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -24,6 +24,7 @@ git diff | python diff2typo.py [OPTIONS]
 | Argument | Default | Description |
 | :--- | :--- | :--- |
 | `FILE` | standard input | One or more input Git diff files. Use `-` to read from standard input. |
+| `--git` | None | Fetch diff directly from Git. Optional arguments are passed to `git diff` (for example, `--git "HEAD~3"`). |
 | `--output`, `-o` | the screen | Path to the output file. Use `-` to print to the screen. |
 | `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), or `list` (typo only). |
 | `--mode` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
@@ -46,6 +47,12 @@ python diff2typo.py feature.diff --mode typos --format list
 
 ```bash
 python diff2typo.py recent_changes.diff --mode audit
+```
+
+**Fetch recent changes directly from Git:**
+
+```bash
+python diff2typo.py --git "HEAD~5" --output recent_typos.txt
 ```
 
 **Pipe directly from Git and save to a file:**


### PR DESCRIPTION
This PR improves the documentation for `diff2typo.py` by adding the missing `--git` flag to the options table and providing a clear usage example.

**Type:** Documentation
**What:** `docs/diff2typo.md`
**Why:** The `--git` flag is a key feature that allows users to process changes directly without manually creating a diff file. Documenting it makes the tool more accessible and easier to use.

The changes follow the "Plain English" and simplicity guidelines, using active voice and clear formatting.

---
*PR created automatically by Jules for task [15247436052171304822](https://jules.google.com/task/15247436052171304822) started by @RainRat*