### PR TITLE
Fix TypeError when tqdm is missing in typostats.py

### DIFF
--- a/typostats.py
+++ b/typostats.py
@@ -522,7 +522,7 @@ def _extract_pairs(input_files: Sequence[str], quiet: bool = False) -> Iterable[
 
         # Text formats
         lines = _read_file_lines_robust(input_file)
-        if not quiet:
+        if not quiet and _TQDM_AVAILABLE:
             iterator = tqdm(lines, desc=f'Processing {input_file}', unit=' lines', leave=False)
         else:
             iterator = lines


### PR DESCRIPTION
* **What:** Added a check for `_TQDM_AVAILABLE` in the `_extract_pairs` function of `typostats.py`.
* **Why:** This prevents a `TypeError` (attempting to call `None`) in environments where the optional `tqdm` dependency is not installed. The tool now gracefully falls back to a standard iterator. No breaking changes were introduced.

---
*PR created automatically by Jules for task [17130723815889514313](https://jules.google.com/task/17130723815889514313) started by @RainRat*