### PR TITLE
[FEAT] Add --version flag to all core tools

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -13,6 +13,9 @@ from typing import List, Dict, Any, Optional
 from tqdm import tqdm
 
 
+VERSION = "1.1.0"
+
+
 # ANSI Color Codes
 BLUE = "\033[1;34m"
 GREEN = "\033[1;32m"
@@ -160,6 +163,12 @@ def parse_arguments() -> argparse.Namespace:
   {GREEN}python cmdrunner.py config.yaml{RESET}
   {GREEN}python cmdrunner.py my_setup.yaml --dry-run{RESET}
 """,
+    )
+
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {VERSION}'
     )
 
     # Configuration Group

--- a/diff2typo.py
+++ b/diff2typo.py
@@ -47,6 +47,9 @@ from typing import Dict, Iterable, List, Optional, Sequence, Set, TextIO
 from tqdm import tqdm
 
 
+VERSION = "1.1.0"
+
+
 # ANSI Color Codes
 BLUE = "\033[1;34m"
 GREEN = "\033[1;32m"
@@ -633,6 +636,12 @@ def main():
   {GREEN}python diff2typo.py diff.txt --output typos.txt --mode typos{RESET}
   {GREEN}git diff | python diff2typo.py -o found.txt -f csv{RESET}
 """,
+    )
+
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {VERSION}'
     )
 
     # Input/Output Options

--- a/gentypos.py
+++ b/gentypos.py
@@ -38,6 +38,9 @@ from typing import Any, Iterable, Mapping, MutableMapping, Sequence, Set, Option
 from tqdm import tqdm  # For progress bars; install via `pip install tqdm`
 
 
+VERSION = "1.1.0"
+
+
 # ANSI Color Codes
 BLUE = "\033[1;34m"
 GREEN = "\033[1;32m"
@@ -822,6 +825,12 @@ def main() -> None:
   {GREEN}python gentypos.py --config my_config.yaml --output typos.txt{RESET}
   {GREEN}python gentypos.py word1 word2 --format csv --no-filter{RESET}
 """,
+    )
+
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {VERSION}'
     )
 
     # Input/Output Options

--- a/multitool.py
+++ b/multitool.py
@@ -16,6 +16,8 @@ from tqdm import tqdm
 import logging
 import json
 
+VERSION = "1.1.0"
+
 try:
     import ahocorasick
     _AHOCORASICK_AVAILABLE = True
@@ -5656,6 +5658,11 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="mode",
         action=ModeHelpAction,
         help="Display extended documentation for a specific mode or all modes.",
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {VERSION}'
     )
 
     # Input/Output Group

--- a/typostats.py
+++ b/typostats.py
@@ -9,6 +9,8 @@ import re
 import time
 from typing import Any, Iterable, List, Mapping, Sequence, Tuple
 
+VERSION = "1.1.0"
+
 try:
     from tqdm import tqdm
     _TQDM_AVAILABLE = True
@@ -1075,6 +1077,12 @@ def main() -> None:
   {GREEN}python typostats.py typos.txt -k -n 20{RESET}       # Find top 20 keyboard slips
   {GREEN}python typostats.py typos.txt -a{RESET}             # Run all analysis modes at once
 """,
+    )
+
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {VERSION}'
     )
 
     # Input/Output Group


### PR DESCRIPTION
### PR Title: [FEAT] Add --version flag to all core tools

### Description:
* **What:** Implemented a standardized `--version` flag across all major CLI entry points (`cmdrunner.py`, `diff2typo.py`, `gentypos.py`, `multitool.py`, and `typostats.py`). Each tool now defines a `VERSION = "1.1.0"` constant and uses `argparse`'s built-in `version` action to report its name and version when invoked with `--version`.
* **Why:** I noticed that while the tools provide extensive help documentation, they lacked a standard way for users to check the installed version. Adding a `--version` flag is a standard practice for professional CLI tools, improving convenience and supportability by allowing users to easily verify their environment.

### Changes:

#### multitool.py
```python
VERSION = "1.1.0"
...
    parser.add_argument(
        '--version',
        action='version',
        version=f'%(prog)s {VERSION}'
    )
```

#### diff2typo.py
```python
VERSION = "1.1.0"
...
    parser.add_argument(
        '--version',
        action='version',
        version=f'%(prog)s {VERSION}'
    )
```

#### typostats.py
```python
VERSION = "1.1.0"
...
    parser.add_argument(
        '--version',
        action='version',
        version=f'%(prog)s {VERSION}'
    )
```

#### gentypos.py
```python
VERSION = "1.1.0"
...
    parser.add_argument(
        '--version',
        action='version',
        version=f'%(prog)s {VERSION}'
    )
```

#### cmdrunner.py
```python
VERSION = "1.1.0"
...
    parser.add_argument(
        '--version',
        action='version',
        version=f'%(prog)s {VERSION}'
    )
```

---
*PR created automatically by Jules for task [14726783130445635724](https://jules.google.com/task/14726783130445635724) started by @RainRat*