### PR TITLE
Narrow broad exception handler in `_get_total_line_count`

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -348,7 +348,7 @@ def _get_total_line_count(input_files: Sequence[str]) -> int:
                     # buffer-aware line counting is generally faster than sum(1 for _ in fp)
                     # but sum(1 for line in fp) is clear and optimized in Python 3
                     total += sum(1 for _ in fp)
-            except Exception:
+            except OSError:
                 pass
     return total
 

--- a/tests/test_line_count_error.py
+++ b/tests/test_line_count_error.py
@@ -1,0 +1,18 @@
+import pytest
+from multitool import _get_total_line_count
+from unittest.mock import patch
+
+def test_get_total_line_count_nonexistent_file():
+    # Attempting to count lines in a non-existent file should return 0 and not raise OSError
+    assert _get_total_line_count(["nonexistent_file.txt"]) == 0
+
+def test_get_total_line_count_oserror_mock():
+    # Mocking open to raise OSError should return 0
+    with patch("builtins.open", side_effect=OSError("Access Denied")):
+        assert _get_total_line_count(["some_file.txt"]) == 0
+
+def test_get_total_line_count_mixed_files(tmp_path):
+    f = tmp_path / "test.txt"
+    f.write_text("line1\nline2\n")
+    # One valid file, one non-existent
+    assert _get_total_line_count([str(f), "nonexistent.txt"]) == 2


### PR DESCRIPTION
**PR Title:** Narrow broad exception handler in `_get_total_line_count`

**Description:**
* **What:** The broad `except Exception:` block in the `_get_total_line_count` function within `multitool.py` has been narrowed to `except OSError:`. Additionally, a new test suite `tests/test_line_count_error.py` has been implemented to verify that the function still handles missing or inaccessible files correctly.
* **Why:** Catching `Exception` is a form of "Error Handling Noise" that can hide critical bugs or unexpected signals (like `KeyboardInterrupt`). By narrowing the scope to `OSError`, the tool specifically handles the I/O-related failures expected during file pre-processing (like a missing file or a permission error) while allowing unrelated logic errors to be properly reported. This improvement enhances code safety and maintainability without changing the external behavior for end-users.

---
*PR created automatically by Jules for task [1663281715680626143](https://jules.google.com/task/1663281715680626143) started by @RainRat*