### PR TITLE
[FEAT] Add dedicated sort mode to multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -106,6 +106,15 @@ These modes help you transform or combine your data.
   - **What it does:** Removes duplicates, keeps order. It removes duplicate items from your list while **keeping the original order** in which they first appeared.
   - **Example:** `python multitool.py unique raw_typos.txt`
 
+- **`sort`**
+  - **What it does:** Sorts items in a list. It sorts items from input file(s) by alphabetical order, length, or numeric value. It supports reverse sorting and deduplication.
+  - **Options:**
+    - Use `--by` to choose the sorting method: `alpha` (alphabetical, default), `length` (string length), or `numeric` (numeric value).
+    - Use `--reverse` to sort in descending order.
+    - Use the `-u` (or `--unique`) flag to remove duplicate items before sorting.
+  - **Note:** For numeric sorting, the tool extracts the first number found in each item for comparison. Numeric sorting works best with the `--raw` flag to prevent digits from being stripped.
+  - **Example:** `python multitool.py sort wordlist.txt --by length --reverse`
+
 - **`resolve`**
   - **What it does:** Shortens typo correction chains. It finds and shortens chains of typo corrections. For example, if your mapping file contains `A -> B` and `B -> C`, this mode will resolve them to `A -> C` and `B -> C`.
   - **Example:** `python multitool.py resolve mappings.csv`

--- a/multitool.py
+++ b/multitool.py
@@ -3805,6 +3805,64 @@ def unique_mode(
     )
 
 
+def sort_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    by: str = 'alpha',
+    reverse: bool = False,
+    unique: bool = False,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Sorts items from input file(s) by alphabetical order, length, or numeric value."""
+    start_time = time.perf_counter()
+
+    if by == 'numeric' and clean_items:
+        logging.warning("Numeric sorting works best with the --raw (-R) flag. Default cleaning might remove digits.")
+
+    all_raw_count = 0
+    all_items = []
+    for file_path in input_files:
+        raw, cleaned, _ = _load_and_clean_file(
+            file_path,
+            min_length,
+            max_length,
+            clean_items=clean_items,
+        )
+        all_raw_count += len(raw)
+        all_items.extend(cleaned)
+
+    if unique or process_output:
+        all_items = list(dict.fromkeys(all_items))
+
+    def numeric_key(s):
+        match = re.search(r'\d+', s)
+        return int(match.group()) if match else 0
+
+    if by == 'length':
+        sort_key = len
+    elif by == 'numeric':
+        sort_key = numeric_key
+    else:  # 'alpha'
+        sort_key = str.lower
+
+    final_items = sorted(all_items, key=sort_key, reverse=reverse)
+
+    write_output(final_items, output_file, output_format, quiet, limit=limit)
+    print_processing_stats(all_raw_count, final_items, start_time=start_time)
+    logging.info(
+        "[Sort Mode] Sorted %d items by %s. Output written to '%s'.",
+        len(final_items),
+        by,
+        output_file,
+    )
+
+
 def zip_mode(
     input_files: Sequence[str],
     file2: str,
@@ -5571,6 +5629,12 @@ MODE_DETAILS = {
         "example": "python multitool.py resolve mappings.csv --output resolved.csv",
         "flags": "",
     },
+    "sort": {
+        "summary": "Sorts items in a list",
+        "description": "Sorts items from input file(s) by alphabetical order, length, or numeric value. It supports reverse sorting and deduplication. Numeric sorting extracts the first number found in each item for comparison.",
+        "example": "python multitool.py sort wordlist.txt --by length --reverse",
+        "flags": "[--by {alpha,length,numeric}] [--reverse] [-u]",
+    },
 }
 
 
@@ -5578,7 +5642,7 @@ def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
         "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "toml", "xml", "line", "words", "ngrams", "regex"],
-        "CHANGE DATA": ["combine", "unique", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
+        "CHANGE DATA": ["combine", "unique", "sort", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
 
@@ -7040,6 +7104,32 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_common_mode_arguments(resolve_parser)
 
+    sort_parser = subparsers.add_parser(
+        'sort',
+        help=MODE_DETAILS['sort']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['sort']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['sort']['example']}{RESET}",
+    )
+    sort_options = sort_parser.add_argument_group(f"{BLUE}SORT OPTIONS{RESET}")
+    sort_options.add_argument(
+        '--by',
+        choices=['alpha', 'length', 'numeric'],
+        default='alpha',
+        help="How to sort the items: 'alpha' (alphabetical), 'length' (string length), or 'numeric' (numeric value).",
+    )
+    sort_options.add_argument(
+        '--reverse',
+        action='store_true',
+        help="Sort in reverse order.",
+    )
+    sort_options.add_argument(
+        '-u', '--unique',
+        action='store_true',
+        help="Remove duplicate items before sorting.",
+    )
+    _add_common_mode_arguments(sort_parser)
+
     align_parser = subparsers.add_parser(
         'align',
         help=MODE_DETAILS['align']['summary'],
@@ -7288,6 +7378,16 @@ def main() -> None:
             resolve_mode,
             {
                 **common_kwargs,
+                'output_format': output_format,
+            },
+        ),
+        'sort': (
+            sort_mode,
+            {
+                **common_kwargs,
+                'by': getattr(args, 'by', 'alpha'),
+                'reverse': getattr(args, 'reverse', False),
+                'unique': getattr(args, 'unique', False),
                 'output_format': output_format,
             },
         ),

--- a/tests/test_multitool_sort.py
+++ b/tests/test_multitool_sort.py
@@ -1,0 +1,70 @@
+import pytest
+from multitool import main
+import sys
+from io import StringIO
+
+def test_sort_alpha(tmp_path, monkeypatch):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("banana\napple\ncherry\n")
+
+    output_file = tmp_path / "output.txt"
+
+    args = ["multitool.py", "sort", str(input_file), "-o", str(output_file), "--by", "alpha"]
+    monkeypatch.setattr(sys, 'argv', args)
+
+    main()
+
+    assert output_file.read_text().strip().split('\n') == ["apple", "banana", "cherry"]
+
+def test_sort_length(tmp_path, monkeypatch):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("banana\napple\ncherryberry\n")
+
+    output_file = tmp_path / "output.txt"
+
+    args = ["multitool.py", "sort", str(input_file), "-o", str(output_file), "--by", "length"]
+    monkeypatch.setattr(sys, 'argv', args)
+
+    main()
+
+    assert output_file.read_text().strip().split('\n') == ["apple", "banana", "cherryberry"]
+
+def test_sort_numeric(tmp_path, monkeypatch):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("item10\nitem2\nitem1\n")
+
+    output_file = tmp_path / "output.txt"
+
+    # Use -R to prevent digits from being stripped during cleaning
+    args = ["multitool.py", "sort", str(input_file), "-o", str(output_file), "--by", "numeric", "-R"]
+    monkeypatch.setattr(sys, 'argv', args)
+
+    main()
+
+    assert output_file.read_text().strip().split('\n') == ["item1", "item2", "item10"]
+
+def test_sort_reverse(tmp_path, monkeypatch):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("apple\nbanana\ncherry\n")
+
+    output_file = tmp_path / "output.txt"
+
+    args = ["multitool.py", "sort", str(input_file), "-o", str(output_file), "--reverse"]
+    monkeypatch.setattr(sys, 'argv', args)
+
+    main()
+
+    assert output_file.read_text().strip().split('\n') == ["cherry", "banana", "apple"]
+
+def test_sort_unique(tmp_path, monkeypatch):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("apple\nbanana\napple\n")
+
+    output_file = tmp_path / "output.txt"
+
+    args = ["multitool.py", "sort", str(input_file), "-o", str(output_file), "-u"]
+    monkeypatch.setattr(sys, 'argv', args)
+
+    main()
+
+    assert output_file.read_text().strip().split('\n') == ["apple", "banana"]


### PR DESCRIPTION
### [FEAT] Add dedicated sort mode to multitool

**What:**
A new `sort` mode has been implemented in `multitool.py`. This mode allows users to sort list items from one or more files based on three primary criteria:
- `alpha`: Standard alphabetical sorting (default).
- `length`: Sorts items by their string length.
- `numeric`: Extracts the first numeric value from each string and sorts by that value.

It also supports:
- `--reverse`: Reverses the sort order.
- `-u` / `--unique`: Integrated deduplication while sorting.
- Standard `multitool` filters like `--min-length`, `--max-length`, and `--raw`.

**Why:**
I noticed that while `multitool.py` provides robust data extraction and cleaning capabilities, it lacked a flexible, standalone sorting utility. Existing modes like `combine` and `unique` (when used with `-P`) perform alphabetical sorting as a secondary effect, but there was no way to sort by length or numeric value, or to perform a reverse sort easily. Adding a dedicated `sort` mode provides "Symmetry" to the tool's list-manipulation feature set and offers immediate "Convenience" for organizing extracted data.

**Changes:**
- **multitool.py**:
    - Added `sort_mode` function.
    - Updated `MODE_DETAILS` dictionary with sort mode metadata.
    - Updated `get_mode_summary_text` to include `sort` in the "CHANGE DATA" category.
    - Configured the CLI subparser for the `sort` command.
    - Registered the mode in the `handler_map`.
- **docs/multitool.md**: Added detailed documentation for the new `sort` mode.
- **tests/test_multitool_sort.py**: Implemented unit tests for all new sorting functionality.

---
*PR created automatically by Jules for task [1814607631672590498](https://jules.google.com/task/1814607631672590498) started by @RainRat*