### PR TITLE
[FEAT] Add `shuffle` mode to Multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -159,6 +159,10 @@ These modes help you transform or combine your data.
   - **What it does:** Picks a random set of lines. You can pick a specific number (`--n 100`) or a percentage (`--percent 10`).
   - **Example:** `python multitool.py sample big_log.txt --n 50`
 
+- **`shuffle`**
+  - **What it does:** Randomly reorders lines. Randomly shuffles the lines in your input files. This is useful for creating randomized test data or breaking up ordered lists.
+  - **Example:** `python multitool.py shuffle wordlist.txt -o randomized.txt`
+
 - **`set_operation`**
   - **What it does:** Compares files using set logic. It compares two files to find shared lines (intersection), all lines (union), lines unique to the first file (difference), or lines unique to either file (symmetric_difference).
   - **Example:** `python multitool.py set_operation a.txt --file2 b.txt --operation symmetric_difference`

--- a/multitool.py
+++ b/multitool.py
@@ -4328,6 +4328,51 @@ def sample_mode(
     )
 
 
+def shuffle_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Randomly reorder lines from the input file(s)."""
+    start_time = time.perf_counter()
+
+    # Extract items
+    raw_items = [
+        item for input_file in input_files
+        for item in _extract_line_items(input_file, quiet=quiet)
+    ]
+
+    if not raw_items:
+        logging.warning("Input is empty or no lines found.")
+        write_output([], output_file, output_format, quiet)
+        return
+
+    # Clean and filter
+    cleaned_items = clean_and_filter(raw_items, min_length, max_length, clean=clean_items)
+
+    # Shuffle
+    shuffled_items = list(cleaned_items)
+    random.shuffle(shuffled_items)
+
+    if process_output:
+        # Note: shuffle followed by process_output (sort/dedup) effectively negates the shuffle,
+        # but we keep it for consistency with other modes.
+        shuffled_items = sorted(set(shuffled_items))
+
+    write_output(shuffled_items, output_file, output_format, quiet, limit=limit)
+
+    print_processing_stats(len(raw_items), shuffled_items, start_time=start_time)
+    logging.info(
+        f"[Shuffle Mode] Shuffled {len(shuffled_items)} valid lines from {len(input_files)} file(s). Output written to '{output_file}'."
+    )
+
+
 def regex_mode(
     input_files: Sequence[str],
     output_file: str,
@@ -5687,6 +5732,12 @@ MODE_DETAILS = {
         "example": "python multitool.py sample big_log.txt -n 100 -o sample.txt",
         "flags": "[-n N|--percent P]",
     },
+    "shuffle": {
+        "summary": "Randomly reorders lines",
+        "description": "Randomly shuffles the lines in your input files. This is useful for creating randomized test data or breaking up ordered lists.",
+        "example": "python multitool.py shuffle wordlist.txt -o randomized.txt",
+        "flags": "",
+    },
     "regex": {
         "summary": "Extracts text matching a pattern",
         "description": "Finds and gets all text that matches a Python regular expression pattern.",
@@ -5856,7 +5907,7 @@ def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
         "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "toml", "xml", "flatten", "line", "words", "ngrams", "regex"],
-        "CHANGE DATA": ["combine", "unique", "sort", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
+        "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
 
@@ -6932,6 +6983,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_common_mode_arguments(sample_parser)
 
+    shuffle_parser = subparsers.add_parser(
+        'shuffle',
+        help=MODE_DETAILS['shuffle']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['shuffle']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['shuffle']['example']}{RESET}",
+    )
+    _add_common_mode_arguments(shuffle_parser)
+
     words_parser = subparsers.add_parser(
         'words',
         help=MODE_DETAILS['words']['summary'],
@@ -7646,6 +7706,13 @@ def main() -> None:
             {
                 **common_kwargs,
                 'right_side': right_side,
+                'output_format': output_format,
+            },
+        ),
+        'shuffle': (
+            shuffle_mode,
+            {
+                **common_kwargs,
                 'output_format': output_format,
             },
         ),

--- a/tests/test_multitool_shuffle.py
+++ b/tests/test_multitool_shuffle.py
@@ -1,0 +1,132 @@
+import pytest
+from unittest.mock import patch
+import multitool
+import random
+
+def create_input_file(filepath):
+    content = """alpha
+beta
+gamma
+delta
+epsilon
+zeta
+eta
+theta
+iota
+kappa
+"""
+    with open(filepath, 'w') as f:
+        f.write(content)
+
+def test_shuffle_mode_basic(tmp_path):
+    """Test that shuffle mode reorders lines."""
+    input_file = tmp_path / "input.txt"
+    output_file = tmp_path / "output.txt"
+    create_input_file(input_file)
+
+    # Use a fixed seed for reproducibility in this test
+    random.seed(42)
+
+    test_args = [
+        "multitool.py", "shuffle", str(input_file),
+        "--output", str(output_file)
+    ]
+    with patch("sys.argv", test_args):
+        multitool.main()
+
+    with open(output_file, 'r') as f:
+        lines = [line.strip() for line in f]
+
+    assert len(lines) == 10
+
+    with open(input_file, 'r') as f:
+        source_lines = [line.strip() for line in f]
+
+    # Verify all original lines are present
+    assert sorted(lines) == sorted(source_lines)
+
+    # Verify the order is different (with seed 42, it should be)
+    assert lines != source_lines
+
+def test_shuffle_mode_empty_input(tmp_path):
+    """Test shuffle mode with empty input."""
+    input_file = tmp_path / "empty.txt"
+    input_file.write_text("")
+    output_file = tmp_path / "output.txt"
+
+    test_args = [
+        "multitool.py", "shuffle", str(input_file),
+        "--output", str(output_file)
+    ]
+    with patch("sys.argv", test_args):
+        multitool.main()
+
+    with open(output_file, 'r') as f:
+        lines = f.readlines()
+    assert len(lines) == 0
+
+def test_shuffle_mode_limit(tmp_path):
+    """Test shuffle mode with --limit flag."""
+    input_file = tmp_path / "input.txt"
+    output_file = tmp_path / "output.txt"
+    create_input_file(input_file)
+
+    test_args = [
+        "multitool.py", "shuffle", str(input_file),
+        "--output", str(output_file),
+        "--limit", "5"
+    ]
+    with patch("sys.argv", test_args):
+        multitool.main()
+
+    with open(output_file, 'r') as f:
+        lines = f.readlines()
+
+    assert len(lines) == 5
+
+def test_shuffle_mode_min_length(tmp_path):
+    """Test shuffle mode with --min-length filter."""
+    input_file = tmp_path / "input.txt"
+    # Mixed lengths
+    content = "a\nbb\nccc\ndddd\n"
+    input_file.write_text(content)
+    output_file = tmp_path / "output.txt"
+
+    test_args = [
+        "multitool.py", "shuffle", str(input_file),
+        "--output", str(output_file),
+        "--min-length", "3"
+    ]
+    with patch("sys.argv", test_args):
+        multitool.main()
+
+    with open(output_file, 'r') as f:
+        lines = [line.strip() for line in f]
+
+    assert len(lines) == 2
+    assert "ccc" in lines
+    assert "dddd" in lines
+    assert "a" not in lines
+    assert "bb" not in lines
+
+def test_shuffle_mode_process_output(tmp_path):
+    """Test shuffle mode with --process flag (should sort and dedup)."""
+    input_file = tmp_path / "input.txt"
+    # Create input with duplicates and out of order
+    content = "zebra\napple\napple\nbanana\n"
+    input_file.write_text(content)
+    output_file = tmp_path / "output.txt"
+
+    test_args = [
+        "multitool.py", "shuffle", str(input_file),
+        "--output", str(output_file),
+        "--process"
+    ]
+    with patch("sys.argv", test_args):
+        multitool.main()
+
+    with open(output_file, 'r') as f:
+        lines = [line.strip() for line in f]
+
+    # Shuffling followed by process (sort/dedup) should result in alphabetical unique list
+    assert lines == ["apple", "banana", "zebra"]


### PR DESCRIPTION
Implemented a new `shuffle` mode in `multitool.py`. This mode allows users to randomly reorder lines from input files, complementing the existing `sort` and `sample` modes.

Key features:
- Uses `random.shuffle` for randomization.
- Supports standard `multitool` filters (`--min-length`, `--max-length`, `--raw`, `--limit`).
- Integrated into the CLI with comprehensive help text and examples.
- Fully documented in `docs/multitool.md`.
- Verified with a new suite of unit tests.

---
*PR created automatically by Jules for task [508409637008499577](https://jules.google.com/task/508409637008499577) started by @RainRat*