### PR TITLE
Deduplicate variation counting in standardize mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -4226,20 +4226,16 @@ def standardize_mode(
         for line in tqdm(file_lines, desc=f"Analyzing {input_file}", unit=" lines", disable=quiet):
             parts = pattern.findall(line)
             for part in parts:
-                # Full word analysis
-                norm = filter_to_letters(part) if clean_items else part.lower()
-                if norm:
-                    if min_length <= len(norm) <= max_length:
-                        variation_counts[norm][part] += 1
-
-                # Sub-word analysis for CamelCase/snake_case consistency
+                # Collect candidates for analysis (full word and any sub-parts)
+                candidates = [part]
                 sub_parts = _smart_split(part)
                 if len(sub_parts) > 1:
-                    for sp in sub_parts:
-                        sp_norm = filter_to_letters(sp) if clean_items else sp.lower()
-                        if sp_norm:
-                            if min_length <= len(sp_norm) <= max_length:
-                                variation_counts[sp_norm][sp] += 1
+                    candidates.extend(sub_parts)
+
+                for cand in candidates:
+                    norm = filter_to_letters(cand) if clean_items else cand.lower()
+                    if norm and min_length <= len(norm) <= max_length:
+                        variation_counts[norm][cand] += 1
 
     # Pass 2: Find "winners" and build mapping
     mapping = {}


### PR DESCRIPTION
* **What:** Unified the logic for analyzing word variations in `standardize_mode` by consolidating the separate blocks for full-word and sub-word analysis into a single loop.
* **Why:** Reduces code duplication and improves maintainability by ensuring that normalization, filtering, and counting logic are managed in one place. No breaking changes were introduced, as verified by the full test suite.

---
*PR created automatically by Jules for task [13143666424914071055](https://jules.google.com/task/13143666424914071055) started by @RainRat*