### PR TITLE
[DOCS] Add replace mode documentation to multitool.md

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -168,6 +168,17 @@ These modes help you transform or combine your data.
   - **What it does:** Randomly reorders lines. Randomly shuffles the lines in your input files. This is useful for creating randomized test data or breaking up ordered lists.
   - **Example:** `python multitool.py shuffle wordlist.txt -o randomized.txt`
 
+- **`replace`**
+  - **What it does:** Replaces text or patterns. It performs text substitution across files. It supports literal string replacement and regular expressions (including backreferences).
+  - **Options:**
+    - Use the `--old` flag to specify the text or regex pattern to search for.
+    - Use the `--new` flag to specify the replacement text.
+    - Use the `--regex` flag to treat the pattern as a regular expression.
+    - **In-Place Editing:** Use the `--in-place` flag to modify files directly. If you provide an extension (for example, `--in-place .bak`), the tool will create a backup of each file before modifying it.
+    - **Dry Run:** Use the `--dry-run` flag to see how many fixes would be made without actually changing any files.
+    - **Diff Preview:** Use the `--diff` flag to see a unified diff of the changes that would be made.
+  - **Example:** `python multitool.py replace . --old 'old-tag' --new 'new-tag' --in-place`
+
 - **`set_operation`**
   - **What it does:** Compares files using set logic. It compares two files to find shared lines (intersection), all lines (union), lines unique to the first file (difference), or lines unique to either file (symmetric_difference).
   - **Example:** `python multitool.py set_operation a.txt --file2 b.txt --operation symmetric_difference`


### PR DESCRIPTION
Added comprehensive documentation for the `replace` mode in `docs/multitool.md`, detailing its text substitution capabilities, regex support, and safety options like dry runs and diff previews. This fills a documentation gap for an existing feature in `multitool.py`.

---
*PR created automatically by Jules for task [6052994418747026090](https://jules.google.com/task/6052994418747026090) started by @RainRat*