### PR TITLE
[FEAT] Add sort mode to Multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -106,6 +106,11 @@ These modes help you transform or combine your data.
   - **What it does:** Removes duplicates, keeps order. It removes duplicate items from your list while **keeping the original order** in which they first appeared.
   - **Example:** `python multitool.py unique raw_typos.txt`
 
+- **`sort`**
+  - **What it does:** Sorts items by length or alpha. Orders your list of words or lines. You can sort alphabetically, by the number of characters (length), or numerically. This is great for finding the longest or shortest typos in a dataset.
+  - **Options:** Use `--by` to choose the criteria (`alpha`, `length`, or `numeric`). Use `--reverse` to flip the order and `-u` to remove duplicates.
+  - **Example:** `python multitool.py sort typos.txt --by length --reverse`
+
 - **`resolve`**
   - **What it does:** Shortens typo correction chains. It finds and shortens chains of typo corrections. For example, if your mapping file contains `A -> B` and `B -> C`, this mode will resolve them to `A -> C` and `B -> C`.
   - **Example:** `python multitool.py resolve mappings.csv`

--- a/multitool.py
+++ b/multitool.py
@@ -4071,6 +4071,55 @@ def resolve_mode(
     )
 
 
+def sort_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    by: str = 'alpha',
+    reverse: bool = False,
+    unique: bool = False,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Sorts lines or items based on alphabetical, length, or numeric criteria."""
+    start_time = time.perf_counter()
+
+    raw_items = []
+    for input_file in input_files:
+        raw_items.extend(_extract_line_items(input_file, quiet=quiet))
+
+    filtered_items = clean_and_filter(raw_items, min_length, max_length, clean=clean_items)
+
+    if unique or process_output:
+        filtered_items = list(dict.fromkeys(filtered_items))
+
+    if by == 'length':
+        sort_key = lambda x: (len(x), x)
+    elif by == 'numeric':
+        def _to_num(s):
+            try:
+                num_str = re.sub(r'[^-0-9.]', '', s)
+                return float(num_str) if num_str else 0
+            except (ValueError, TypeError):
+                return 0
+        sort_key = _to_num
+    else:  # alpha
+        sort_key = str.lower
+
+    filtered_items.sort(key=sort_key, reverse=reverse)
+
+    write_output(filtered_items, output_file, output_format, quiet, limit=limit)
+
+    print_processing_stats(len(raw_items), filtered_items, start_time=start_time)
+    logging.info(
+        f"[Sort Mode] Successfully sorted {len(filtered_items)} items by {by}. Output written to '{output_file}'."
+    )
+
+
 def sample_mode(
     input_files: Sequence[str],
     output_file: str,
@@ -5313,6 +5362,12 @@ MODE_DETAILS = {
         "example": "python multitool.py unique raw_typos.txt --output clean_typos.txt",
         "flags": "",
     },
+    "sort": {
+        "summary": "Sorts items by length or alpha",
+        "description": "Orders your list of words or lines. You can sort alphabetically, by the number of characters (length), or numerically. This is great for finding the longest or shortest typos in a dataset.",
+        "example": "python multitool.py sort typos.txt --by length --reverse",
+        "flags": "[--by {alpha,length,numeric}] [--reverse] [-u]",
+    },
     "backtick": {
         "summary": "Extracts text inside backticks",
         "description": "Finds text inside backticks (like `code`). It prioritizes items near words like 'error' or 'warning' to find the most relevant data.",
@@ -5578,7 +5633,7 @@ def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
         "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "toml", "xml", "line", "words", "ngrams", "regex"],
-        "CHANGE DATA": ["combine", "unique", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
+        "CHANGE DATA": ["combine", "unique", "sort", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
 
@@ -6132,6 +6187,32 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['unique']['example']}{RESET}",
     )
     _add_common_mode_arguments(unique_parser)
+
+    sort_parser = subparsers.add_parser(
+        'sort',
+        help=MODE_DETAILS['sort']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['sort']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['sort']['example']}{RESET}",
+    )
+    sort_options = sort_parser.add_argument_group(f"{BLUE}SORT OPTIONS{RESET}")
+    sort_options.add_argument(
+        '--by',
+        choices=['alpha', 'length', 'numeric'],
+        default='alpha',
+        help="Criteria to sort by: 'alpha' (alphabetical, default), 'length' (word length), or 'numeric'.",
+    )
+    sort_options.add_argument(
+        '--reverse',
+        action='store_true',
+        help="Reverse the sorting order (e.g., longest words first).",
+    )
+    sort_options.add_argument(
+        '-u', '--unique',
+        action='store_true',
+        help="Remove duplicate items before sorting.",
+    )
+    _add_common_mode_arguments(sort_parser)
 
     line_parser = subparsers.add_parser(
         'line',
@@ -7468,6 +7549,16 @@ def main() -> None:
                 'output_format': output_format,
                 'clean_items': clean_items,
                 'limit': limit,
+            },
+        ),
+        'sort': (
+            sort_mode,
+            {
+                **common_kwargs,
+                'by': getattr(args, 'by', 'alpha'),
+                'reverse': getattr(args, 'reverse', False),
+                'unique': getattr(args, 'unique', False),
+                'output_format': output_format,
             },
         ),
         'diff': (

--- a/tests/test_multitool_sort.py
+++ b/tests/test_multitool_sort.py
@@ -1,0 +1,87 @@
+import os
+import pytest
+from multitool import sort_mode
+
+def test_sort_mode_alpha(tmp_path):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("banana\napple\ncherry\n")
+    output_file = tmp_path / "output.txt"
+
+    sort_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        by='alpha',
+        reverse=False,
+        unique=False,
+        output_format='line',
+        quiet=True,
+        clean_items=False
+    )
+
+    assert output_file.read_text().splitlines() == ["apple", "banana", "cherry"]
+
+def test_sort_mode_length(tmp_path):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("a\nbbb\ncc\n")
+    output_file = tmp_path / "output.txt"
+
+    sort_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        by='length',
+        reverse=False,
+        unique=False,
+        output_format='line',
+        quiet=True,
+        clean_items=False
+    )
+
+    assert output_file.read_text().splitlines() == ["a", "cc", "bbb"]
+
+def test_sort_mode_numeric(tmp_path):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("10\n2\n20\n1\n")
+    output_file = tmp_path / "output.txt"
+
+    sort_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        by='numeric',
+        reverse=False,
+        unique=False,
+        output_format='line',
+        quiet=True,
+        clean_items=False
+    )
+
+    assert output_file.read_text().splitlines() == ["1", "2", "10", "20"]
+
+def test_sort_mode_reverse_unique(tmp_path):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("apple\nbanana\napple\ncherry\n")
+    output_file = tmp_path / "output.txt"
+
+    sort_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        by='alpha',
+        reverse=True,
+        unique=True,
+        output_format='line',
+        quiet=True,
+        clean_items=False
+    )
+
+    assert output_file.read_text().splitlines() == ["cherry", "banana", "apple"]


### PR DESCRIPTION
### [FEAT] Add `sort` mode to Multitool

This PR introduces a new `sort` mode to the Multitool utility, expanding its data transformation capabilities.

#### What:
A dedicated `sort` command has been added to `multitool.py`. It allows users to order text data using three primary criteria:
- **`alpha`**: Standard case-insensitive alphabetical sorting (default).
- **`length`**: Sorting by string length, useful for finding long/short typos.
- **`numeric`**: Extracts numbers from lines to sort them numerically.

The mode supports the following flags:
- `--by {alpha,length,numeric}`: Select sorting criteria.
- `--reverse`: Flip the sort order.
- `-u` / `--unique`: Remove duplicate items before sorting.

#### Why:
While Multitool provided many ways to extract and clean data, it lacked a flexible way to reorder lists. Sorting by length is a common task when curating typo dictionaries or analyzing Git history results to find anomalies. Numeric sorting provides interoperability with datasets that include counts or IDs. This addition completes a logical gap in the "CHANGE DATA" category of the suite.

#### Changes:
1.  **Code**: Implemented `sort_mode` and integrated it into the `argparse` subparser logic.
2.  **Metadata**: Added `sort` to `MODE_DETAILS` and categorized it under `CHANGE DATA` in the help summary.
3.  **Docs**: Updated `docs/multitool.md` with detailed descriptions and examples.
4.  **Tests**: Created `tests/test_multitool_sort.py` covering all new functionality.

Verified with 808 passing tests.

---
*PR created automatically by Jules for task [3624049294344125482](https://jules.google.com/task/3624049294344125482) started by @RainRat*