### PR TITLE
[FEAT] Casing transformation mode for multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -148,6 +148,13 @@ These modes help you transform or combine your data.
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) directly on the command line.
   - **Example:** `python multitool.py map input.txt --add teh:the`
 
+- **`case`**
+  - **What it does:** Changes word casing. It converts words to a specified casing style. It automatically identifies sub-words within compound words and preserves the overall structure.
+  - **Options:**
+    - Use the `--to` flag to choose the target casing style: `lower`, `upper`, `snake` (snake_case), `camel` (camelCase), `pascal` (PascalCase), `kebab` (kebab-case), `title` (Title Case), `constant` (CONSTANT_CASE), or `sentence` (Sentence case).
+    - Use the `--pairs` (or `-p`) flag to see both the original and converted words.
+  - **Example:** `python multitool.py case wordlist.txt --to snake --pairs`
+
 - **`sample`**
   - **What it does:** Picks a random set of lines. You can pick a specific number (`--n 100`) or a percentage (`--percent 10`).
   - **Example:** `python multitool.py sample big_log.txt --n 50`

--- a/multitool.py
+++ b/multitool.py
@@ -304,6 +304,36 @@ def _smart_split(text: str) -> List[str]:
     return re.findall(r'[A-Z]?[a-z]+|[A-Z]+(?![a-z])|[0-9]+', text)
 
 
+def to_case(text: str, style: str) -> str:
+    """Converts a string to a specified casing style."""
+    words = _smart_split(text)
+    if not words:
+        return text
+
+    style = style.lower()
+    if style == 'lower':
+        return text.lower()
+    if style == 'upper':
+        return text.upper()
+    if style == 'snake':
+        return '_'.join(w.lower() for w in words)
+    if style == 'camel':
+        return words[0].lower() + ''.join(w.capitalize() for w in words[1:])
+    if style == 'pascal':
+        return ''.join(w.capitalize() for w in words)
+    if style == 'kebab':
+        return '-'.join(w.lower() for w in words)
+    if style == 'title':
+        return ' '.join(w.capitalize() for w in words)
+    if style == 'constant':
+        return '_'.join(w.upper() for w in words)
+    if style == 'sentence':
+        res = ' '.join(w.lower() for w in words)
+        return res[0].upper() + res[1:] if res else ""
+
+    return text
+
+
 def clean_and_filter(items: Iterable[str], min_length: int, max_length: int, clean: bool = True) -> List[str]:
     """Clean items to letters only (if clean=True) and apply length filtering."""
     if clean:
@@ -2995,6 +3025,54 @@ def fuzzymatch_mode(
     )
 
 
+def case_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    to: str = 'lower',
+    pairs: bool = False,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """
+    Converts items to a specified casing style.
+    """
+    start_time = time.perf_counter()
+    raw_item_count = 0
+    results = []
+
+    for input_file in input_files:
+        lines = _read_file_lines_robust(input_file)
+        for line in lines:
+            line_content = line.strip()
+            if not line_content:
+                continue
+
+            raw_item_count += 1
+            transformed = to_case(line_content, to)
+
+            # Re-apply length filtering to the result
+            if transformed and min_length <= len(transformed) <= max_length:
+                results.append((line_content, transformed) if pairs else transformed)
+
+    if process_output:
+        results = sorted(set(results))
+
+    if pairs:
+        _write_paired_output(results, output_file, output_format, "Case", quiet, limit=limit)
+    else:
+        write_output(results, output_file, output_format, quiet, limit=limit)
+
+    stats_items = [r[1] if isinstance(r, tuple) else r for r in results]
+    print_processing_stats(
+        raw_item_count, stats_items, item_label="case-converted-item", start_time=start_time
+    )
+
+
 def casing_mode(
     input_files: Sequence[str],
     output_file: str,
@@ -5496,6 +5574,12 @@ MODE_DETAILS = {
         "example": "python multitool.py map input.txt --add teh:the --smart-case --pairs",
         "flags": "[-s MAPPING] [-a K:V] [--smart-case] [-p]",
     },
+    "case": {
+        "summary": "Changes word casing",
+        "description": "Converts words to a specified casing style like snake_case, camelCase, or PascalCase. It automatically identifies sub-words within compound words and preserves the overall structure. Use --pairs to see both the original and converted words.",
+        "example": "python multitool.py case wordlist.txt --to snake --pairs",
+        "flags": "[--to STYLE] [-p]",
+    },
     "zip": {
         "summary": "Pairs lines from two files",
         "description": "Joins two files line-by-line into a paired format like 'typo -> correction'. Useful for creating mapping files from two separate lists. Length filters are applied to both items in each pair.",
@@ -5647,7 +5731,7 @@ def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
         "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "toml", "xml", "line", "words", "ngrams", "regex"],
-        "CHANGE DATA": ["combine", "unique", "sort", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "zip", "swap", "pairs", "scrub", "standardize"],
+        "CHANGE DATA": ["combine", "unique", "sort", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
 
@@ -6804,6 +6888,27 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_common_mode_arguments(map_parser)
 
+    case_parser = subparsers.add_parser(
+        'case',
+        help=MODE_DETAILS['case']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['case']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['case']['example']}{RESET}",
+    )
+    case_options = case_parser.add_argument_group(f"{BLUE}CASE OPTIONS{RESET}")
+    case_options.add_argument(
+        '--to',
+        choices=['lower', 'upper', 'snake', 'camel', 'pascal', 'kebab', 'title', 'constant', 'sentence'],
+        default='lower',
+        help="Target casing style.",
+    )
+    case_options.add_argument(
+        '-p', '--pairs',
+        action='store_true',
+        help='Output the original word along with its transformation.',
+    )
+    _add_common_mode_arguments(case_parser)
+
     scrub_parser = subparsers.add_parser(
         'scrub',
         help=MODE_DETAILS['scrub']['summary'],
@@ -7667,6 +7772,15 @@ def main() -> None:
                 'output_format': output_format,
                 'pairs': getattr(args, 'pairs', False),
                 'smart_case': getattr(args, 'smart_case', False),
+            }
+        ),
+        'case': (
+            case_mode,
+            {
+                **common_kwargs,
+                'to': getattr(args, 'to', 'lower'),
+                'pairs': getattr(args, 'pairs', False),
+                'output_format': output_format,
             }
         ),
         'rename': (

--- a/tests/test_multitool_case.py
+++ b/tests/test_multitool_case.py
@@ -1,0 +1,88 @@
+import pytest
+from multitool import to_case, case_mode
+import io
+import contextlib
+
+def test_to_case():
+    s = "helloWorld_test-case"
+    assert to_case(s, "lower") == "helloworld_test-case"
+    assert to_case(s, "upper") == "HELLOWORLD_TEST-CASE"
+    assert to_case(s, "snake") == "hello_world_test_case"
+    assert to_case(s, "camel") == "helloWorldTestCase"
+    assert to_case(s, "pascal") == "HelloWorldTestCase"
+    assert to_case(s, "kebab") == "hello-world-test-case"
+    assert to_case(s, "title") == "Hello World Test Case"
+    assert to_case(s, "constant") == "HELLO_WORLD_TEST_CASE"
+    assert to_case(s, "sentence") == "Hello world test case"
+    assert to_case(s, "unknown") == s
+
+def test_to_case_simple():
+    s = "hello"
+    assert to_case(s, "upper") == "HELLO"
+    assert to_case(s, "snake") == "hello"
+    assert to_case(s, "pascal") == "Hello"
+
+def test_to_case_numbers():
+    s = "hello123world"
+    assert to_case(s, "snake") == "hello_123_world"
+    assert to_case(s, "camel") == "hello123World"
+
+def test_case_mode_basic(tmp_path):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("helloWorld\ntest-case\n")
+    output_file = tmp_path / "output.txt"
+
+    case_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        to='snake',
+        pairs=False,
+        output_format='line',
+        quiet=True,
+        clean_items=True
+    )
+
+    assert output_file.read_text() == "hello_world\ntest_case\n"
+
+def test_case_mode_pairs(tmp_path):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("helloWorld\n")
+    output_file = tmp_path / "output.txt"
+
+    case_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        to='pascal',
+        pairs=True,
+        output_format='line',
+        quiet=True,
+        clean_items=True
+    )
+
+    assert output_file.read_text() == "helloWorld -> HelloWorld\n"
+
+def test_case_mode_filter(tmp_path):
+    input_file = tmp_path / "input.txt"
+    input_file.write_text("a\nabc\nabcdef\n")
+    output_file = tmp_path / "output.txt"
+
+    case_mode(
+        input_files=[str(input_file)],
+        output_file=str(output_file),
+        min_length=2,
+        max_length=4,
+        process_output=False,
+        to='upper',
+        pairs=False,
+        output_format='line',
+        quiet=True,
+        clean_items=True
+    )
+
+    assert output_file.read_text() == "ABC\n"


### PR DESCRIPTION
This PR introduces a new `case` mode to `multitool.py`, providing a symmetric counterpart to the existing `casing` analysis mode.

### What
The new `case` mode allows users to transform text items into standard casing styles:
- `lower`, `upper`
- `snake` (snake_case)
- `camel` (camelCase)
- `pascal` (PascalCase)
- `kebab` (kebab-case)
- `title` (Title Case)
- `constant` (CONSTANT_CASE)
- `sentence` (Sentence case)

It integrates with the tool's global filtering options (`--min-length`, `--max-length`, `--process-output`, `--limit`) and supports a `--pairs` flag to output the original and transformed words together.

### Why
The "Symmetry" heuristic suggested that if the tool can analyze casing inconsistencies, it should also be able to resolve them by applying a uniform style. This feature adds immediate value for developers looking to standardize variable names, file contents, or documentation styles.

### Changes
- **multitool.py**: Added `to_case` and `case_mode` functions. Updated CLI parser (`_build_parser`), mode registry (`MODE_DETAILS`), and summary table (`get_mode_summary_text`).
- **docs/multitool.md**: Added documentation for the new `case` mode.
- **tests/test_multitool_case.py**: Created a new test suite for verification.

---
*PR created automatically by Jules for task [5210294901925055297](https://jules.google.com/task/5210294901925055297) started by @RainRat*