### PR TITLE
[DOCS] Standardize --quiet flag help text across all tools

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -190,7 +190,7 @@ def parse_arguments() -> argparse.Namespace:
     options_group.add_argument(
         '--quiet',
         action='store_true',
-        help='Hide progress bars and show fewer log messages.'
+        help='Hide progress bars and status messages.'
     )
 
     return parser.parse_args()

--- a/diff2typo.py
+++ b/diff2typo.py
@@ -880,7 +880,7 @@ def main():
     analysis_group.add_argument(
         '--quiet', '-q',
         action='store_true',
-        help='Suppress progress bars and other non-essential output.'
+        help='Hide progress bars and status messages.'
     )
 
     args = parser.parse_args()

--- a/gentypos.py
+++ b/gentypos.py
@@ -895,7 +895,7 @@ def main() -> None:
     gen_group.add_argument(
         '-q', '--quiet',
         action='store_true',
-        help="Hide progress bars and show fewer log messages.",
+        help="Hide progress bars and status messages.",
     )
 
     args = parser.parse_args()

--- a/multitool.py
+++ b/multitool.py
@@ -4936,7 +4936,7 @@ def _add_common_mode_arguments(
         '-q', '--quiet',
         action='store_true',
         default=argparse.SUPPRESS,
-        help='Suppress progress bars and informational log output.',
+        help='Hide progress bars and status messages.',
     )
 
     # Processing Configuration Group
@@ -5684,7 +5684,7 @@ def _build_parser() -> argparse.ArgumentParser:
     io_group.add_argument(
         '-q', '--quiet',
         action='store_true',
-        help='Suppress progress bars and informational log output.',
+        help='Hide progress bars and status messages.',
     )
 
     # Processing Options Group

--- a/typostats.py
+++ b/typostats.py
@@ -1101,7 +1101,7 @@ def main() -> None:
         default=None,
         help="The format of the report. If not provided, it is automatically detected from the output file extension. (default: arrow).",
     )
-    io_group.add_argument('-q', '--quiet', action='store_true', help="Suppress informational log output.")
+    io_group.add_argument('-q', '--quiet', action='store_true', help="Hide progress bars and status messages.")
 
     # Analysis Options Group
     analysis_group = parser.add_argument_group(f"{BLUE}ANALYSIS OPTIONS{RESET}")


### PR DESCRIPTION
This PR standardizes the internal help strings for the `--quiet` (or `-q`) flag across the entire tool suite. 

By replacing varied and technical descriptions (e.g., "Suppress informational log output," "Suppress progress bars and other non-essential output") with a consistent, Plain English message—"Hide progress bars and status messages."—we ensure that the CLI interface is more accessible to international users and easier to understand for everyone.

**Changes:**
- Updated `multitool.py`, `typostats.py`, `diff2typo.py`, `cmdrunner.py`, and `gentypos.py`.
- Replaced jargon like "Suppress" with "Hide".
- Replaced "informational log output" with "status messages".
- Verified consistency via `--help` output of all modified scripts.
- Verified no regressions with the full project test suite.

---
*PR created automatically by Jules for task [11529967778278153218](https://jules.google.com/task/11529967778278153218) started by @RainRat*