### PR TITLE
[DOCS] Add missing delimiter flag to CSV mode help in multitool.py

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -5125,9 +5125,9 @@ MODE_DETAILS = {
     },
     "csv": {
         "summary": "Extracts columns from CSV",
-        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, or --column to pick specific numbers.",
-        "example": "python multitool.py csv typos.csv --column 2 -o corrections.txt",
-        "flags": "[--first-column] [-c N]",
+        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, --column to pick specific numbers, or --delimiter to use a custom separator.",
+        "example": "python multitool.py csv typos.csv --column 2 --delimiter ';' -o corrections.txt",
+        "flags": "[--first-column] [-c N] [-d DELIM]",
     },
     "markdown": {
         "summary": "Extracts Markdown list items",


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** Updated the `csv` mode entry in the `MODE_DETAILS` dictionary within `multitool.py`.
* **Why:** The built-in help text for the `csv` mode was missing information about the `--delimiter` (or `-d`) flag, which is a key feature for handling non-comma-separated files. This change makes the tool easier to use by documenting all its primary options in the CLI help.

---
*PR created automatically by Jules for task [3031361692926373219](https://jules.google.com/task/3031361692926373219) started by @RainRat*