### PR TITLE
[UI/UX] Enhance typo classification labels and semantic coloring

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -231,7 +231,8 @@ def get_adjacent_keys(include_diagonals: bool = True) -> dict[str, set[str]]:
 def classify_typo(typo: str, correction: str, adj_keys: dict[str, set[str]]) -> str:
     """
     Groups a typo based on its relationship to the correction.
-    Returns a code: [K] Keyboard, [T] Transposition, [D] Deletion, [I] Insertion, [R] Replacement, [M] Multiple letters.
+    Returns a code: [K] Keyboard, [T] Transposition, [Del] Deletion, [Ins] Insertion,
+    [1:2] 1-to-2 replacement, [2:1] 2-to-1 replacement, [R] Replacement, [M] Multiple.
     """
     if not typo or not correction or typo == correction:
         return "[?]"
@@ -257,21 +258,31 @@ def classify_typo(typo: str, correction: str, adj_keys: dict[str, set[str]]) -> 
 
         return "[M]"
 
-    # 2. Deletion [D] - Typo is shorter (a character was removed)
-    if len_diff == -1:
-        for i in range(c_len):
-            if correction[:i] + correction[i+1:] == typo:
-                return "[D]"
-        return "[M]"
-
-    # 3. Insertion [I] - Typo is longer (a character was added)
+    # Typo is longer (Insertion or 1-to-2 replacement)
     if len_diff == 1:
-        for i in range(t_len):
-            if typo[:i] + typo[i+1:] == correction:
-                return "[I]"
-        return "[M]"
+        # Check for 1-to-2 replacement or Insertion
+        for i in range(c_len):
+            if typo[:i] == correction[:i] and typo[i+2:] == correction[i+1:]:
+                if correction[i] in typo[i:i+2]:
+                    return "[Ins]"
+                return "[1:2]"
+        # Insertion at the end
+        if typo[:-1] == correction:
+            return "[Ins]"
 
-    # 5. Multiple letters [M] - Fallback for any other length difference or non-match
+    # Typo is shorter (Deletion or 2-to-1 replacement)
+    if len_diff == -1:
+        # Check for 2-to-1 replacement or Deletion
+        for i in range(t_len):
+            if correction[:i] == typo[:i] and correction[i+2:] == typo[i+1:]:
+                if typo[i] in correction[i:i+2]:
+                    return "[Del]"
+                return "[2:1]"
+        # Deletion at the end
+        if correction[:-1] == typo:
+            return "[Del]"
+
+    # Fallback for any other length difference or non-match
     return "[M]"
 
 
@@ -993,6 +1004,8 @@ def _write_paired_output(
                 c_green = GREEN if show_color else ""
                 c_red = RED if show_color else ""
                 c_cyan = CYAN if show_color else ""
+                c_magenta = MAGENTA if show_color else ""
+                c_yellow = YELLOW if show_color else ""
                 c_reset = RESET if show_color else ""
 
                 # Header and divider
@@ -1016,7 +1029,18 @@ def _write_paired_output(
                     row = f"{padding}{c_red}{left:<{max_left}}{c_reset} {sep} {c_green}{right:<{max_right}}{c_reset}"
                     if has_attr:
                         attr = p[2]
-                        row += f" {sep} {c_cyan}{attr:<{max_attr}}{c_reset}"
+                        # Semantic coloring for the attribute column
+                        c_attr = c_cyan
+                        if "[T]" in attr:
+                            c_attr = c_magenta
+                        elif any(tag in attr for tag in ("[Del]", "[2:1]")):
+                            c_attr = c_red
+                        elif any(tag in attr for tag in ("[Ins]", "[1:2]")):
+                            c_attr = c_green
+                        elif any(tag in attr for tag in ("[R]", "[M]")):
+                            c_attr = c_yellow
+
+                        row += f" {sep} {c_attr}{attr:<{max_attr}}{c_reset}"
                     out_file.write(row + "\n")
                 out_file.write("\n")
         else:  # 'line' or fallback
@@ -5314,7 +5338,7 @@ MODE_DETAILS = {
     },
     "classify": {
         "summary": "Groups typos by error type",
-        "description": "Labels typo pairs with error codes like [K] Keyboard, [T] Transposition, [D] Deletion, [I] Insertion, [R] Replacement, and [M] Multiple letters. Use --show-dist to include the number of character changes.",
+        "description": "Labels typo pairs with error codes like [K] Keyboard, [T] Transposition, [Del] Deletion, [Ins] Insertion, [1:2] 1-to-2, [2:1] 2-to-1, [R] Replacement, and [M] Multiple. Use --show-dist to include the number of character changes.",
         "example": "python multitool.py classify typos.txt --show-dist --output labeled.txt",
         "flags": "[--show-dist]",
     },

--- a/tests/test_multitool_classify.py
+++ b/tests/test_multitool_classify.py
@@ -54,11 +54,11 @@ def test_classify_typo_logic():
     # [T] Transposition
     assert multitool.classify_typo("teh", "the", adj) == "[T]"
 
-    # [D] Deletion
-    assert multitool.classify_typo("helo", "hello", adj) == "[D]"
+    # [Del] Deletion
+    assert multitool.classify_typo("helo", "hello", adj) == "[Del]"
 
-    # [I] Insertion
-    assert multitool.classify_typo("helloo", "hello", adj) == "[I]"
+    # [Ins] Insertion
+    assert multitool.classify_typo("helloo", "hello", adj) == "[Ins]"
 
     # [K] Keyboard
     assert multitool.classify_typo("helko", "hello", adj) == "[K]"
@@ -77,7 +77,7 @@ def test_classify_typo_logic():
 
     # Coverage for line 202: return "[?]"
     # This is hard to reach because [M] covers anything with distance > 1,
-    # and [T], [D], [I], [R], [K] cover distance 1.
+    # and [T], [Del], [Ins], [R], [K] cover distance 1.
     # Distance 0?
     assert multitool.classify_typo("the", "the", adj) == "[?]"
 
@@ -97,7 +97,7 @@ def test_classify_mode_basic(tmp_path):
 
     content = output_file.read_text()
     assert "teh" in content and "the" in content and "[T]" in content
-    assert "helo" in content and "hello" in content and "[D]" in content
+    assert "helo" in content and "hello" in content and "[Del]" in content
 
 def test_classify_mode_show_dist(tmp_path):
     input_file = tmp_path / "input.txt"

--- a/tests/test_multitool_coverage_completion.py
+++ b/tests/test_multitool_coverage_completion.py
@@ -14,11 +14,12 @@ def strip_ansi(text):
     return ansi_escape.sub('', text)
 
 def test_classify_typo_multiple_letters_gaps():
-    # Line 191: Deletion-length-diff-1 but not a simple deletion
+    # Deletion-length-diff-1 but not a simple deletion
     # 'abc' (len 3) -> 'ax' (len 2)
-    assert multitool.classify_typo("ax", "abc", {}) == "[M]"
+    # This is now identified as a 2-to-1 replacement
+    assert multitool.classify_typo("ax", "abc", {}) == "[2:1]"
 
-    # Line 198: Insertion-length-diff-1 but not a simple insertion
+    # Insertion-length-diff-1 but not a simple insertion
     # 'abc' (len 3) -> 'axby' (len 4)
     assert multitool.classify_typo("axby", "abc", {}) == "[M]"
 

--- a/tests/test_multitool_discovery.py
+++ b/tests/test_multitool_discovery.py
@@ -21,8 +21,8 @@ def test_discovery_mode_basic(tmp_path):
     )
 
     content = output_file.read_text().splitlines()
-    assert "helo -> hello [D]" in content
-    assert "worldd -> world [I]" in content
+    assert "helo -> hello [Del]" in content
+    assert "worldd -> world [Ins]" in content
     assert len(content) == 2
 
 def test_discovery_mode_json_format(tmp_path):
@@ -46,7 +46,7 @@ def test_discovery_mode_json_format(tmp_path):
 
     with open(output_file) as f:
         data = json.load(f)
-    assert data == {"aple": "apple [D]"}
+    assert data == {"aple": "apple [Del]"}
 
 def test_discovery_mode_thresholds(tmp_path):
     input_file = tmp_path / "input.txt"
@@ -109,7 +109,7 @@ def test_discovery_mode_distance(tmp_path):
         output_format='line'
     )
     content = output_file.read_text().splitlines()
-    assert "distnce -> distance [D]" in content
+    assert "distnce -> distance [Del]" in content
     assert "distnc -> distance" not in content
 
     # Max distance 2
@@ -126,7 +126,7 @@ def test_discovery_mode_distance(tmp_path):
         output_format='line'
     )
     content = output_file.read_text().splitlines()
-    assert "distnce -> distance [D]" in content
+    assert "distnce -> distance [Del]" in content
     assert "distnc -> distance [M]" in content
 
 def test_discovery_mode_smart_splitting(tmp_path):


### PR DESCRIPTION
### [UI/UX] Enhance Typo Classification and Feedback

**Context:** CLI (multitool.py)

**Problem:** 
The `classify` mode in `multitool.py` used generic labels like `[D]` (Deletion) and `[I]` (Insertion) and lacked granular detection for common multi-character patterns like 1-to-2 replacements (e.g., 'm' -> 'rn'). Additionally, the output was monochrome, making it harder to quickly scan and interpret results compared to the rich visual reports in `typostats.py`.

**Solution:**
1.  **Granular Labels:** Updated the classification logic to identify `[1:2]` and `[2:1]` replacements and renamed `[D]`/`[I]` to `[Del]`/`[Ins]` for better clarity and consistency with the suite.
2.  **Semantic Coloring:** Introduced color-coding for the `Attr` column in `arrow` format. Labels are now colorized based on error type:
    *   **Red:** Deletions and 2-to-1 replacements.
    *   **Green:** Insertions and 1-to-2 replacements.
    *   **Cyan:** Keyboard slips (`[K]`).
    *   **Magenta:** Transpositions (`[T]`).
    *   **Yellow:** General replacements or multiple changes.

This improvement reduces cognitive load when analyzing large typo lists and provides immediate visual feedback on the nature of detected errors.

**Changes:**
- Modified `classify_typo` and `_write_paired_output` in `multitool.py`.
- Updated `MODE_DETAILS` and docstrings.
- Updated 3 test files to match the new label format.

---
*PR created automatically by Jules for task [15752825974353302577](https://jules.google.com/task/15752825974353302577) started by @RainRat*