### PR TITLE
Extract redundant visual bar rendering logic in typostats.py

### DIFF
--- a/typostats.py
+++ b/typostats.py
@@ -141,6 +141,23 @@ def levenshtein_distance(s1: str, s2: str) -> int:
     return previous_row[-1]
 
 
+def _render_visual_bar(percentage: float, max_bar: int = 20) -> str:
+    """
+    Creates a high-resolution visual bar using Unicode block characters.
+    """
+    total_blocks = (percentage * max_bar) / 100
+    full_blocks = int(total_blocks)
+    fraction = total_blocks - full_blocks
+    blocks = [" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"]
+    frac_idx = int(fraction * 8)
+
+    bar = "█" * full_blocks
+    if full_blocks < max_bar:
+        bar += blocks[frac_idx]
+        bar += " " * (max_bar - full_blocks - 1)
+    return bar
+
+
 def _format_analysis_summary(
     raw_count: int,
     filtered_items: Sequence[Any],
@@ -194,16 +211,7 @@ def _format_analysis_summary(
         retention = (filtered_count / raw_count) * 100
         # High-res visual bar for retention
         max_bar = 20
-        total_blocks = (retention * max_bar) / 100
-        full_blocks = int(total_blocks)
-        fraction = total_blocks - full_blocks
-        blocks = [" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"]
-        frac_idx = int(fraction * 8)
-
-        bar = "█" * full_blocks
-        if full_blocks < max_bar:
-            bar += blocks[frac_idx]
-            bar += " " * (max_bar - full_blocks - 1)
+        bar = _render_visual_bar(retention, max_bar)
 
         report.append(
             f"  {c_bold}{c_blue}{'Retention rate:':<{label_width}}{c_reset} {c_green}{retention:>5.1f}%{c_reset} {c_blue}{bar}{c_reset}"
@@ -958,16 +966,7 @@ def generate_report(
                 marker_color_for_bar = marker_color
 
             # Create a high-resolution visual bar
-            total_blocks = (percent * max_bar) / 100
-            full_blocks = int(total_blocks)
-            fraction = total_blocks - full_blocks
-            blocks = [" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"]
-            frac_idx = int(fraction * 8)
-
-            bar = "█" * full_blocks
-            if full_blocks < max_bar:
-                bar += blocks[frac_idx]
-                bar += " " * (max_bar - full_blocks - 1)
+            bar = _render_visual_bar(percent, max_bar)
             row = (
                 f"{padding}{c_red}{typo_char:<{max_t}}{c_reset} {sep} "
                 f"{c_green}{correct_char:<{max_c}}{c_reset} {sep} "


### PR DESCRIPTION
This PR addresses a code duplication issue in `typostats.py`. The logic for rendering high-resolution visual bars using Unicode block characters was repeated in both `_format_analysis_summary` and `generate_report`. 

I have extracted this logic into a new helper function `_render_visual_bar(percentage: float, max_bar: int = 20) -> str`. 

Key changes:
- Created `_render_visual_bar` to handle Unicode bar construction.
- Updated `_format_analysis_summary` to use the helper.
- Updated `generate_report` to use the helper.

These changes are purely internal refactoring and do not change any public APIs or tool output. All relevant tests passed.

---
*PR created automatically by Jules for task [16192364656046865457](https://jules.google.com/task/16192364656046865457) started by @RainRat*