### PR TITLE
[DOCS] Standardize and simplify Multitool help text and documentation

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -73,7 +73,7 @@ These modes help you pull specific data out of a messy file.
   - **Example:** `python multitool.py toml pyproject.toml --key tool.poetry.dependencies`
 
 - **`line`**
-  - **What it does:** Reads a file line by line. Use this to simply clean or filter a text file without special getting logic.
+  - **What it does:** Extracts every line from a file. Use this to simply clean or filter a text file without special getting logic.
   - **Example:** `python multitool.py line raw_words.txt`
 
 - **`words`**
@@ -86,7 +86,7 @@ These modes help you pull specific data out of a messy file.
   - **Example:** `python multitool.py ngrams report.txt -n 2 --smart`
 
 - **`regex`**
-  - **What it does:** Finds and gets text that matches a Python regular expression pattern. Unlike other modes, it **keeps the original text** (it does not convert to lowercase or remove punctuation) by default.
+  - **What it does:** Extracts text matching a pattern. Finds and gets all text that matches a Python regular expression pattern. Unlike other modes, it **keeps the original text** (it does not convert to lowercase or remove punctuation) by default.
   - **Example:** `python multitool.py regex inputs.txt --pattern 'user_\w+'`
 
 ### 2. CHANGE DATA
@@ -120,7 +120,7 @@ These modes help you transform or combine your data.
   - **Example:** `python multitool.py rename src/ --mapping corrections.csv --in-place`
 
 - **`diff`**
-  - **What it does:** Finds added, removed, and changed items between two files. It can compare simple lists of words or (with the `--pairs` flag) find changes in typo-correction mappings.
+  - **What it does:** Shows differences between files. Finds added, removed, and changed items between two files. It can compare simple lists of words or (with the `--pairs` flag) find changes in typo-correction mappings.
   - **Supported Formats:** Color-coded terminal output (default) and structured JSON output.
   - **Example:** `python multitool.py diff old_list.txt new_list.txt`
   - **Pairs Example:** `python multitool.py diff old_typos.csv new_typos.csv --pairs`
@@ -197,7 +197,7 @@ These modes help you transform or combine your data.
 These modes help you analyze your data.
 
 - **`check`**
-  - **What it does:** Finds words that appear as both a typo *and* a correction. This is useful for spotting errors in your typo database (loops).
+  - **What it does:** Finds words used as both typos and fixes. Checks for words that appear in both the typo and correction columns of a file. This is useful for spotting errors in your typo database (loops).
   - **Example:** `python multitool.py check mappings.csv`
 
 - **`classify`**
@@ -252,7 +252,7 @@ These modes help you analyze your data.
   - **Example:** `python multitool.py similarity typos.txt --max-dist 2 --show-dist`
 
 - **`stats`**
-  - **What it does:** Shows a high-level summary of your dataset. It reports counts, unique items, and statistics. If the `--pairs` flag is used, it additionally analyzes the file as paired data (typos/corrections) and reports conflicts (one typo to multiple corrections), overlaps (words that are both typos and corrections), and character change statistics.
+  - **What it does:** Shows statistics for a list. Provides a detailed overview of your dataset. It reports counts, unique items, and statistics. If the `--pairs` flag is used, it additionally analyzes the file as paired data (typos/corrections) and reports conflicts (one typo to multiple corrections), overlaps (words that are both typos and corrections), and character change statistics.
   - **Supported Formats:** `json`, `yaml`, `markdown`, `md-table`, and `line` (human-readable).
   - **Example:** `python multitool.py stats typos.csv --pairs`
 

--- a/multitool.py
+++ b/multitool.py
@@ -4914,7 +4914,7 @@ def _add_common_mode_arguments(
         type=str,
         nargs='+',
         metavar='FILE',
-        help="Path(s) to the input file(s) (legacy flag, supports multiple).",
+        help="Path(s) to the input file(s). Supports multiple files.",
     )
     io_group.add_argument(
         '-o', '--output',
@@ -5203,7 +5203,7 @@ MODE_DETAILS = {
         "flags": "[-k KEY]",
     },
     "line": {
-        "summary": "Reads a file line by line",
+        "summary": "Extracts every line from a file",
         "description": "Reads every line from a file, cleans the text, and writes it to the output. Useful for simple cleaning and filtering.",
         "example": "python multitool.py line raw_words.txt --output filtered.txt",
         "flags": "",
@@ -5233,7 +5233,7 @@ MODE_DETAILS = {
         "flags": "[FILE2]",
     },
     "check": {
-        "summary": "Finds words that are typos & fixes",
+        "summary": "Finds words used as both typos and fixes",
         "description": "Checks for words that appear in both the typo and correction columns of a file. Use this to find errors in your typo lists.",
         "example": "python multitool.py check typos.csv --output duplicates.txt",
         "flags": "",
@@ -5251,7 +5251,7 @@ MODE_DETAILS = {
         "flags": "[-n N|--percent P]",
     },
     "regex": {
-        "summary": "Finds text matching a pattern",
+        "summary": "Extracts text matching a pattern",
         "description": "Finds and gets all text that matches a Python regular expression pattern.",
         "example": "python multitool.py regex inputs.txt --pattern 'user_\\w+' --output users.txt",
         "flags": "[-r PATTERN]",
@@ -5305,7 +5305,7 @@ MODE_DETAILS = {
         "flags": "[FILE2] [--max-dist N] [-k] [-t] [--show-dist]",
     },
     "stats": {
-        "summary": "Calculates stats for a list",
+        "summary": "Shows statistics for a list",
         "description": "Provides a detailed overview of your dataset. It reports counts, unique items, statistics, and (optionally) paired data stats like conflicts, overlaps, and the number of changes between words.",
         "example": "python multitool.py stats typos.csv --pairs --output-format json",
         "flags": "[-p]",
@@ -5383,7 +5383,7 @@ MODE_DETAILS = {
         "flags": "[MAPPING] [-s MAPPING] [FILES...] [-a K:V] [--in-place] [--dry-run] [--smart-case]",
     },
     "diff": {
-        "summary": "Finds differences between files",
+        "summary": "Shows differences between files",
         "description": "Finds differences between two files or lists. It can track simple word additions/removals or (with --pairs) find changed corrections for existing typos. Color-coded output highlights what is added (+), what is removed (-), and what changed (~).",
         "example": "python multitool.py diff old_typos.csv new_typos.csv --pairs --output-format json",
         "flags": "[FILE2] [-p]",


### PR DESCRIPTION
**PR Title:** [DOCS] Standardize and simplify Multitool help text and documentation

**Description:**
* **Type:** Documentation / Internal Help
* **What:** Updated `MODE_DETAILS` in `multitool.py` and the corresponding sections in `docs/multitool.md`. Simplified the `-i/--input` help string in `multitool.py`.
* **Why:** This change standardizes terminology across all data extraction modes (using "Extracts"), removes technical jargon like "legacy flag", and ensures the command-line help matches the external documentation for better accessibility and clarity.

---
*PR created automatically by Jules for task [10548833378378385629](https://jules.google.com/task/10548833378378385629) started by @RainRat*