### PR TITLE
[FEAT] Error type filtering for similarity-based modes

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2486,12 +2486,17 @@ def similarity_mode(
     quiet: bool = False,
     clean_items: bool = True,
     limit: int | None = None,
+    keyboard: bool = False,
+    transposition: bool = False,
 ) -> None:
     """
     Filters paired data based on the number of character changes between words.
+    Supports filtering by error type (keyboard slips or transpositions).
     """
     start_time = time.perf_counter()
     raw_pairs = _extract_pairs(input_files, quiet=quiet)
+
+    adj_keys = get_adjacent_keys() if keyboard else {}
 
     filtered_results = []
     stats_items = []
@@ -2515,6 +2520,16 @@ def similarity_mode(
             continue
         if max_dist is not None and dist > max_dist:
             continue
+
+        # Filter by error type if requested
+        if keyboard or transposition:
+            label = classify_typo(left, right, adj_keys)
+            if keyboard and label == "[K]":
+                pass
+            elif transposition and label == "[T]":
+                pass
+            else:
+                continue
 
         if show_dist:
             # Append number of changes to the right side for display
@@ -2555,9 +2570,12 @@ def near_duplicates_mode(
     quiet: bool = False,
     clean_items: bool = True,
     limit: int | None = None,
+    keyboard: bool = False,
+    transposition: bool = False,
 ) -> None:
     """
     Finds pairs of words in a single list that are similar to each other.
+    Supports filtering by error type (keyboard slips or transpositions).
     """
     start_time = time.perf_counter()
     raw_item_count = 0
@@ -2578,6 +2596,8 @@ def near_duplicates_mode(
     # Sort by length for optimized comparison
     unique_items.sort(key=len)
 
+    adj_keys = get_adjacent_keys() if keyboard else {}
+
     results = []
     stats_items = []
     num_items = len(unique_items)
@@ -2597,6 +2617,16 @@ def near_duplicates_mode(
             dist = levenshtein_distance(word_i, word_j)
 
             if min_dist <= dist <= max_dist:
+                # Filter by error type if requested
+                if keyboard or transposition:
+                    label = classify_typo(word_i, word_j, adj_keys)
+                    if keyboard and label == "[K]":
+                        pass
+                    elif transposition and label == "[T]":
+                        pass
+                    else:
+                        continue
+
                 if show_dist:
                     results.append((word_i, f"{word_j} (changes: {dist})"))
                 else:
@@ -2636,9 +2666,12 @@ def fuzzymatch_mode(
     quiet: bool = False,
     clean_items: bool = True,
     limit: int | None = None,
+    keyboard: bool = False,
+    transposition: bool = False,
 ) -> None:
     """
     Finds pairs of words between two lists that are similar to each other.
+    Supports filtering by error type (keyboard slips or transpositions).
     """
     start_time = time.perf_counter()
     raw_item_count = 0
@@ -2667,6 +2700,8 @@ def fuzzymatch_mode(
     # Sort list2 by length for optimized comparison
     list2_unique = sorted(set(list2_unique), key=len)
 
+    adj_keys = get_adjacent_keys() if keyboard else {}
+
     results = []
     stats_items = []
 
@@ -2685,6 +2720,16 @@ def fuzzymatch_mode(
             dist = levenshtein_distance(word_i, word_j)
 
             if min_dist <= dist <= max_dist:
+                # Filter by error type if requested
+                if keyboard or transposition:
+                    label = classify_typo(word_i, word_j, adj_keys)
+                    if keyboard and label == "[K]":
+                        pass
+                    elif transposition and label == "[T]":
+                        pass
+                    else:
+                        continue
+
                 if show_dist:
                     results.append((word_i, f"{word_j} (changes: {dist})"))
                 else:
@@ -2962,9 +3007,12 @@ def discovery_mode(
     limit: int | None = None,
     delimiter: str | None = None,
     smart: bool = False,
+    keyboard: bool = False,
+    transposition: bool = False,
 ) -> None:
     """
     Finds potential typos by comparing rare words to frequent words.
+    Supports filtering by error type (keyboard slips or transpositions).
     """
     start_time = time.perf_counter()
     word_counts = Counter()
@@ -2984,6 +3032,8 @@ def discovery_mode(
     rare_words = sorted([word for word, count in word_counts.items() if count <= rare_max])
     frequent_words = sorted([word for word, count in word_counts.items() if count >= freq_min], key=len)
 
+    adj_keys = get_adjacent_keys() if keyboard else {}
+
     results = []
     stats_items = []
     for rare in tqdm(rare_words, desc="Finding likely corrections", unit="word", disable=quiet):
@@ -2998,6 +3048,16 @@ def discovery_mode(
 
             dist = levenshtein_distance(rare, freq)
             if min_dist <= dist <= max_dist:
+                # Filter by error type if requested
+                if keyboard or transposition:
+                    label = classify_typo(rare, freq, adj_keys)
+                    if keyboard and label == "[K]":
+                        pass
+                    elif transposition and label == "[T]":
+                        pass
+                    else:
+                        continue
+
                 if show_dist:
                     results.append((rare, f"{freq} (changes: {dist})"))
                 else:
@@ -5160,21 +5220,21 @@ MODE_DETAILS = {
     },
     "similarity": {
         "summary": "Filters pairs by changes",
-        "description": "Filters pairs (typo -> correction) based on the number of character changes needed to turn one word into another. Use this to remove extra data or find specific types of typos.",
-        "example": "python multitool.py similarity typos.txt --max-dist 2 --show-dist",
-        "flags": "[--max-dist N] [--show-dist]",
+        "description": "Filters pairs (typo -> correction) based on the number of character changes needed to turn one word into another. Use this to remove extra data or find specific types of typos. Supports filtering by error type (keyboard slips or transpositions).",
+        "example": "python multitool.py similarity typos.txt --max-dist 2 --keyboard --show-dist",
+        "flags": "[--max-dist N] [--show-dist] [-k] [-t]",
     },
     "near_duplicates": {
         "summary": "Finds similar words in one list",
-        "description": "Finds pairs of words in your list that are very similar (only a few characters apart). Use this to find potential typos or unintended duplicates in a project.",
-        "example": "python multitool.py near_duplicates words.txt --max-dist 1 --show-dist",
-        "flags": "[--max-dist N] [--show-dist]",
+        "description": "Finds pairs of words in your list that are very similar (only a few characters apart). Use this to find potential typos or unintended duplicates in a project. Supports filtering by error type (keyboard slips or transpositions).",
+        "example": "python multitool.py near_duplicates words.txt --max-dist 1 --keyboard --show-dist",
+        "flags": "[--max-dist N] [--show-dist] [-k] [-t]",
     },
     "fuzzymatch": {
         "summary": "Finds similar words in two lists",
-        "description": "Finds words in your list that are similar to words in a second list (large dictionary). Use this to find likely corrections for typos. It defaults to a threshold of 1 character change.",
-        "example": "python multitool.py fuzzymatch typos.txt words.csv --max-dist 1 --show-dist",
-        "flags": "[FILE2] [--max-dist N] [--show-dist]",
+        "description": "Finds words in your list that are similar to words in a second list (large dictionary). Use this to find likely corrections for typos. It defaults to a threshold of 1 character change. Supports filtering by error type (keyboard slips or transpositions).",
+        "example": "python multitool.py fuzzymatch typos.txt words.csv --max-dist 1 --keyboard --show-dist",
+        "flags": "[FILE2] [--max-dist N] [--show-dist] [-k] [-t]",
     },
     "stats": {
         "summary": "Calculates stats for a list",
@@ -5190,9 +5250,9 @@ MODE_DETAILS = {
     },
     "discovery": {
         "summary": "Finds typos in rare words",
-        "description": "Automatically finds potential typos in a text by seeing rare words that are very similar to frequent words. It assumes that frequent words are likely correct and rare variations are likely typos. This is a powerful way to find errors without needing a dictionary.",
-        "example": "python multitool.py discovery code.py --smart --rare-max 2 --freq-min 10 --max-dist 1",
-        "flags": "[--rare-max N] [-S]",
+        "description": "Automatically finds potential typos in a text by seeing rare words that are very similar to frequent words. It assumes that frequent words are likely correct and rare variations are likely typos. This is a powerful way to find errors without needing a dictionary. Supports filtering by error type (keyboard slips or transpositions).",
+        "example": "python multitool.py discovery code.py --smart --rare-max 2 --freq-min 10 --keyboard",
+        "flags": "[--rare-max N] [-S] [-k] [-t]",
     },
     "casing": {
         "summary": "Finds inconsistent casing",
@@ -5894,6 +5954,16 @@ def _build_parser() -> argparse.ArgumentParser:
         action='store_true',
         help="Include the number of character changes in the output.",
     )
+    similarity_options.add_argument(
+        '-k', '--keyboard',
+        action='store_true',
+        help="Only include typos caused by hitting a nearby key on the keyboard.",
+    )
+    similarity_options.add_argument(
+        '-t', '--transposition',
+        action='store_true',
+        help="Only include typos caused by swapping two adjacent letters (for example, 'teh' -> 'the').",
+    )
     _add_common_mode_arguments(similarity_parser)
 
     near_duplicates_parser = subparsers.add_parser(
@@ -5920,6 +5990,16 @@ def _build_parser() -> argparse.ArgumentParser:
         '--show-dist',
         action='store_true',
         help="Include the number of character changes in the output.",
+    )
+    nd_options.add_argument(
+        '-k', '--keyboard',
+        action='store_true',
+        help="Only include words caused by hitting a nearby key on the keyboard.",
+    )
+    nd_options.add_argument(
+        '-t', '--transposition',
+        action='store_true',
+        help="Only include words caused by swapping two adjacent letters (for example, 'teh' -> 'the').",
     )
     _add_common_mode_arguments(near_duplicates_parser)
 
@@ -5953,6 +6033,16 @@ def _build_parser() -> argparse.ArgumentParser:
         '--show-dist',
         action='store_true',
         help="Include the number of character changes in the output.",
+    )
+    fm_options.add_argument(
+        '-k', '--keyboard',
+        action='store_true',
+        help="Only include words caused by hitting a nearby key on the keyboard.",
+    )
+    fm_options.add_argument(
+        '-t', '--transposition',
+        action='store_true',
+        help="Only include words caused by swapping two adjacent letters (for example, 'teh' -> 'the').",
     )
     _add_common_mode_arguments(fuzzymatch_parser)
 
@@ -6032,6 +6122,16 @@ def _build_parser() -> argparse.ArgumentParser:
         '-S', '--smart',
         action='store_true',
         help='Split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").',
+    )
+    discovery_options.add_argument(
+        '-k', '--keyboard',
+        action='store_true',
+        help="Only include potential typos caused by hitting a nearby key on the keyboard.",
+    )
+    discovery_options.add_argument(
+        '-t', '--transposition',
+        action='store_true',
+        help="Only include potential typos caused by swapping two adjacent letters (for example, 'teh' -> 'the').",
     )
     _add_common_mode_arguments(discovery_parser)
 
@@ -7186,6 +7286,8 @@ def main() -> None:
                 'max_dist': getattr(args, 'max_dist', None),
                 'show_dist': getattr(args, 'show_dist', False),
                 'output_format': output_format,
+                'keyboard': getattr(args, 'keyboard', False),
+                'transposition': getattr(args, 'transposition', False),
             },
         ),
         'near_duplicates': (
@@ -7196,6 +7298,8 @@ def main() -> None:
                 'max_dist': getattr(args, 'max_dist', 1),
                 'show_dist': getattr(args, 'show_dist', False),
                 'output_format': output_format,
+                'keyboard': getattr(args, 'keyboard', False),
+                'transposition': getattr(args, 'transposition', False),
             },
         ),
         'fuzzymatch': (
@@ -7207,6 +7311,8 @@ def main() -> None:
                 'max_dist': getattr(args, 'max_dist', 1),
                 'show_dist': getattr(args, 'show_dist', False),
                 'output_format': output_format,
+                'keyboard': getattr(args, 'keyboard', False),
+                'transposition': getattr(args, 'transposition', False),
             },
         ),
         'stats': (
@@ -7229,6 +7335,8 @@ def main() -> None:
                 'output_format': output_format,
                 'delimiter': delimiter,
                 'smart': getattr(args, 'smart', False),
+                'keyboard': getattr(args, 'keyboard', False),
+                'transposition': getattr(args, 'transposition', False),
             },
         ),
         'highlight': (

--- a/tests/test_multitool_similarity_filters.py
+++ b/tests/test_multitool_similarity_filters.py
@@ -1,0 +1,112 @@
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+import multitool
+import os
+
+class TestSimilarityFilters(unittest.TestCase):
+
+    def setUp(self):
+        # Create some test data
+        self.test_dir = "temp_test_similarity_filters"
+        os.makedirs(self.test_dir, exist_ok=True)
+
+        self.words_file = os.path.join(self.test_dir, "words.txt")
+        with open(self.words_file, "w") as f:
+            # teh -> the [T] dist 2
+            # thw -> the [K] dist 1
+            # thz -> the [R] dist 1 (z is not near e)
+            f.write("teh\n")
+            f.write("the\n")
+            f.write("thw\n")
+            f.write("thz\n")
+
+        self.pairs_file = os.path.join(self.test_dir, "pairs.txt")
+        with open(self.pairs_file, "w") as f:
+            f.write("teh -> the\n")
+            f.write("thw -> the\n")
+            f.write("thz -> the\n")
+
+        self.dict_file = os.path.join(self.test_dir, "dict.txt")
+        with open(self.dict_file, "w") as f:
+            f.write("the\n")
+            f.write("other\n")
+
+    def tearDown(self):
+        # Clean up
+        for f in [self.words_file, self.pairs_file, self.dict_file]:
+            if os.path.exists(f):
+                os.remove(f)
+        if os.path.exists(self.test_dir):
+            os.rmdir(self.test_dir)
+
+    def run_multitool(self, args):
+        with patch('sys.stdout', new=StringIO()) as fake_out, \
+             patch('sys.stderr', new=StringIO()) as fake_err, \
+             patch('sys.argv', ['multitool.py'] + args):
+            try:
+                multitool.main()
+            except SystemExit as e:
+                if e.code != 0:
+                    # In case of error, show what happened
+                    sys.stderr.write(fake_err.getvalue())
+                    raise
+            return fake_out.getvalue(), fake_err.getvalue()
+
+    def test_similarity_keyboard(self):
+        # thw -> the is Keyboard
+        # teh -> the is Transposition
+        # thz -> the is Replacement (non-adjacent)
+        out, _ = self.run_multitool(['similarity', self.pairs_file, '--keyboard'])
+        self.assertIn("thw -> the", out)
+        self.assertNotIn("teh -> the", out)
+        self.assertNotIn("thz -> the", out)
+
+    def test_similarity_transposition(self):
+        out, _ = self.run_multitool(['similarity', self.pairs_file, '--transposition'])
+        self.assertIn("teh -> the", out)
+        self.assertNotIn("thw -> the", out)
+        self.assertNotIn("thz -> the", out)
+
+    def test_near_duplicates_keyboard(self):
+        # the and thw are near duplicates (Keyboard)
+        # the and thz are near duplicates (Replacement, dist 1)
+        # the and teh are near duplicates (Transposition, dist 2)
+        # near_duplicates default max-dist is 1
+        out, _ = self.run_multitool(['near_duplicates', self.words_file, '--keyboard', '--max-dist', '1'])
+        self.assertIn("the", out)
+        self.assertIn("thw", out)
+        self.assertNotIn("thz", out)
+        self.assertNotIn("teh", out)
+
+    def test_fuzzymatch_transposition(self):
+        # list1: teh, thw, thz
+        # list2: the
+        # teh -> the is transposition (dist 2)
+        out, _ = self.run_multitool(['fuzzymatch', self.words_file, '--file2', self.dict_file, '--transposition', '--max-dist', '2'])
+        self.assertIn("teh", out)
+        self.assertIn("the", out)
+        self.assertNotIn("thw", out)
+        self.assertNotIn("thz", out)
+
+    def test_discovery_keyboard(self):
+        discovery_file = os.path.join(self.test_dir, "discovery.txt")
+        with open(discovery_file, "w") as f:
+            for _ in range(10):
+                f.write("the\n")
+            f.write("thw\n")
+            f.write("thz\n")
+            f.write("teh\n")
+
+        out, _ = self.run_multitool(['discovery', discovery_file, '--keyboard', '--freq-min', '5', '--rare-max', '1'])
+        self.assertIn("thw", out)
+        self.assertIn("the", out)
+        self.assertNotIn("thz", out)
+        self.assertNotIn("teh", out)
+
+        if os.path.exists(discovery_file):
+            os.remove(discovery_file)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces error-type filtering for all similarity-based detection modes in `multitool.py`.

### What:
- Added `--keyboard` (`-k`) and `--transposition` (`-t`) flags to the following modes:
  - `similarity`: Filters paired data.
  - `near_duplicates`: Finds similar words within a single list.
  - `fuzzymatch`: Finds similar words between two lists.
  - `discovery`: Finds potential typos by comparing rare words to frequent ones.
- Leverages the existing `classify_typo` and `get_adjacent_keys` helpers to identify specific error patterns.
- Updated the CLI help system and internal `MODE_DETAILS` documentation.

### Why:
I noticed that while the tool can calculate statistics on typo types (using `stats` or `classify` modes), users had no way to *act* on this classification during the discovery or matching phases. By adding these filters, users can now narrow down thousands of similar-word matches to only those most likely to be mechanical typing errors (e.g., hitting 'w' instead of 'e' or swapping 'teh' for 'the'). This creates immediate value by reducing noise in large-scale typo analysis.

### Changes:
- **multitool.py**: 
  - Updated `similarity_mode`, `near_duplicates_mode`, `fuzzymatch_mode`, and `discovery_mode` signatures and logic.
  - Updated `_build_parser` to expose the new flags.
  - Updated `MODE_DETAILS` for user documentation.
  - Updated `handler_map` to pass the new arguments.
- **tests/test_multitool_similarity_filters.py**: 
  - New test suite covering all four modified modes and both new filter flags.

---
*PR created automatically by Jules for task [9127820428084864837](https://jules.google.com/task/9127820428084864837) started by @RainRat*