### PR TITLE
[DOCS] Standardize Multitool terminology and category headers

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -23,7 +23,7 @@ Most modes default to reading from **standard input** if you do not specify an i
 
 Multitool operates in different "modes," each designed for a specific task.
 
-### 1. GETTING DATA
+### 1. GET DATA
 
 These modes help you pull specific data out of a messy file.
 
@@ -89,7 +89,7 @@ These modes help you pull specific data out of a messy file.
   - **What it does:** Finds and gets text that matches a Python regular expression pattern. Unlike other modes, it **keeps the original text** (it does not convert to lowercase or remove punctuation) by default.
   - **Example:** `python multitool.py regex inputs.txt --pattern 'user_\w+'`
 
-### 2. CHANGING DATA
+### 2. CHANGE DATA
 
 These modes help you transform or combine your data.
 
@@ -192,7 +192,7 @@ These modes help you transform or combine your data.
   - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py pairs typos.json --output-format csv`
 
-### 3. CHECKING DATA
+### 3. CHECK & ANALYZE
 
 These modes help you analyze your data.
 
@@ -221,7 +221,7 @@ These modes help you analyze your data.
     - `-l`, `--lines`: Count frequencies of raw lines instead of individual words.
     - `-c`, `--chars`: Count frequencies of individual characters.
     - `-B`, `--by-file`: Count how many files contain each item instead of total matches. This is useful for finding words that are common across your entire project.
-    - **Auditing:** Use the `--mapping` flag or `--add` to count matches of specific typos across your files.
+    - **Checking:** Use the `--mapping` flag or `--add` to count matches of specific typos across your files.
   - **Visual Report:** Use `--output-format arrow` to generate a rich visual report. This includes an **ANALYSIS SUMMARY** dashboard with metrics like retention rate, an aligned frequency table, and high-resolution bar charts.
   - **Supported Formats:** `arrow`, `json`, `csv`, `markdown`, `md-table`, and `line`.
   - **Note:** This mode has built-in sorting; the `--process-output` flag is not needed.

--- a/multitool.py
+++ b/multitool.py
@@ -5348,7 +5348,7 @@ MODE_DETAILS = {
         "flags": "[QUERY] [-Q QUERY] [FILES...] [-S] [-k] [-t] [-n] [-B N] [-A N] [-C N]",
     },
     "scan": {
-        "summary": "Audits project for known typos",
+        "summary": "Scans project for known typos",
         "description": "Like a batch version of the 'search' mode. It searches for every word in a mapping file or provided via --add and reports all matches with filename, line number, and highlighting. It also supports context lines.",
         "example": "python multitool.py scan . --add teh:the --smart -A 1",
         "flags": "[MAPPING] [-s MAPPING] [FILES...] [-a K:V] [-S] [-B N] [-A N] [-C N]",
@@ -5402,8 +5402,8 @@ def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
         "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "toml", "line", "words", "ngrams", "regex"],
-        "CHANGING DATA": ["combine", "unique", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
-        "AUDIT & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
+        "CHANGE DATA": ["combine", "unique", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
+        "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
 
     use_color = _should_enable_color(sys.stdout)

--- a/tests/test_multitool_help.py
+++ b/tests/test_multitool_help.py
@@ -19,8 +19,8 @@ def test_mode_help_all_implicit(monkeypatch, capsys):
     # Check for presence of summary table header and content
     assert "Available Modes:" in output
     assert "GET DATA" in output
-    assert "CHANGING DATA" in output
-    assert "AUDIT & ANALYZE" in output
+    assert "CHANGE DATA" in output
+    assert "CHECK & ANALYZE" in output
     assert "arrow" in output
     assert "csv" in output
     # In table view, we print "Summary: ..." as just the text column


### PR DESCRIPTION
**PR Title:** [DOCS] Standardize terminology and use active voice in Multitool documentation

**Description:**
* **Type:** Documentation and Internal Help
* **What:** Refined category names, mode summaries, and section headers in `multitool.py`, `docs/multitool.md`, and the corresponding test suite.
* **Why:** This change improves accessibility and consistency by using direct, active-voice commands (e.g., "GET DATA", "CHANGE DATA") and removing formal business jargon like "Audit" in favor of simpler terms like "Scan" or "Check". This ensures the documentation remains easy to understand for an international audience and perfectly matches the tool's runtime help output.

---
*PR created automatically by Jules for task [15555726707527054952](https://jules.google.com/task/15555726707527054952) started by @RainRat*