### PR TITLE
[DOCS] Synchronize Multitool documentation with CLI help output

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -23,53 +23,53 @@ Most modes default to reading from **standard input** if you do not specify an i
 
 Multitool operates in different "modes," each designed for a specific task.
 
-### 1. GET DATA
+### GET DATA
 
 These modes help you pull specific data out of a messy file.
 
 - **`arrow`**
-  - **What it does:** Gets text from lines that use arrows (for example, `typo -> correction`). Useful for getting a clean list of typos from a log. It saves the left side by default. You can also get the right side (the correction) by adding the `--right` flag.
+  - **What it does:** Extracts text from arrow lines. It finds text in lines that use arrows (like 'typo -> correction') and saves the left side by default. Use `--right` to save the right side instead.
   - **Example:** `python multitool.py arrow typos.log --right`
 
 - **`table`**
-  - **What it does:** Gets keys or values from entries like `key = "value"`. It saves the key by default. Use the `--right` flag to get the quoted value instead.
+  - **What it does:** Extracts text from key=value. It gets keys or values from entries like `key = "value"`. It saves the key by default. Use the `--right` flag to get the quoted value instead.
   - **Example:** `python multitool.py table typos.toml --right`
 
 - **`backtick`**
-  - **What it does:** Gets text found inside backticks (for example, \`code\`). It picks items near words like 'error' or 'warning' to find the most useful data.
+  - **What it does:** Extracts text inside backticks. It finds text inside backticks (like `code`) and prioritizes items near words like 'error' or 'warning' to find the most useful data.
   - **Example:** `python multitool.py backtick build.log`
 
 - **`quoted`**
-  - **What it does:** Gets text found inside double (`"`) or single (`'`) quotes. It handles backslash escaping (like `\"` or `\'`) to correctly extract strings from code or data files.
+  - **What it does:** Extracts text inside quotes. It finds text inside double (`"`) or single (`'`) quotes. It handles backslash escaping (like `\"` or `\'`) to correctly extract strings from code or data files.
   - **Example:** `python multitool.py quoted source.py`
 
 - **`between`**
-  - **What it does:** Gets text found between two markers. It is useful for extracting data from templating languages, logs, or custom file formats. You can use the `--multi-line` flag to capture content that spans multiple lines.
+  - **What it does:** Extracts text between markers. It finds text between a starting marker and an ending marker. It is useful for extracting data from templating languages, logs, or custom file formats. You can use the `--multi-line` flag to capture content that spans multiple lines.
   - **Options:** Requires `--start` and `--end` to define the markers.
   - **Example:** `python multitool.py between input.txt --start '{{' --end '}}'`
 
 - **`csv`**
-  - **What it does:** Gets columns from a CSV file. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) followed by one or more numbers to get specific columns. Use `--delimiter` (or `-d`) to pick a different column separator (for example, `;`).
+  - **What it does:** Extracts columns from CSV. It gets data from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) followed by one or more numbers to get specific columns. Use `--delimiter` (or `-d`) to pick a different column separator (for example, `;`).
   - **Example:** `python multitool.py csv data.csv --column 2`
 
 - **`markdown`**
-  - **What it does:** Gets items from Markdown bulleted lists (lines starting with `- `, `* `, or `+ `). It can also split items by `:` or `->` to get one side of a pair (use the `--right` flag for the second part).
+  - **What it does:** Extracts Markdown list items. It finds text in lines starting with `- `, `* `, or `+ `. It can also split items by `:` or `->` to get one side of a pair (use the `--right` flag for the second part).
   - **Example:** `python multitool.py markdown notes.md --right`
 
 - **`md-table`**
-  - **What it does:** Gets text from Markdown tables. It saves the first column by default. Use the `--right` flag to save the second column instead, or `--column` (or `-c`) followed by one or more numbers to get specific columns. It automatically skips header and divider rows.
+  - **What it does:** Extracts Markdown table items. It finds text in cells of a Markdown table. It saves the first column by default. Use the `--right` flag to save the second column instead, or `--column` (or `-c`) followed by one or more numbers to get specific columns. It automatically skips header and divider rows.
   - **Example:** `python multitool.py md-table readme.md --column 2`
 
 - **`json`**
-  - **What it does:** Gets values from a JSON file using a specific key. You can use dots for keys inside other keys (for example, `user.name`). If you do not provide a key, it gets items from the top level. It automatically handles lists and objects.
+  - **What it does:** Extracts JSON values by key. It finds values for a specific key in a JSON file. You can use dots for keys inside other keys (for example, `user.name`). If you do not provide a key, it gets items from the top level. It automatically handles lists and objects.
   - **Example:** `python multitool.py json report.json --key replacements.typo`
 
 - **`yaml`**
-  - **What it does:** Gets values from a YAML file using a key path. Like JSON mode, it supports dot notation (for example, `config.items`). If you do not provide a key, it gets items from the top level.
+  - **What it does:** Extracts YAML values by key. It finds values for a specific key in a YAML file using a key path. Like JSON mode, it supports dot notation (for example, `config.items`). If you do not provide a key, it gets items from the top level.
   - **Example:** `python multitool.py yaml config.yaml --key config.items`
 
 - **`toml`**
-  - **What it does:** Gets values from a TOML file using a key path. Like JSON and YAML modes, it supports dot notation (for example, `tool.poetry.dependencies`). If you do not provide a key, it gets items from the top level. It automatically handles nested tables.
+  - **What it does:** Extracts TOML values by key. It finds values for a specific key in a TOML file using a key path. Like JSON and YAML modes, it supports dot notation (for example, `tool.poetry.dependencies`). If you do not provide a key, it gets items from the top level. It automatically handles nested tables.
   - **Example:** `python multitool.py toml pyproject.toml --key tool.poetry.dependencies`
 
 - **`line`**
@@ -77,88 +77,101 @@ These modes help you pull specific data out of a messy file.
   - **Example:** `python multitool.py line raw_words.txt`
 
 - **`words`**
-  - **What it does:** Gets individual words from a file. It splits lines by whitespace by default, but you can pick a custom character using `--delimiter` (or `-d`). Use the `--smart` (or `-S`) flag to also split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").
+  - **What it does:** Extracts words from a file. It splits a file into individual words using whitespace or a custom delimiter. It's the standard way to get a list of every word used in a document. Use the `--smart` (or `-S`) flag to also split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").
   - **Example:** `python multitool.py words report.txt --smart`
 
 - **`ngrams`**
-  - **What it does:** Gets sequences of N words from a file. This is useful for finding common phrases or context around typos. It supports sequences across line boundaries.
+  - **What it does:** Extracts sequences of words. It gets sequences of words from a file. This is useful for finding common phrases or context around typos. It supports sequences across line boundaries.
   - **Options:** Use `-n` to pick the number of words in each sequence (default is 2). Like the `words` mode, it supports custom delimiters and smart word splitting.
   - **Example:** `python multitool.py ngrams report.txt -n 2 --smart`
 
 - **`regex`**
-  - **What it does:** Extracts text matching a pattern. Finds and gets all text that matches a Python regular expression pattern. Unlike other modes, it **keeps the original text** (it does not convert to lowercase or remove punctuation) by default.
+  - **What it does:** Extracts text matching a pattern. It finds and gets all text that matches a Python regular expression pattern. Unlike other modes, it **keeps the original text** (it does not convert to lowercase or remove punctuation) by default.
   - **Example:** `python multitool.py regex inputs.txt --pattern 'user_\w+'`
 
-### 2. CHANGE DATA
+### CHANGE DATA
 
 These modes help you transform or combine your data.
 
 - **`combine`**
-  - **What it does:** Merges multiple files (or standard input) into one list, removes duplicates, and sorts the result alphabetically.
+  - **What it does:** Merges multiple files into one. It combines several files (or standard input) into one list, removes duplicates, and sorts the result alphabetically.
   - **Note:** This mode has built-in sorting and deduplication; the `--process-output` flag is not needed.
   - **Example:** `python multitool.py combine file1.txt file2.txt`
 
 - **`unique`**
-  - **What it does:** Removes duplicate items from your list while **keeping the original order**. This is useful when the sequence of items is important.
+  - **What it does:** Removes duplicates, keeps order. It removes duplicate items from your list while **keeping the original order**. This is useful when the sequence of items is important.
   - **Example:** `python multitool.py unique raw_typos.txt`
 
+- **`diff`**
+  - **What it does:** Shows differences between files. It finds added, removed, and changed items between two files. It can compare simple lists of words or (with the `--pairs` flag) find changes in typo-correction mappings.
+  - **Supported Formats:** Color-coded terminal output (default) and structured JSON output.
+  - **Example:** `python multitool.py diff old_list.txt new_list.txt`
+  - **Pairs Example:** `python multitool.py diff old_typos.csv new_typos.csv --pairs`
+
+- **`highlight`**
+  - **What it does:** Color-codes words from a list. It searches for words from a list, mapping, or extra pairs and colors them in the output. This is useful as a preview before using the `scrub` mode to make permanent changes.
+  - **Options:**
+    - Use the `--mapping` flag to provide a file with typos or words to find.
+    - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) or words to match directly on the command line.
+    - The `--smart` flag allows for coloring subwords within larger compound words (like variable names).
+  - **Example:** `python multitool.py highlight input.txt --add teh:the`
+
 - **`resolve`**
-  - **What it does:** Finds and shortens chains of typo corrections. For example, if your mapping file contains `A -> B` and `B -> C`, this mode will resolve them to `A -> C` and `B -> C`. This ensures that your mappings always point directly to the final correct word, making them more efficient for fixing typos and analysis.
-  - **Example:** `python multitool.py resolve mappings.csv`
+  - **What it does:** Shortens typo correction chains. It finds and shortens chains of typo corrections (for example, 'A' -> 'B' and 'B' -> 'C' becomes 'A' -> 'C'). This ensures that your mapping files always point directly to the final correct word, which improves the efficiency of fixing typos and analysis.
+  - **Example:** `python multitool.py resolve mappings.csv --output resolved.csv`
 
 - **`align`**
-  - **What it does:** Extracts typo-correction pairs from any supported format (CSV, Arrow, Markdown lists/tables, JSON, YAML, TOML) and outputs them in perfectly aligned columns by automatically calculating the maximum width of the left column. This is the recommended way to "beautify" your typo lists for human readability.
+  - **What it does:** Aligns typo-correction pairs. It extracts typo-correction pairs from any supported format (CSV, Arrow, Markdown lists/tables, JSON, YAML, TOML) and outputs them in perfectly aligned columns by automatically calculating the maximum width of the left column. This is the recommended way to "beautify" your typo lists for human readability.
   - **Options:** Use the `--sep` flag to customize the separator string between columns (default is ` -> `).
   - **Example:** `python multitool.py align typos.csv --sep ' | '`
 
 - **`rename`**
-  - **What it does:** Changes file and folder names using a mapping file or extra pairs. It is useful for fixing typos in filenames across your entire project. It handles nested renames by processing files before their parent folders.
+  - **What it does:** Batch renames files and folders. It changes file and folder names using a mapping file or extra pairs. It is useful for fixing typos in filenames across your entire project. It handles nested renames by processing files before their parent folders.
   - **Options:**
     - Supports `--in-place` renaming and `--dry-run` preview.
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add old_name:new_name`) directly on the command line.
     - Use the `--smart-case` flag to automatically match the casing of the original filename.
   - **Example:** `python multitool.py rename src/ --mapping corrections.csv --in-place`
 
-- **`diff`**
-  - **What it does:** Shows differences between files. Finds added, removed, and changed items between two files. It can compare simple lists of words or (with the `--pairs` flag) find changes in typo-correction mappings.
-  - **Supported Formats:** Color-coded terminal output (default) and structured JSON output.
-  - **Example:** `python multitool.py diff old_list.txt new_list.txt`
-  - **Pairs Example:** `python multitool.py diff old_typos.csv new_typos.csv --pairs`
-
 - **`filterfragments`**
-  - **What it does:** Removes words from your input file if they appear anywhere inside a second file (`--file2`).
+  - **What it does:** Removes words found inside others. It removes words from your input file if they appear anywhere (even as a fragment) inside words in a second file.
   - **Example:** `python multitool.py filterfragments candidates.txt --file2 dictionary.txt`
 
-- **`map`**
-  - **What it does:** Changes items in your list using values from a mapping file or extra pairs. Supports CSV, Arrow, Table (`typo = "correction"`), JSON, YAML, and TOML formats. By default, it keeps items that are not in the mapping. The `--min-length` and `--max-length` filters are **re-applied** to items after they are changed. Use `--drop-missing` to remove unmatched items.
-  - **Options:**
-    - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) directly on the command line.
-  - **Example:** `python multitool.py map input.txt --add teh:the`
-
-- **`sample`**
-  - **What it does:** Picks a random set of lines from a file. You can pick a specific number (`--n 100`) or a percentage (`--percent 10`).
-  - **Example:** `python multitool.py sample big_log.txt --n 50`
-
 - **`set_operation`**
-  - **What it does:** Compares two files using standard set logic:
+  - **What it does:** Compares files using set logic. It compares two files using standard set logic:
     - `intersection`: Finds lines common to both files.
     - `union`: Combines all lines from both files.
     - `difference`: Finds lines in the first file that are not in the second.
     - `symmetric_difference`: Finds lines that are unique to each file (items in either file, but not both).
   - **Example:** `python multitool.py set_operation a.txt --file2 b.txt --operation symmetric_difference`
 
+- **`sample`**
+  - **What it does:** Picks a random set of lines. It selects a random set of lines from a file. You can pick a specific number (`--n 100`) or a percentage (`--percent 10`).
+  - **Example:** `python multitool.py sample big_log.txt --n 50`
+
+- **`map`**
+  - **What it does:** Replaces items using a mapping. It changes items in your list using values from a mapping file or extra pairs. Supports CSV, Arrow, Table (`typo = "correction"`), JSON, YAML, and TOML formats. By default, it keeps items that are not in the mapping. The `--min-length` and `--max-length` filters are **re-applied** to items after they are changed. Use `--drop-missing` to remove unmatched items.
+  - **Options:**
+    - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) directly on the command line.
+  - **Example:** `python multitool.py map input.txt --add teh:the`
+
 - **`zip`**
-  - **What it does:** Joins two files line-by-line into a paired format. It applies `--min-length` and `--max-length` filters to **both items in each pair**. If the files have a different number of lines, the output will stop at the end of the shortest file.
+  - **What it does:** Pairs lines from two files. It joins two files line-by-line into a paired format. It applies `--min-length` and `--max-length` filters to **both items in each pair**. If the files have a different number of lines, the output will stop at the end of the shortest file.
   - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py zip typos.txt --file2 corrections.txt --output-format arrow`
 
 - **`swap`**
-  - **What it does:** Flips the order of elements in paired data (for example, `typo -> correction` becomes `correction -> typo`).
+  - **What it does:** Reverses the order of pairs. It flips the order of elements in paired data (for example, `typo -> correction` becomes `correction -> typo`).
   - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py swap mappings.csv --output-format arrow`
 
+- **`pairs`**
+  - **What it does:** Converts paired data formats. It works with and converts paired data (like `typo -> correction`) from any supported format and writes it to the specified output format. This is the primary way to convert between paired formats (for example, from JSON to CSV) while applying cleaning and length filters.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
+  - **Example:** `python multitool.py pairs typos.json --output-format csv`
+
 - **`scrub`**
-  - **What it does:** Fixes typos in your text files using a mapping file or extra pairs. It tries to keep the surrounding context (punctuation, whitespace) while fixing errors. It automatically handles compound words like `CamelCase` and `snake_case` variables.
+  - **What it does:** Fixes typos in text files. It fixes typos in your text files using a mapping file or extra pairs. It tries to keep the surrounding context (punctuation, whitespace) while fixing errors. It automatically handles compound words like `CamelCase` and `snake_case` variables.
   - **Supported Formats:** Supports CSV, Arrow, Table, JSON, YAML, and TOML mapping formats.
   - **Options:**
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) directly on the command line.
@@ -170,7 +183,7 @@ These modes help you transform or combine your data.
   - **In-Place Example:** `python multitool.py scrub file1.txt file2.txt --mapping corrections.csv --in-place`
 
 - **`standardize`**
-  - **What it does:** Fixes inconsistent casing or spelling by using the most frequent form. It analyzes your files to find words used with different capitalization (for example, 'database' vs 'Database') or similar spelling (for example, 'teh' vs 'the'). It then automatically replaces all less frequent versions with the most popular one across the entire project. This ensures consistency without needing a manual mapping file.
+  - **What it does:** Fixes casing/spelling project-wide. It fixes inconsistent casing or spelling by using the most frequent form. It analyzes your files to find words used with different capitalization (for example, 'database' vs 'Database') or similar spelling (for example, 'teh' vs 'the'). It then automatically replaces all less frequent versions with the most popular one across the entire project. This ensures consistency without needing a manual mapping file.
   - **Options:**
     - Supports `--in-place` editing and `--dry-run` preview.
     - **Similar Word Matching:** Use `--fuzzy` to set the maximum character distance for matching similar words.
@@ -179,40 +192,12 @@ These modes help you transform or combine your data.
     - Works with standard filters like `--min-length` and `--max-length`.
   - **Example:** `python multitool.py standardize . --diff --min-length 4 --fuzzy 1`
 
-- **`highlight`**
-  - **What it does:** Searches for words from a list, mapping, or extra pairs and colors them in the output. This is useful as a preview before using the `scrub` mode to make permanent changes.
-  - **Options:**
-    - Use the `--mapping` flag to provide a file with typos or words to find.
-    - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) or words to match directly on the command line.
-    - The `--smart` flag allows for coloring subwords within larger compound words (like variable names).
-  - **Example:** `python multitool.py highlight input.txt --add teh:the`
-
-- **`pairs`**
-  - **What it does:** Works with and converts paired data (like `typo -> correction`) from any supported format and writes it to the specified output format. This is the primary way to convert between paired formats (for example, from JSON to CSV) while applying cleaning and length filters.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
-  - **Example:** `python multitool.py pairs typos.json --output-format csv`
-
-### 3. CHECK & ANALYZE
+### CHECK & ANALYZE
 
 These modes help you analyze your data.
 
-- **`check`**
-  - **What it does:** Finds words used as both typos and fixes. Checks for words that appear in both the typo and correction columns of a file. This is useful for spotting errors in your typo database (loops).
-  - **Example:** `python multitool.py check mappings.csv`
-
-- **`classify`**
-  - **What it does:** Groups typo corrections based on their error type. It labels each pair with a code like `[K]` (Keyboard), `[T]` (Transposition), `[D]` (Deletion), `[I]` (Insertion), `[R]` (Replacement), or `[M]` (Multiple letters).
-  - **Options:** Use `--show-dist` to include the number of character changes in the output labels.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
-  - **Example:** `python multitool.py classify typos.txt --show-dist --output labeled.txt`
-
-- **`conflict`**
-  - **What it does:** Finds typos that are associated with more than one unique correction. Use this to find inconsistencies in your typo lists.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
-  - **Example:** `python multitool.py conflict mappings.csv`
-
 - **`count`**
-  - **What it does:** Counts how often each word, pair, line, or character appears in a file and sorts them by frequency (most frequent first).
+  - **What it does:** Counts how often items appear. It counts how often each word, pair, line, or character appears in a file and sorts them by frequency (most frequent first).
   - **Options:**
     - `--min-count` and `--max-count`: Filter results by their frequency.
     - `-d`, `--delimiter`: The character to split words by (default: whitespace).
@@ -229,35 +214,50 @@ These modes help you analyze your data.
   - **By-File Example:** `python multitool.py count src/*.py --by-file --output-format arrow`
   - **Pairs Example:** `python multitool.py count typos.log --pairs --output-format arrow`
 
+- **`check`**
+  - **What it does:** Finds words used as both typos and fixes. It checks for words that appear in both the typo and correction columns of a file. This is useful for spotting errors in your typo database (loops).
+  - **Example:** `python multitool.py check mappings.csv`
+
+- **`conflict`**
+  - **What it does:** Finds typos with multiple fixes. It finds typos that are associated with more than one unique correction. Use this to find inconsistencies in your typo lists.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
+  - **Example:** `python multitool.py conflict mappings.csv`
+
 - **`cycles`**
-  - **What it does:** Finds loops in typo-correction pairs (for example, "A" maps to "B" and "B" maps back to "A"). These repeated loops can cause issues when automatically fixing text and often indicate errors in your data.
+  - **What it does:** Finds loops in typo pairs. It finds loops in typo-correction pairs (for example, "A" maps to "B" and "B" maps back to "A"). These repeated loops can cause issues when automatically fixing text and often indicate errors in your data.
   - **Example:** `python multitool.py cycles typos.csv --output-format arrow`
 
-- **`fuzzymatch`**
-  - **What it does:** Finds words in your list that are similar to words in a second list (large dictionary). Use this to find likely corrections for typos.
-  - **Options:** Use `--min-dist` and `--max-dist` to control the number of changes allowed, and `--show-dist` to see the number of changes in the output.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
-  - **Example:** `python multitool.py fuzzymatch typos.txt words.csv --max-dist 1 --show-dist`
-
-- **`near_duplicates`**
-  - **What it does:** Finds pairs of words in your list that are very similar (only a few characters are different). This is useful for finding potential typos or unintended duplicates.
-  - **Options:** Use `--min-dist` and `--max-dist` to control the number of changes allowed, and `--show-dist` to see the number of changes in the output.
-  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
-  - **Example:** `python multitool.py near_duplicates words.txt --max-dist 1 --show-dist`
-
 - **`similarity`**
-  - **What it does:** Filters paired data (like `typo -> correction`) based on the number of character changes needed to turn one word into another. Use this to remove extra data or find specific types of typos.
+  - **What it does:** Filters pairs by changes. It filters paired data (like `typo -> correction`) based on the number of character changes needed to turn one word into another. Use this to remove extra data or find specific types of typos.
   - **Options:** Use `--min-dist` and `--max-dist` to set the range of allowed changes, and `--show-dist` to include the number of changes in the output.
   - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
   - **Example:** `python multitool.py similarity typos.txt --max-dist 2 --show-dist`
 
+- **`near_duplicates`**
+  - **What it does:** Finds similar words in one list. It finds pairs of words in your list that are very similar (only a few characters are different). This is useful for finding potential typos or unintended duplicates.
+  - **Options:** Use `--min-dist` and `--max-dist` to control the number of changes allowed, and `--show-dist` to see the number of changes in the output.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
+  - **Example:** `python multitool.py near_duplicates words.txt --max-dist 1 --show-dist`
+
+- **`fuzzymatch`**
+  - **What it does:** Finds similar words in two lists. It finds words in your list that are similar to words in a second list (large dictionary). Use this to find likely corrections for typos.
+  - **Options:** Use `--min-dist` and `--max-dist` to control the number of changes allowed, and `--show-dist` to see the number of changes in the output.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
+  - **Example:** `python multitool.py fuzzymatch typos.txt words.csv --max-dist 1 --show-dist`
+
 - **`stats`**
-  - **What it does:** Shows statistics for a list. Provides a detailed overview of your dataset. It reports counts, unique items, and statistics. If the `--pairs` flag is used, it additionally analyzes the file as paired data (typos/corrections) and reports conflicts (one typo to multiple corrections), overlaps (words that are both typos and corrections), and character change statistics.
+  - **What it does:** Shows statistics for a list. It provides a detailed overview of your dataset. It reports counts, unique items, and statistics. If the `--pairs` flag is used, it additionally analyzes the file as paired data (typos/corrections) and reports conflicts (one typo to multiple corrections), overlaps (words that are both typos and corrections), and character change statistics.
   - **Supported Formats:** `json`, `yaml`, `markdown`, `md-table`, and `line` (human-readable).
   - **Example:** `python multitool.py stats typos.csv --pairs`
 
+- **`classify`**
+  - **What it does:** Groups typos by error type. It groups typo corrections based on their error type and labels each pair with a code like `[K]` (Keyboard), `[T]` (Transposition), `[D]` (Deletion), `[I]` (Insertion), `[R]` (Replacement), or `[M]` (Multiple letters).
+  - **Options:** Use `--show-dist` to include the number of character changes in the output labels.
+  - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, and `toml`.
+  - **Example:** `python multitool.py classify typos.txt --show-dist --output labeled.txt`
+
 - **`discovery`**
-  - **What it does:** Automatically finds potential typos in a text by finding rare words that are very similar to frequent words. It assumes that frequent words are likely correct and rare versions are likely typos. This is a powerful way to find errors in a dataset without needing a dictionary.
+  - **What it does:** Finds typos in rare words. It automatically finds potential typos in a text by finding rare words that are very similar to frequent words. It assumes that frequent words are likely correct and rare variations are likely typos. This is a powerful way to find errors in a dataset without needing a dictionary.
   - **Options:**
     - `--rare-max`: Maximum frequency for a word to be considered a potential typo (default: 1).
     - `--freq-min`: Minimum frequency for a word to be considered a potential correction (default: 5).
@@ -269,7 +269,7 @@ These modes help you analyze your data.
   - **Example:** `python multitool.py discovery code.py --smart --rare-max 2 --freq-min 10 --max-dist 1`
 
 - **`casing`**
-  - **What it does:** Finds words that appear in your files with multiple different casing styles (for example, 'hello', 'Hello', 'HELLO'). This is useful for seeing inconsistent naming or typos that differ only by case.
+  - **What it does:** Finds inconsistent casing. It finds words that appear in your files with multiple different casing styles (for example, 'hello', 'Hello', 'HELLO'). This is useful for seeing inconsistent naming or typos that differ only by case.
   - **Options:**
     - `-d`, `--delimiter`: The character to split words by (default: whitespace).
     - `-S`, `--smart`: Split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").
@@ -277,7 +277,7 @@ These modes help you analyze your data.
   - **Example:** `python multitool.py casing report.txt --smart --output-format arrow`
 
 - **`repeated`**
-  - **What it does:** Finds consecutive identical words (for example, "the the"). It's a common typing error that is often missed by standard spell-checkers.
+  - **What it does:** Finds doubled words. It finds consecutive identical words (for example, "the the"). It's a common typing error that is often missed by standard spell-checkers.
   - **Options:**
     - `-d`, `--delimiter`: The character to split words by (default: whitespace).
     - `-S`, `--smart`: Split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").
@@ -285,7 +285,7 @@ These modes help you analyze your data.
   - **Example:** `python multitool.py repeated report.txt --smart --output-format arrow`
 
 - **`search`**
-  - **What it does:** A typo-aware search tool. It searches for a query in your files and can find similar words (typos) or subword matches.
+  - **What it does:** Searches for words or patterns. It is a typo-aware search tool. It searches for a query in your files and can find similar words (typos) or subword matches.
   - **Options:**
     - `-Q`, `--query`: The word or pattern to search for.
     - `--max-dist`: Maximum number of character changes for similar word matching (default: 0).
@@ -294,7 +294,7 @@ These modes help you analyze your data.
   - **Example:** `python multitool.py search report.txt -Q 'teh' --max-dist 1 --line-numbers`
 
 - **`scan`**
-  - **What it does:** Like a batch version of the `search` mode. It searches for every word in a mapping file, list, or extra pairs and reports all matches with filename, line number, and highlighting. This is the recommended way to check your project for a set of known typos before performing replacements.
+  - **What it does:** Scans project for known typos. It is like a batch version of the `search` mode. It searches for every word in a mapping file, list, or extra pairs and reports all matches with filename, line number, and highlighting. This is the recommended way to check your project for a set of known typos before performing replacements.
   - **Options:**
     - Use the `--mapping` flag to provide a file with typos or words to find.
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) or words to match directly on the command line.
@@ -302,7 +302,7 @@ These modes help you analyze your data.
   - **Example:** `python multitool.py scan . --add teh:the --smart`
 
 - **`verify`**
-  - **What it does:** Finds which entries in a mapping file or extra pairs are present in the provided input files. It provides a high-level summary of which typos were found and which were missing.
+  - **What it does:** Checks if typos exist in project. It finds which entries in a mapping file or extra pairs are present in the provided input files. It provides a high-level summary of which typos were found and which were missing.
   - **Options:**
     - Use the `--mapping` flag to provide the file containing typos to check.
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) or words to match directly on the command line.


### PR DESCRIPTION
This PR synchronizes the **Multitool** documentation in `docs/multitool.md` with the tool's actual CLI help output.

**Changes:**
- Updated "What it does" descriptions for all modes to start with the exact summary string from `multitool.py`.
- Standardized GET DATA mode summaries to use the verb "Extracts" (replacing "Gets").
- Removed numbering from category headers (GET DATA, CHANGE DATA, CHECK & ANALYZE) to match the CLI help categories.
- Fixed a duplication of the `resolve` mode entry that was present in a previous draft.
- Verified that all documentation examples and labels match the current code behavior.

**Reasoning:**
Consistent documentation is essential for usability. By ensuring the Markdown docs match the `--help` output exactly, we reduce confusion for users who switch between the web documentation and the command line. The use of Plain English and active voice improves accessibility for a global audience.

---
*PR created automatically by Jules for task [10553635585993164347](https://jules.google.com/task/10553635585993164347) started by @RainRat*