### PR TITLE
[FEAT] Support typo extraction from file renames and copies

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -6,7 +6,7 @@ Purpose:
     This helps ensure that typos you find are caught in future changes.
 
 Features:
-    - Finds typo corrections in Git diffs.
+    - Finds typo corrections in Git diffs and file renames or copies.
     - Splits compound words based on spaces, underscores, and capital letters.
     - Skips corrections where the "before" word is in the large dictionary.
     - Works with the `typos` tool to avoid duplicate entries.
@@ -311,6 +311,20 @@ def find_typos(diff_text: str, min_length: int = 2, max_dist: Optional[int] = No
     additions: List[str] = []
 
     for line in lines:
+        # Handle file renames and copies
+        if line.startswith('rename from ') or line.startswith('copy from '):
+            path = line.split(' from ', 1)[1].strip()
+            removals.append(path)
+            continue
+        if line.startswith('rename to ') or line.startswith('copy to '):
+            path = line.split(' to ', 1)[1].strip()
+            additions.append(path)
+            # Renames/copies are typically paired immediately in the diff header
+            typos.extend(process_diff_block(removals, additions, min_length, max_dist))
+            removals = []
+            additions = []
+            continue
+
         if line.startswith('---') or line.startswith('+++'):
             continue
         if line.startswith('-'):
@@ -613,7 +627,7 @@ def main():
 
     # Setup command-line argument parsing
     parser = argparse.ArgumentParser(
-        description=f"{BOLD}Process a Git diff to find typos for the `typos` tool.{RESET}",
+        description=f"{BOLD}Process a Git diff (including file renames) to find typos for the `typos` tool.{RESET}",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=f"""{BLUE}Examples:{RESET}
   {GREEN}python diff2typo.py diff.txt --output typos.txt --mode typos{RESET}

--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -14,7 +14,7 @@ git diff | python diff2typo.py [OPTIONS]
 
 ## Core Features
 
-1. **Find typos in diffs:** Reads Git diff files or data sent directly from other commands to find words you have corrected.
+1. **Find typos in diffs:** Reads Git diff files or data sent directly from other commands to find words you have corrected. This includes finding typos corrected by renaming or copying files.
 2. **Variable Support:** Automatically splits compound words like `camelCase` and `snake_case` to find typos hidden inside variable names.
 3. **Smart Filtering:** Uses a large dictionary of correct words and a list of "allowed" words to prevent the tool from reporting correct words as typos.
 4. **Integration:** Can check your findings against the external `typos` tool to ensure your list only contains mistakes.

--- a/tests/test_diff2typo.py
+++ b/tests/test_diff2typo.py
@@ -464,6 +464,47 @@ def test_filter_known_typos_cleans_temp_directory(monkeypatch, tmp_path):
     assert result == candidates
     assert created_paths and not created_paths[0].exists()
 
+def test_find_typos_rename_and_copy():
+    # Test rename
+    diff_rename = (
+        "diff --git a/registre.py b/register.py\n"
+        "similarity index 100%\n"
+        "rename from registre.py\n"
+        "rename to register.py\n"
+    )
+    assert diff2typo.find_typos(diff_rename) == ['registre -> register']
+
+    # Test copy
+    diff_copy = (
+        "diff --git a/src/util.py b/src/utils.py\n"
+        "similarity index 100%\n"
+        "copy from src/util.py\n"
+        "copy to src/utils.py\n"
+    )
+    assert diff2typo.find_typos(diff_copy) == ['util -> utils']
+
+    # Test nested paths
+    diff_nested = (
+        "rename from project/modul/file.py\n"
+        "rename to project/module/file.py\n"
+    )
+    assert diff2typo.find_typos(diff_nested) == ['modul -> module']
+
+    # Test combined content and rename
+    diff_combined = (
+        "rename from old.py\n"
+        "rename to new.py\n"
+        "--- a/old.py\n"
+        "+++ b/new.py\n"
+        "@@\n"
+        "-content typo\n"
+        "+content type\n"
+    )
+    results = diff2typo.find_typos(diff_combined)
+    assert 'old -> new' in results
+    assert 'typo -> type' in results
+
+
 def test_main_default_values_preserved(monkeypatch):
     """Verify that default values are correctly preserved when no flags are passed."""
     monkeypatch.setattr(sys, 'argv', ['diff2typo.py'])


### PR DESCRIPTION
This PR enhances `diff2typo.py` to automatically identify typos corrected by renaming or copying files or directories.

### Changes:
- **`diff2typo.py`**: Updated `find_typos` to detect `rename from`, `rename to`, `copy from`, and `copy to` lines in Git diffs. These paths are now processed using the tool's existing subword-splitting and sequence alignment logic to extract typo candidates.
- **`docs/diff2typo.md`**: Updated documentation to include support for renames and copies in the list of core features.
- **`tests/test_diff2typo.py`**: Added `test_find_typos_rename_and_copy` to verify functionality for standard renames, file copies, nested paths, and combined metadata/content diffs.

### Why:
This addresses a "missing piece" in the tool's symmetry. Users frequently fix typos in filenames alongside code corrections, but these were previously ignored by the suite. Filename typos are high-visibility errors that often impact project structure and imports, making their detection particularly valuable.

---
*PR created automatically by Jules for task [17675653839598963219](https://jules.google.com/task/17675653839598963219) started by @RainRat*