### PR TITLE
[DOCS] Document `replace` mode in Multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -168,6 +168,15 @@ These modes help you transform or combine your data.
   - **What it does:** Randomly reorders lines. Randomly shuffles the lines in your input files. This is useful for creating randomized test data or breaking up ordered lists.
   - **Example:** `python multitool.py shuffle wordlist.txt -o randomized.txt`
 
+- **`replace`**
+  - **What it does:** Replaces text or patterns. It performs text substitution across multiple files. It supports literal string replacement and regular expressions (including backreferences).
+  - **Options:**
+    - Use `--old` to set the text or regex pattern to search for.
+    - Use `--new` to set the replacement text.
+    - Use the `--regex` flag to treat the search pattern as a regular expression.
+    - Supports `--in-place` modification, `--dry-run` previews, and `--diff` reports.
+  - **Example:** `python multitool.py replace . --old 'old-tag' --new 'new-tag' --in-place`
+
 - **`set_operation`**
   - **What it does:** Compares files using set logic. It compares two files to find shared lines (intersection), all lines (union), lines unique to the first file (difference), or lines unique to either file (symmetric_difference).
   - **Example:** `python multitool.py set_operation a.txt --file2 b.txt --operation symmetric_difference`


### PR DESCRIPTION
This PR adds missing documentation for the `replace` mode in the `multitool.py` utility. 

**Type:** Documentation
**What:** Added a new section for the `replace` mode in `docs/multitool.md` under the `CHANGE DATA` heading.
**Why:** The `replace` mode was implemented in the code but not documented in the main Multitool documentation file. This addition makes the feature discoverable and provides clear instructions on how to use it for literal and regular expression substitutions across multiple files, including support for in-place modifications and diff previews.

The documentation follows the project's style guidelines:
- **Plain English:** Clear and direct language.
- **Simplicity:** Short, active-voice sentences.
- **No Jargon:** Avoids unnecessary technical complexity while remaining accurate.
- **Casual but Professional:** Helpful and accessible tone.

Verification:
- Verified `replace` mode behavior in `multitool.py` source code and CLI help.
- Verified Markdown formatting and content in `docs/multitool.md`.
- Ran all 866 project tests to ensure no regressions.

---
*PR created automatically by Jules for task [5476292777573268913](https://jules.google.com/task/5476292777573268913) started by @RainRat*