### PR TITLE
[FEAT] Add XML support for typo mappings in Multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -184,7 +184,7 @@ These modes help you transform or combine your data.
 
 - **`scrub`**
   - **What it does:** Fixes typos in text files. It uses a mapping file or extra pairs to fix typos in your files. It tries to keep the surrounding context (punctuation, whitespace) while fixing errors.
-  - **Supported Formats:** Supports CSV, Arrow, Table, JSON, YAML, TOML, and XML mapping formats.
+  - **Supported Formats:** Supports CSV, Arrow, Table, JSON, YAML, TOML, and XML mapping formats. For XML, it expects `<pair>` elements with `<left>`/`<right>` or `<typo>`/`<correction>` children.
   - **Options:**
     - Use the `--add` flag to provide extra mapping pairs (for example, `--add teh:the`) directly on the command line.
   - **In-Place Editing:** Use the `--in-place` flag to modify files directly. If you provide an extension (for example, `--in-place .bak`), the tool will create a backup of each file before modifying it.

--- a/multitool.py
+++ b/multitool.py
@@ -824,6 +824,29 @@ def _extract_pairs(input_files: Sequence[str], quiet: bool = False) -> Iterable[
                     logging.error(f"Failed to parse TOML in '{input_file}': {e}")
             continue
 
+        if ext.endswith('.xml'):
+            content = "".join(_read_file_lines_robust(input_file))
+            if content.strip():
+                try:
+                    root = ET.fromstring(content)
+                    # Support standard <pair><left>...</left><right>...</right></pair> format
+                    for pair in root.findall('.//pair'):
+                        left = pair.find('left')
+                        right = pair.find('right')
+                        if left is not None and right is not None:
+                            yield left.text.strip() if left.text else "", right.text.strip() if right.text else ""
+                        else:
+                            # Also support <typo> and <correction> for compatibility
+                            typo = pair.find('typo')
+                            correction = pair.find('correction')
+                            if correction is None:
+                                correction = pair.find('correct')
+                            if typo is not None and correction is not None:
+                                yield typo.text.strip() if typo.text else "", correction.text.strip() if correction.text else ""
+                except Exception as e:
+                    logging.error(f"Failed to parse XML in '{input_file}': {e}")
+            continue
+
         # Text formats
         lines = _read_file_lines_robust(input_file)
         for line in tqdm(lines, desc=f'Processing {input_file}', unit=' lines', disable=quiet):
@@ -4420,7 +4443,7 @@ def _resolve_full_mapping(
     # 1. Load from file if provided
     if mapping_file:
         # Load mapping or list
-        if mapping_file.lower().endswith(('.json', '.csv', '.yaml', '.yml', '.toml')):
+        if mapping_file.lower().endswith(('.json', '.csv', '.yaml', '.yml', '.toml', '.xml')):
             full_mapping.update(dict(_extract_pairs([mapping_file], quiet=quiet)))
         else:
             # Treat as a simple list of words if not a common mapping format


### PR DESCRIPTION
This PR adds the ability to use XML files as typo mapping sources in `multitool.py`.

Previously, `multitool` could write paired data to XML but could not read it back for operations like `scrub` or `count --pairs`. This change brings XML mapping support to parity with JSON, YAML, and TOML.

Key changes:
- Enhanced `_extract_pairs` to handle XML files.
- Whitelisted `.xml` extension in `_resolve_full_mapping`.
- Updated documentation with the expected XML structure.
- Verified with existing test suite and reproduction scripts.

---
*PR created automatically by Jules for task [786534183616270140](https://jules.google.com/task/786534183616270140) started by @RainRat*