### PR TITLE
[FEAT] Add keyboard and transposition filters to standardize mode

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -174,10 +174,12 @@ These modes help you transform or combine your data.
   - **Options:**
     - Supports `--in-place` editing and `--dry-run` preview.
     - **Similar Word Matching:** Use `--fuzzy` to set the maximum character distance for matching similar words.
+      - **Keyboard Filter:** Use `--keyboard` (or `-k`) to only match words likely caused by hitting a nearby key.
+      - **Transposition Filter:** Use `--transposition` (or `-t`) to only match words likely caused by swapping two adjacent letters.
     - **Frequency Ratio:** Use `--threshold` to set the minimum frequency ratio required to consider a rare word a typo (default: 10.0).
     - **Diff Preview:** Use the `--diff` flag to see a unified diff of the changes that would be made.
     - Works with standard filters like `--min-length` and `--max-length`.
-  - **Example:** `python multitool.py standardize . --diff --min-length 4 --fuzzy 1`
+    - **Example:** `python multitool.py standardize . --diff --min-length 4 --fuzzy 1 --keyboard`
 
 - **`highlight`**
   - **What it does:** Searches for words from a list, mapping, or extra pairs and colors them in the output. This is useful as a preview before using the `scrub` mode to make permanent changes.

--- a/multitool.py
+++ b/multitool.py
@@ -4208,6 +4208,8 @@ def standardize_mode(
     dry_run: bool = False,
     fuzzy: int = 0,
     threshold: float = 10.0,
+    keyboard: bool = False,
+    transposition: bool = False,
     diff: bool = False,
 ) -> None:
     """
@@ -4252,10 +4254,18 @@ def standardize_mode(
         norm_totals[norm] = sum(counts.values())
 
     # 2b: If similar word matching is enabled, group similar normalized words
-    if fuzzy > 0:
+    # Adjust effective distance if filters are used but default or restrictive dist was kept
+    effective_fuzzy = fuzzy
+    if transposition and effective_fuzzy < 2:
+        effective_fuzzy = 2
+    if keyboard and effective_fuzzy < 1:
+        effective_fuzzy = 1
+
+    if effective_fuzzy > 0:
         # Sort normalized words by total frequency descending to find "anchors"
         sorted_norms = sorted(norm_totals.keys(), key=lambda n: norm_totals[n], reverse=True)
         fuzzy_groups = {}  # rare_norm -> frequent_norm
+        adj_keys = get_adjacent_keys() if (keyboard or transposition) else {}
 
         for i, frequent in enumerate(sorted_norms):
             f_count = norm_totals[frequent]
@@ -4269,7 +4279,17 @@ def standardize_mode(
 
                 # Only consider if the frequent word is significantly more common
                 if f_count >= r_count * threshold:
-                    if levenshtein_distance(frequent, rare) <= fuzzy:
+                    if levenshtein_distance(frequent, rare) <= effective_fuzzy:
+                        if keyboard or transposition:
+                            label = classify_typo(rare, frequent, adj_keys)
+                            matches_filter = False
+                            if keyboard and label == "[K]":
+                                matches_filter = True
+                            if transposition and label == "[T]":
+                                matches_filter = True
+                            if not matches_filter:
+                                continue
+
                         fuzzy_groups[rare] = frequent
                         logging.info(f"[Fuzzy] Identified likely typo: '{rare}' ({r_count}) -> '{frequent}' ({f_count})")
 
@@ -5344,9 +5364,9 @@ MODE_DETAILS = {
     },
     "standardize": {
         "summary": "Fixes casing/spelling project-wide",
-        "description": "Analyzes your files to find words used with different capitalization (for example, 'database' vs 'Database') or similar spelling (for example, 'teh' vs 'the'). It then automatically replaces all less frequent versions with the most popular one across the entire project. Use --fuzzy to enable similar word matching based on your project's dominant patterns.",
-        "example": "python multitool.py standardize . --diff --min-length 4 --fuzzy 1",
-        "flags": "[FILES...] [--in-place] [--dry-run] [--fuzzy N] [--threshold RATIO] [--diff]",
+        "description": "Analyzes your files to find words used with different capitalization (for example, 'database' vs 'Database') or similar spelling (for example, 'teh' vs 'the'). It then automatically replaces all less frequent versions with the most popular one across the entire project. Use --fuzzy to enable similar word matching, and add --keyboard or --transposition to restrict those matches to specific error types.",
+        "example": "python multitool.py standardize . --diff --min-length 4 --fuzzy 1 --transposition",
+        "flags": "[FILES...] [--in-place] [--dry-run] [--fuzzy N] [-k] [-t] [--threshold RATIO] [--diff]",
     },
     "search": {
         "summary": "Searches for words or patterns",
@@ -6642,6 +6662,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Maximum distance for similar word matching (for example, --fuzzy 1 to fix 'teh' -> 'the'). Set to 0 to only fix casing (default: 0).",
     )
     standardize_options.add_argument(
+        '-k', '--keyboard',
+        action='store_true',
+        help="Only include matches likely caused by hitting a nearby key.",
+    )
+    standardize_options.add_argument(
+        '-t', '--transposition',
+        action='store_true',
+        help="Only include matches likely caused by swapping two adjacent letters.",
+    )
+    standardize_options.add_argument(
         '--threshold',
         type=float,
         default=10.0,
@@ -7374,6 +7404,8 @@ def main() -> None:
                 'dry_run': getattr(args, 'dry_run', False),
                 'fuzzy': getattr(args, 'fuzzy', 0),
                 'threshold': getattr(args, 'threshold', 10.0),
+                'keyboard': getattr(args, 'keyboard', False),
+                'transposition': getattr(args, 'transposition', False),
                 'diff': getattr(args, 'diff', False),
             }
         ),

--- a/tests/test_multitool_standardize_filters.py
+++ b/tests/test_multitool_standardize_filters.py
@@ -1,0 +1,77 @@
+import subprocess
+import os
+
+def run_multitool(args):
+    result = subprocess.run(
+        ['python3', 'multitool.py'] + args,
+        capture_output=True,
+        text=True
+    )
+    return result
+
+def test_standardize_filters():
+    test_file = 'test_standardize.txt'
+    with open(test_file, 'w') as f:
+        # 'above' is frequent, 'abovf' is rare and a keyboard slip (f is next to e)
+        # 'the' is frequent, 'teh' is rare and a transposition
+        content = (
+            "above above above above above above above above above above\n"
+            "abovf\n"
+            "the the the the the the the the the the\n"
+            "teh\n"
+        )
+        f.write(content)
+
+    print("--- Test 1: No filters, fuzzy 2 ---")
+    res = run_multitool(['standardize', test_file, '--fuzzy', '2'])
+    print(res.stdout)
+    assert 'above' in res.stdout
+    assert 'abovf' not in res.stdout
+    assert 'the' in res.stdout
+    assert 'teh' not in res.stdout
+    print("Test 1 passed (both fixed)")
+
+    print("--- Test 2: Keyboard filter only ---")
+    # Should fix abovf -> above, but NOT teh -> the
+    res = run_multitool(['standardize', test_file, '--fuzzy', '2', '--keyboard'])
+    print(res.stdout)
+    assert 'above' in res.stdout
+    assert 'abovf' not in res.stdout # Fixed
+    assert 'teh' in res.stdout       # Not fixed
+    print("Test 2 passed (only keyboard fixed)")
+
+    print("--- Test 3: Transposition filter only ---")
+    # Should fix teh -> the, but NOT abovf -> above
+    res = run_multitool(['standardize', test_file, '--fuzzy', '2', '--transposition'])
+    print(res.stdout)
+    assert 'abovf' in res.stdout     # Not fixed
+    assert 'the' in res.stdout
+    assert 'teh' not in res.stdout   # Fixed
+    print("Test 3 passed (only transposition fixed)")
+
+    print("--- Test 4: Both filters ---")
+    res = run_multitool(['standardize', test_file, '--fuzzy', '2', '--keyboard', '--transposition'])
+    print(res.stdout)
+    assert 'abovf' not in res.stdout
+    assert 'teh' not in res.stdout
+    print("Test 4 passed (both fixed with both filters)")
+
+    print("--- Test 5: Automatic distance boosting ---")
+    # Even with fuzzy 0, --transposition should boost to 2 and fix teh
+    res = run_multitool(['standardize', test_file, '--transposition'])
+    print(res.stdout)
+    assert 'teh' not in res.stdout
+    assert 'abovf' in res.stdout # fuzzy 0 -> boosted to 2 for trans, but keyboard still needs its flag or fuzzy
+    print("Test 5 passed (boosted distance worked)")
+
+    os.remove(test_file)
+
+if __name__ == "__main__":
+    try:
+        test_standardize_filters()
+        print("\nALL TESTS PASSED!")
+    except Exception as e:
+        print(f"\nTEST FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)


### PR DESCRIPTION
### [FEAT] Add keyboard and transposition filters to standardize mode

#### What:
This PR adds `-k/--keyboard` and `-t/--transposition` flags to the `standardize` mode in `multitool.py`. These filters restrict automatic spelling corrections to specific typo types: keyboard slips (adjacent keys) and transpositions (swapped adjacent letters). 

Key technical changes:
- Updated `standardize_mode` to utilize internal `classify_typo` logic during its fuzzy matching pass.
- Implemented automatic distance boosting: search distance is automatically ensured to be at least 1 for keyboard slips and 2 for transpositions if those filters are active.
- Added CLI arguments to the `standardize` subparser.
- Updated project documentation and internal metadata for consistent help output.
- Included a new test suite `tests/test_multitool_standardize_filters.py`.

#### Why:
The `standardize` mode's primary strength is its ability to find and fix inconsistencies without a manual dictionary. However, using a high `--fuzzy` value can sometimes introduce false positives. By adding these targeted filters, users can perform safe, automated cleanup of project-wide spelling errors with much higher confidence. This addition provides symmetry with existing analytical tools in the suite (`similarity`, `discovery`, `search`) and improves the overall convenience of the "fix-it" workflow.

---
*PR created automatically by Jules for task [17264181299824136234](https://jules.google.com/task/17264181299824136234) started by @RainRat*