### PR TITLE
[UI/UX] Add shorthand flags -I and -D to reduce CLI friction

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -5913,7 +5913,7 @@ MODE_DETAILS = {
         "summary": "Fixes casing/spelling project-wide",
         "description": "Analyzes your files to find words used with different capitalization (for example, 'database' vs 'Database') or similar spelling (for example, 'teh' vs 'the'). It then automatically replaces all less frequent versions with the most popular one across the entire project. Use --fuzzy to enable similar word matching, and add --keyboard or --transposition to restrict those matches to specific error types.",
         "example": "python multitool.py standardize . --diff --min-length 4 --fuzzy 1 --transposition",
-        "flags": "[FILES...] [--in-place] [--dry-run] [--fuzzy N] [-kt] [--diff]",
+        "flags": "[FILES...] [-IDkt] [--dry-run] [--fuzzy N]",
     },
     "search": {
         "summary": "Searches for words or patterns",
@@ -5937,7 +5937,7 @@ MODE_DETAILS = {
         "summary": "Fixes typos in text files",
         "description": "Performs in-place replacements of typos in your text files using a mapping file or extra pairs provided via --add. It tries to preserve the surrounding context (punctuation, whitespace) while fixing errors. It automatically handles compound words like 'CamelCase' and 'snake_case' variables. Supports CSV, Arrow, Table, JSON, and YAML mapping formats.",
         "example": "python multitool.py scrub input.txt --add teh:the --diff",
-        "flags": "[FILES...] [-s MAPPING] [-a K:V] [--in-place] [--smart-case] [--diff]",
+        "flags": "[FILES...] [-s MAPPING] [-a K:V] [-ID] [--smart-case]",
     },
     "align": {
         "summary": "Aligns typo-correction pairs",
@@ -5949,7 +5949,7 @@ MODE_DETAILS = {
         "summary": "Batch renames files and folders",
         "description": "Renames files or directories based on a typo mapping or extra pairs provided via --add. It preserves the directory structure and can automatically handle CamelCase or snake_case names using --smart-case. It handles nested renames by processing files before their parent directories.",
         "example": "python multitool.py rename src/ --add teh:the --in-place",
-        "flags": "[-s MAPPING] [-a K:V] [--in-place] [--dry-run] [--smart-case]",
+        "flags": "[FILES...] [-s MAPPING] [-a K:V] [-I] [--dry-run] [--smart-case]",
     },
     "diff": {
         "summary": "Shows differences between files",
@@ -5979,7 +5979,7 @@ MODE_DETAILS = {
         "summary": "Replaces text or patterns",
         "description": "Performs text substitution across files. It supports literal string replacement and regular expressions (with backreferences). Use --old for the pattern and --new for the replacement. Supports in-place editing, dry-runs, and unified diffs.",
         "example": "python multitool.py replace . --old 'old-tag' --new 'new-tag' --in-place",
-        "flags": "--old TEXT --new TEXT [--regex] [--in-place] [--dry-run] [--diff]",
+        "flags": "[FILES...] --old TEXT --new TEXT [--regex] [-ID] [--dry-run]",
     },
 }
 
@@ -6074,7 +6074,8 @@ def get_mode_summary_text() -> str:
     tips = [
         ("-f arrow", "Rich visual reports with bar charts and percentages"),
         ("-P", "Automatically sort results and remove duplicates"),
-        ("--in-place", "Modify files directly (for scrub, standardize, rename)"),
+        ("--in-place (-I)", "Modify files directly (for scrub, standardize, rename, replace)"),
+        ("--diff (-D)", "Show a unified diff of the changes to be made"),
         ("--raw (-R)", "Keep original text (no lowercase, no cleaning)"),
         ("--limit (-L)", "Restrict the number of items in the output")
     ]
@@ -7218,7 +7219,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help='Extra mapping pairs (for example "teh:the") or words to match.',
     )
     scrub_options.add_argument(
-        '--in-place',
+        '-I', '--in-place',
         nargs='?',
         const='',
         metavar='EXT',
@@ -7235,7 +7236,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Automatically match the casing of the original word (for example, 'Teh' -> 'The').",
     )
     scrub_options.add_argument(
-        '--diff',
+        '-D', '--diff',
         action='store_true',
         help="Show a unified diff of the changes that would be made.",
     )
@@ -7264,7 +7265,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help='Extra mapping pairs (for example "teh:the") or words to match.',
     )
     rename_options.add_argument(
-        '--in-place',
+        '-I', '--in-place',
         action='store_true',
         help="Perform the actual renaming of files and directories.",
     )
@@ -7289,7 +7290,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     standardize_options = standardize_parser.add_argument_group(f"{BLUE}STANDARDIZE OPTIONS{RESET}")
     standardize_options.add_argument(
-        '--in-place',
+        '-I', '--in-place',
         nargs='?',
         const='',
         metavar='EXT',
@@ -7323,7 +7324,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="The minimum frequency ratio to consider a rare word a typo (default: 10.0).",
     )
     standardize_options.add_argument(
-        '--diff',
+        '-D', '--diff',
         action='store_true',
         help="Show a unified diff of the changes that would be made.",
     )
@@ -7570,7 +7571,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Treat '--old' as a regular expression.",
     )
     replace_options.add_argument(
-        '--in-place',
+        '-I', '--in-place',
         nargs='?',
         const='',
         metavar='EXT',
@@ -7582,7 +7583,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Show what would be changed without modifying any files.",
     )
     replace_options.add_argument(
-        '--diff',
+        '-D', '--diff',
         action='store_true',
         help="Show a unified diff of the changes that would be made.",
     )


### PR DESCRIPTION
This PR implements a specific UI/UX improvement for the `multitool.py` CLI by introducing intuitive shorthand flags for frequently used modification and diagnostic actions.

**Changes:**
1.  **Friction Reduction:** Added `-I` shorthand for `--in-place` and `-D` shorthand for `--diff` in `scrub`, `rename`, `standardize`, and `replace` modes. This significantly reduces keystrokes for common workflows.
2.  **Visual Hierarchy & Information Density:** Updated the `MODE_DETAILS` summary table to use grouped shorthand notation (e.g., `[-IDkt]`), making the "Primary Options" column more readable and less prone to truncation in standard terminal widths.
3.  **Consistency:** Ensured that the "QUICK TIPS" section in the help output explicitly mentions these new shorthands alongside other global flags like `-R` and `-L`.
4.  **Stability:** Verified that all 866 existing tests pass and confirmed the new flags work as expected through manual CLI verification.

---
*PR created automatically by Jules for task [17149946764972657853](https://jules.google.com/task/17149946764972657853) started by @RainRat*