### PR TITLE
[UI/UX] Enhance detailed mode help with categorized flag descriptions

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -5516,14 +5516,14 @@ def show_mode_help(mode_name: str | None, parser: argparse.ArgumentParser) -> No
         label_color = f"{BLUE}{BOLD}"
         block = [
             divider,
-            f"{label_color}{'MODE:':<13}{RESET}{GREEN}{mode_name.upper()}{RESET}",
+            f"{label_color}{'MODE:':<15}{RESET}{GREEN}{mode_name.upper()}{RESET}",
             divider,
-            f"{label_color}{'SUMMARY:':<13}{RESET}{details['summary']}",
+            f"{label_color}{'SUMMARY:':<15}{RESET}{details['summary']}",
         ]
 
         if details.get("description"):
             desc = details['description']
-            block.append(f"{label_color}{'DESCRIPTION:':<13}{RESET}{desc}")
+            block.append(f"{label_color}{'DESCRIPTION:':<15}{RESET}{desc}")
 
         flags_str = details.get("flags", "[FILES...]")
         all_tokens = flags_str.split()
@@ -5546,22 +5546,67 @@ def show_mode_help(mode_name: str | None, parser: argparse.ArgumentParser) -> No
         pos_args_str = (" " + " ".join(pos_args)) if pos_args else ""
         usage_line = f"python {parser.prog} {mode_name}{pos_args_str} [FILES...] [OPTIONS]"
 
-        block.append(f"\n{label_color}{'USAGE:':<13}{RESET}{BOLD}{usage_line}{RESET}")
+        block.append(f"\n{label_color}{'USAGE:':<15}{RESET}{BOLD}{usage_line}{RESET}")
 
-        if details.get("flags"):
-            # Filter out positional arguments and generic FILES labels from the options display
-            filtered_tokens = []
-            for token in all_tokens:
-                if token in pos_args or token in ("[FILES...]", "FILES..."):
-                    continue
-                filtered_tokens.append(token)
+        # Extract detailed option information from the subparser
+        subparser = None
+        for action in parser._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                subparser = action.choices.get(mode_name)
+                break
 
-            if filtered_tokens:
-                options_str = " ".join(filtered_tokens)
-                block.append(f"{label_color}{'OPTIONS:':<13}{RESET}{YELLOW}{options_str}{RESET}")
+        if subparser:
+            # We want to show mode-specific options first, then general processing, then I/O
+            # Sort groups: Mode-specific first, then general ones
+            ordered_groups = []
+            # First pass: Mode-specific groups
+            for group in subparser._action_groups:
+                if group.title and 'OPTIONS' in group.title and 'INPUT/OUTPUT' not in group.title and 'PROCESSING' not in group.title:
+                    ordered_groups.append(group)
+            # Second pass: PROCESSING OPTIONS
+            for group in subparser._action_groups:
+                if group.title == 'PROCESSING OPTIONS':
+                    ordered_groups.append(group)
+            # Third pass: INPUT/OUTPUT OPTIONS
+            for group in subparser._action_groups:
+                if group.title == 'INPUT/OUTPUT OPTIONS':
+                    ordered_groups.append(group)
+
+            for group in ordered_groups:
+                group_actions = []
+                for action in group._group_actions:
+                    if action.help == argparse.SUPPRESS:
+                        continue
+
+                    # Format flags and metavar
+                    option_flags = ", ".join(action.option_strings)
+                    metavar = ""
+                    if action.metavar:
+                        metavar = f" {action.metavar}"
+                    elif action.choices:
+                        metavar = f" {{{','.join(map(str, action.choices))}}}"
+
+                    option_help = action.help or ""
+                    group_actions.append((option_flags + metavar, option_help))
+
+                if group_actions:
+                    block.append(f"\n{label_color}{group.title + ':':<15}{RESET}")
+
+                    flag_col_width = 30
+                    help_indent_width = 35 # 2 (initial indent) + 30 (flag_col) + 3 (gap)
+                    help_indent = ' ' * help_indent_width
+
+                    for flags, help_text in group_actions:
+                        wrapped_help = help_text.replace('\n', '\n' + help_indent)
+
+                        if len(flags) > flag_col_width:
+                            block.append(f"  {YELLOW}{flags}{RESET}")
+                            block.append(f"{help_indent}{wrapped_help}")
+                        else:
+                            block.append(f"  {YELLOW}{flags:<{flag_col_width}}{RESET}   {wrapped_help}")
 
         if details.get("example"):
-            block.append(f"\n{label_color}{'EXAMPLE:':<13}{RESET}")
+            block.append(f"\n{label_color}{'EXAMPLE:':<15}{RESET}")
             block.append(f"  {GREEN}{details['example']}{RESET}")
 
         block.append(divider)

--- a/tests/test_coverage_completion_final.py
+++ b/tests/test_coverage_completion_final.py
@@ -194,7 +194,7 @@ def test_mode_help_action_usage_formatting(capsys):
     output = captured.err + captured.out
     # Strip ANSI codes for comparison
     clean_output = re.sub(r'\x1b\[[0-9;]*m', '', output)
-    assert "USAGE:       python multitool.py search [QUERY] [FILES...] [OPTIONS]" in clean_output
+    assert "USAGE:         python multitool.py search [QUERY] [FILES...] [OPTIONS]" in clean_output
 
 def test_main_search_fallback(tmp_path):
     """Cover multitool.py lines 5673-5674: main() search mode fallbacks."""


### PR DESCRIPTION
### Context
CLI (Command Line Interface)

### Problem
The `multitool.py help <mode>` command previously provided a minimal summary and usage line, omitting descriptions for the available flags. Users had to rely on the standard `--help` output, which lacked the thematic styling of the `help` subcommand and did not clearly distinguish between mode-specific and global options.

### Solution
Enhanced the `show_mode_help` function to dynamically extract option details directly from the `argparse` subparser groups. 

**Key Improvements:**
1.  **Logical Grouping:** Options are now categorized into mode-specific sections (e.g., `SEARCH OPTIONS`), `PROCESSING OPTIONS`, and `INPUT/OUTPUT OPTIONS`, allowing users to quickly identify relevant flags.
2.  **Tabular Alignment:** Implemented a structured layout where labels are padded to 15 characters, flags are aligned in a 30-character column, and help text is indented to column 35.
3.  **Color & Style:** Maintained the tool's thematic style using `BLUE` for headers/labels and `YELLOW` for flags, improving scanning speed.
4.  **Graceful Wrapping:** Long flag strings (like those with multiple choices) or multi-line descriptions are handled automatically with clean indentation to prevent layout breakage.
5.  **Test Synchronization:** Updated the existing test suite to ensure compatibility with the refined `USAGE` line spacing.

### Impact
This change provides a "best of both worlds" help experience: the high-level readability of the custom help system combined with the technical depth of the standard `argparse` documentation.

---
*PR created automatically by Jules for task [11707798940940241853](https://jules.google.com/task/11707798940940241853) started by @RainRat*