### PR TITLE
Consolidate variation counting logic in `standardize_mode`

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -4226,20 +4226,16 @@ def standardize_mode(
         for line in tqdm(file_lines, desc=f"Analyzing {input_file}", unit=" lines", disable=quiet):
             parts = pattern.findall(line)
             for part in parts:
-                # Full word analysis
-                norm = filter_to_letters(part) if clean_items else part.lower()
-                if norm:
-                    if min_length <= len(norm) <= max_length:
-                        variation_counts[norm][part] += 1
-
-                # Sub-word analysis for CamelCase/snake_case consistency
+                # Identify candidates: the word itself and any sub-parts (CamelCase/snake_case)
+                candidates = [part]
                 sub_parts = _smart_split(part)
                 if len(sub_parts) > 1:
-                    for sp in sub_parts:
-                        sp_norm = filter_to_letters(sp) if clean_items else sp.lower()
-                        if sp_norm:
-                            if min_length <= len(sp_norm) <= max_length:
-                                variation_counts[sp_norm][sp] += 1
+                    candidates.extend(sub_parts)
+
+                for cand in candidates:
+                    norm = filter_to_letters(cand) if clean_items else cand.lower()
+                    if norm and min_length <= len(norm) <= max_length:
+                        variation_counts[norm][cand] += 1
 
     # Pass 2: Find "winners" and build mapping
     mapping = {}


### PR DESCRIPTION
**PR Title:** Consolidate variation counting logic in `standardize_mode`

**Description:**
* **What:** Refactored the first pass of the `standardize_mode` function in `multitool.py` to eliminate duplicated logic. The normalization, length validation, and frequency counting for both primary words and their constituent sub-parts (from `_smart_split`) now share a single code path by iterating over a unified `candidates` list.
* **Why:** This change improves code maintainability and readability by resolving a redundant logic block. It strictly adheres to the existing behavioral conditions—sub-parts are only analyzed for compound words—ensuring no breaking changes or regressions in functionality.

---
*PR created automatically by Jules for task [6413199776205665140](https://jules.google.com/task/6413199776205665140) started by @RainRat*