### PR TITLE
[UI/UX] Implement semantic coloring for typo attributes in `multitool.py`

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -993,6 +993,8 @@ def _write_paired_output(
                 c_green = GREEN if show_color else ""
                 c_red = RED if show_color else ""
                 c_cyan = CYAN if show_color else ""
+                c_magenta = MAGENTA if show_color else ""
+                c_yellow = YELLOW if show_color else ""
                 c_reset = RESET if show_color else ""
 
                 # Header and divider
@@ -1016,7 +1018,20 @@ def _write_paired_output(
                     row = f"{padding}{c_red}{left:<{max_left}}{c_reset} {sep} {c_green}{right:<{max_right}}{c_reset}"
                     if has_attr:
                         attr = p[2]
-                        row += f" {sep} {c_cyan}{attr:<{max_attr}}{c_reset}"
+                        # Apply semantic coloring to the attribute column
+                        attr_color = c_cyan
+                        if "[K]" in attr:
+                            attr_color = c_cyan
+                        elif "[T]" in attr:
+                            attr_color = c_magenta
+                        elif "[D]" in attr:
+                            attr_color = c_red
+                        elif "[I]" in attr:
+                            attr_color = c_green
+                        elif "[R]" in attr or "[M]" in attr:
+                            attr_color = c_yellow
+
+                        row += f" {sep} {attr_color}{attr:<{max_attr}}{c_reset}"
                     out_file.write(row + "\n")
                 out_file.write("\n")
         else:  # 'line' or fallback


### PR DESCRIPTION
### Context: CLI

### Problem:
In modes that classify typos (like `classify`, `similarity`, or `discovery`), the `Attr` (Attribute) column in the rich `arrow` output format was hardcoded to a single color (Cyan). This uniform coloring reduced information density and made it difficult for users to quickly distinguish between different error categories (such as keyboard slips vs. transpositions) when scanning large reports.

### Solution:
I implemented a semantic coloring scheme for the `Attr` column within the `_write_paired_output` function. Typo classification tags are now color-coded based on their content:
- **Cyan**: Keyboard slips `[K]`
- **Magenta**: Transpositions `[T]`
- **Red**: Deletions `[D]` (e.g., missed characters)
- **Green**: Insertions `[I]` (e.g., extra characters)
- **Yellow**: Replacements `[R]` and Multiple-letter errors `[M]`

This change significantly improves the visual hierarchy of the reports, allowing users to identify patterns at a glance. It also brings `multitool.py` into visual alignment with the sophisticated reporting style used in `typostats.py`, ensuring a consistent experience across the toolset. The implementation remains "invisible" and non-destructive, as it respects all existing color-suppression rules (such as file redirection or the `NO_COLOR` environment variable).

### Changes:
- Modified `multitool.py` to include `c_magenta` and `c_yellow` in the local color definitions of the `arrow` format handler.
- Updated the data rendering loop in `_write_paired_output` to apply conditional coloring to the attribute string.

---
*PR created automatically by Jules for task [16145870926635047781](https://jules.google.com/task/16145870926635047781) started by @RainRat*