### PR TITLE
[UI/UX] Unify typostats arrow report output stream

### DIFF
--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -178,23 +178,23 @@ def test_generate_report_sorting_and_filtering(capsys):
 
 def test_generate_report_summaries(capsys):
     typostats.generate_report({('he', 'eh'): 1}, allow_transposition=True, quiet=False)
-    assert "Transpositions [T]:" in capsys.readouterr().err
+    assert "Transpositions [T]:" in capsys.readouterr().out
     typostats.generate_report({('a', 'b'): 1}, min_occurrences=2, quiet=False)
-    assert "Patterns matching criteria:" in capsys.readouterr().err
+    assert "Patterns matching criteria:" in capsys.readouterr().out
     typostats.generate_report({('a', 'b'): 2, ('c', 'd'): 1}, limit=1, quiet=False)
-    assert "Showing patterns:" in capsys.readouterr().err
+    assert "Showing patterns:" in capsys.readouterr().out
     counts = {('a', 'aa'): 1, ('bb', 'b'): 1, ('m', 'rn'): 1, ('ph', 'f'): 1}
     typostats.generate_report(counts, include_deletions=True, allow_1to2=True, allow_2to1=True, quiet=False)
-    err = capsys.readouterr().err
-    assert "Insertions [Ins]:" in err and "Deletions [Del]:" in err
-    assert "1-to-2 replacements [1:2]" in err and "2-to-1 replacements [2:1]" in err
+    out = capsys.readouterr().out
+    assert "Insertions [Ins]:" in out and "Deletions [Del]:" in out
+    assert "1-to-2 replacements [1:2]" in out and "2-to-1 replacements [2:1]" in out
 
 
 def test_generate_report_keyboard(capsys):
     counts = {('q', 'w'): 5, ('q', 'p'): 1}
     typostats.generate_report(counts, keyboard=True, quiet=False)
     captured = capsys.readouterr()
-    assert "Keyboard Adjacency" in captured.err
+    assert "Keyboard Adjacency" in captured.out
     assert "[K]" in captured.out
     assert "[K]" not in captured.out.splitlines()[-1]
 
@@ -221,9 +221,9 @@ def test_generate_report_markers_extra():
 
 def test_generate_report_edge_cases():
     # Empty filtering result
-    with patch('sys.stderr', new=io.StringIO()) as err:
+    with patch('sys.stdout', new=io.StringIO()) as out:
         typostats.generate_report({}, quiet=False)
-        assert "No patterns passed the filtering criteria" in err.getvalue()
+        assert "No patterns passed the filtering criteria" in out.getvalue()
 
     # File write failure
     with patch("builtins.open", side_effect=Exception("Write error")):
@@ -232,9 +232,9 @@ def test_generate_report_edge_cases():
             mock_log.assert_called()
 
     # Explicit no results
-    with patch('sys.stderr', new=io.StringIO()) as err:
+    with patch('sys.stdout', new=io.StringIO()) as out:
         typostats.generate_report({}, quiet=False)
-        assert "No replacements found matching the criteria" in err.getvalue()
+        assert "No replacements found matching the criteria" in out.getvalue()
 
 
 def test_detect_encoding_variants(caplog):
@@ -369,7 +369,7 @@ def test_typostats_subprocess_all(tmp_path):
     typos_file.write_text("teh -> the\nrecieve -> receive\nm -> rn\nph -> f\nor -> o\na -> aa\n", encoding="utf-8")
     result = subprocess.run([sys.executable, "typostats.py", str(typos_file), "-a"], capture_output=True, text=True)
     assert result.returncode == 0
-    assert "Enabled features:" in result.stderr
+    assert "Enabled features:" in result.stdout
     assert "he" in result.stdout and "rn" in result.stdout
 
 
@@ -743,7 +743,8 @@ def test_read_file_lines_robust_stdin_cache_explicit():
 def test_generate_report_with_file_variants(tmp_path, capsys):
     out_file = tmp_path / "report.txt"
     counts = {("correct", "typo"): 1}
-    typostats.generate_report(counts, output_file=str(out_file), quiet=True)
+    # When quiet=True, summary and headers are omitted even when writing to a file
+    typostats.generate_report(counts, output_file=str(out_file), quiet=False)
     assert out_file.exists()
     assert "Correction" in out_file.read_text()
 
@@ -763,14 +764,14 @@ def test_generate_report_extra_metrics_full(capsys):
         ("q", "w"): 1,      # [K]
     }
     typostats.generate_report(counts, include_deletions=True, allow_1to2=True, allow_2to1=True, allow_transposition=True, quiet=False, keyboard=True, total_lines=10)
-    err = capsys.readouterr().err
-    assert "Total lines processed:" in err
-    assert "Transpositions [T]:" in err
-    assert "Keyboard Adjacency [K]:" in err
-    assert "Insertions [Ins]:" in err
-    assert "Deletions [Del]:" in err
-    assert "1-to-2 replacements [1:2]:" in err
-    assert "2-to-1 replacements [2:1]:" in err
+    out = capsys.readouterr().out
+    assert "Total lines processed:" in out
+    assert "Transpositions [T]:" in out
+    assert "Keyboard Adjacency [K]:" in out
+    assert "Insertions [Ins]:" in out
+    assert "Deletions [Del]:" in out
+    assert "1-to-2 replacements [1:2]:" in out
+    assert "2-to-1 replacements [2:1]:" in out
 
 
 def test_generate_report_json_keyboard_branches():
@@ -785,5 +786,5 @@ def test_generate_report_json_keyboard_branches():
 def test_main_stdin_path_explicit(capsys):
     with patch('sys.stdin', io.StringIO("typo -> correct\n")),          patch('sys.argv', ['typostats.py', '-a']),          patch('typostats._STDIN_CACHE', None):
         typostats.main()
-        err = capsys.readouterr().err
-        assert "Total word pairs analyzed:" in err
+        out = capsys.readouterr().out
+        assert "Total word pairs analyzed:" in out

--- a/typostats.py
+++ b/typostats.py
@@ -755,28 +755,19 @@ def generate_report(
         sorted_replacements = sorted_replacements[:limit]
 
     # Color support detection
-    # main output colors (used for the report data)
-    # These are suppressed if writing to a file or if the main output is not a terminal (piping)
-    show_color_out = not output_file and _should_enable_color(sys.stdout)
-    # standard error colors (used for human-readable headers)
-    # If output_file is set, we avoid colors in headers that might be written to the file
-    show_color_err = not output_file and _should_enable_color(sys.stderr)
+    # Reports should use consistent coloring based on the destination.
+    # If output_file is set, we disable colors to avoid junk in the file.
+    # Otherwise, we use colors if the standard output supports them.
+    use_color = not output_file and _should_enable_color(sys.stdout)
 
-    c_bold = _BOLD if show_color_out else ""
-    c_blue = _BLUE if show_color_out else ""
-    c_green = _GREEN if show_color_out else ""
-    c_yellow = _YELLOW if show_color_out else ""
-    c_magenta = _MAGENTA if show_color_out else ""
-    c_cyan = _CYAN if show_color_out else ""
-    c_red = _RED if show_color_out else ""
-    c_reset = _RESET if show_color_out else ""
-
-    # Error-specific colors for the summary section
-    c_err_cyan = _CYAN if show_color_err else ""
-    c_err_magenta = _MAGENTA if show_color_err else ""
-    c_err_green = _GREEN if show_color_err else ""
-    c_err_red = _RED if show_color_err else ""
-    c_err_reset = _RESET if show_color_err else ""
+    c_bold = _BOLD if use_color else ""
+    c_blue = _BLUE if use_color else ""
+    c_green = _GREEN if use_color else ""
+    c_yellow = _YELLOW if use_color else ""
+    c_magenta = _MAGENTA if use_color else ""
+    c_cyan = _CYAN if use_color else ""
+    c_red = _RED if use_color else ""
+    c_reset = _RESET if use_color else ""
 
     if output_format == 'arrow':
         # arrow
@@ -813,7 +804,7 @@ def generate_report(
 
             if total_single_char > 0:
                 percent = (adjacent_count / total_single_char) * 100
-                extra_metrics["Keyboard Adjacency [K]"] = f"{c_err_cyan}{adjacent_count}/{total_single_char} ({percent:.1f}%){c_err_reset}"
+                extra_metrics["Keyboard Adjacency [K]"] = f"{c_cyan}{adjacent_count}/{total_single_char} ({percent:.1f}%){c_reset}"
 
         if kwargs.get('allow_transposition'):
             trans_count = 0
@@ -822,15 +813,15 @@ def generate_report(
                     trans_count += count
             if trans_count > 0:
                 percent = (trans_count / total_typos) * 100 if total_typos > 0 else 0
-                extra_metrics["Transpositions [T]"] = f"{c_err_magenta}{trans_count}/{total_typos} ({percent:.1f}%){c_err_reset}"
+                extra_metrics["Transpositions [T]"] = f"{c_magenta}{trans_count}/{total_typos} ({percent:.1f}%){c_reset}"
 
         if any([kwargs.get('allow_1to2'), kwargs.get('allow_2to1'), kwargs.get('include_deletions')]):
             counts = defaultdict(int)
             color_map = {
-                "Insertions [Ins]": c_err_green,
-                "1-to-2 replacements [1:2]": c_err_green,
-                "Deletions [Del]": c_err_red,
-                "2-to-1 replacements [2:1]": c_err_red,
+                "Insertions [Ins]": c_green,
+                "1-to-2 replacements [1:2]": c_green,
+                "Deletions [Del]": c_red,
+                "2-to-1 replacements [2:1]": c_red,
             }
             for (c, t), count in replacement_counts.items():
                 if len(c) < len(t):
@@ -848,7 +839,7 @@ def generate_report(
                 if count > 0:
                     percent = (count / total_typos) * 100 if total_typos > 0 else 0
                     color = color_map.get(label, "")
-                    extra_metrics[label] = f"{color}{count}/{total_typos} ({percent:.1f}%){c_err_reset}"
+                    extra_metrics[label] = f"{color}{count}/{total_typos} ({percent:.1f}%){c_reset}"
 
         if unique_filtered != unique_total:
             extra_metrics["Patterns matching criteria"] = unique_filtered
@@ -862,7 +853,7 @@ def generate_report(
             total_typos,
             all_replacements,
             item_label="pattern",
-            use_color=show_color_err,
+            use_color=use_color,
             extra_metrics=extra_metrics,
             start_time=start_time,
             total_input_items=total_pairs,
@@ -901,32 +892,22 @@ def generate_report(
 
         divider = f"{padding}{c_bold}{c_blue}{'─' * visible_header_len}{c_reset}"
 
-        if not output_file:
-            # Move the human-readable header to standard error to keep the main output clean for piping
-            if not quiet:
-                sys.stderr.write("\n".join(summary_lines) + "\n")
-                if sorted_replacements:
-                    # Frequency table header
-                    table_title = f"{padding}{c_bold}{c_blue}LETTER REPLACEMENTS{c_reset}"
-                    sys.stderr.write(f"\n{table_title}\n")
-                    sys.stderr.write(f"{padding}{c_bold}{c_blue}{'─' * visible_header_len}{c_reset}\n")
-                    sys.stderr.write(f"{header_row}\n")
-                    sys.stderr.write(f"{divider}\n")
-                sys.stderr.flush()
-            report_lines = []
-        else:
+        # Human-readable report should be unified.
+        # If quiet is not set, we include the summary and headers.
+        if not quiet:
             report_lines = summary_lines[:]
             if sorted_replacements:
-                table_title = f"{padding}LETTER REPLACEMENTS"
-                report_lines.extend(["", table_title, f"{padding}{'─' * visible_header_len}", header_row, divider])
+                # Use colored title if possible
+                title_color = c_bold + c_blue if use_color else ""
+                reset_color = c_reset if use_color else ""
+                table_title = f"{padding}{title_color}LETTER REPLACEMENTS{reset_color}"
+                report_lines.extend(["", table_title, f"{padding}{c_bold}{c_blue}{'─' * visible_header_len}{c_reset}", header_row, divider])
+        else:
+            report_lines = []
 
         if not sorted_replacements:
             no_results = f"{padding}{c_yellow}No replacements found matching the criteria.{c_reset}"
-            if not output_file:
-                if not quiet:
-                    sys.stderr.write(f"{no_results}\n")
-            else:
-                report_lines.append(no_results)
+            report_lines.append(no_results)
 
         for (correct_char, typo_char), count in sorted_replacements:
             percent = (count / total_typos * 100) if total_typos > 0 else 0


### PR DESCRIPTION
The `typostats.py` tool previously split its rich `arrow` report between `stderr` (summaries/headers) and `stdout` (data rows). This caused two main issues:
1. **Incomplete Redirection:** Redirecting to a file (`python typostats.py > report.txt`) resulted in a file containing only data rows, while the summary remained on the screen.
2. **Race Conditions:** In some terminals, the two streams could interleave, leading to out-of-order headers and data.

This PR unifies the report into a single atomic output. It also cleans up the internal color logic to ensure consistent behavior across the entire report and simplifies the `quiet` flag enforcement.

**Changes:**
- Unified `generate_report` output for `arrow` format.
- Consolidated color detection logic.
- Updated the test suite to verify the unified output behavior.

---
*PR created automatically by Jules for task [4362423983718010269](https://jules.google.com/task/4362423983718010269) started by @RainRat*