### PR TITLE
[FEAT] Add 'unflatten' mode to multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -168,6 +168,12 @@ These modes help you transform or combine your data.
   - **What it does:** Randomly reorders lines. Randomly shuffles the lines in your input files. This is useful for creating randomized test data or breaking up ordered lists.
   - **Example:** `python multitool.py shuffle wordlist.txt -o randomized.txt`
 
+- **`unflatten`**
+  - **What it does:** Reconstructs nested structures. It transforms dot-separated `key.path = value` pairs back into nested JSON, YAML, or TOML structures.
+  - **Options:** Use the `-k` (or `--key`) flag to unflatten only paths starting with a specific key and remove that prefix.
+  - **Supported Formats:** Reconstructs data into `json`, `yaml`, `toml`, and `xml` formats.
+  - **Example:** `python multitool.py unflatten data.txt --output-format json`
+
 - **`set_operation`**
   - **What it does:** Compares files using set logic. It compares two files to find shared lines (intersection), all lines (union), lines unique to the first file (difference), or lines unique to either file (symmetric_difference).
   - **Example:** `python multitool.py set_operation a.txt --file2 b.txt --operation symmetric_difference`

--- a/multitool.py
+++ b/multitool.py
@@ -1756,6 +1756,137 @@ def xml_mode(
     )
 
 
+def unflatten_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    key: str = "",
+    output_format: str = 'json',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """
+    Reconstructs nested structures from dot-separated key.path = value pairs.
+    """
+    start_time = time.perf_counter()
+    raw_pairs = list(_extract_pairs(input_files, quiet=quiet))
+
+    root = {}
+    path_prefix = key + "." if key else ""
+
+    filtered_paths = []
+    for p, v in raw_pairs:
+        orig_p = p
+        if key:
+            if p.startswith(path_prefix):
+                p = p[len(path_prefix):]
+            elif p == key:
+                # If it's the exact key and no sub-paths follow, it would be the root.
+                # But unflattening usually expects sub-paths. We'll skip exact key if it's just a value.
+                continue
+            else:
+                continue
+
+        # Apply cleaning and filtering to the value
+        v_processed = filter_to_letters(v) if clean_items else v
+        if not (min_length <= len(v_processed) <= max_length):
+            continue
+
+        filtered_paths.append(orig_p)
+        parts = p.split('.')
+        curr = root
+        for part in parts[:-1]:
+            if part not in curr or not isinstance(curr[part], dict):
+                curr[part] = {}
+            curr = curr[part]
+
+        curr[parts[-1]] = v_processed
+
+    def dict_to_lists(d):
+        if not isinstance(d, dict):
+            return d
+
+        new_d = {k: dict_to_lists(v) for k, v in d.items()}
+
+        if not new_d:
+            return new_d
+
+        # Check if all keys are numeric and form a continuous sequence starting at 0
+        if all(k.isdigit() for k in new_d.keys()):
+            indices = sorted(int(k) for k in new_d.keys())
+            if indices == list(range(len(indices))):
+                return [new_d[str(i)] for i in range(len(indices))]
+
+        return new_d
+
+    result_data = dict_to_lists(root)
+
+    # Resolve output format if it was defaulted to 'line'
+    if output_format == 'line':
+        output_format = 'json'
+
+    with smart_open_output(output_file) as out:
+        if output_format == 'json':
+            json.dump(result_data, out, indent=2)
+            out.write('\n')
+        elif output_format == 'yaml':
+            try:
+                import yaml
+                yaml.dump(result_data, out, default_flow_style=False, sort_keys=False)
+            except ImportError:
+                json.dump(result_data, out, indent=2)
+                out.write('\n')
+        elif output_format == 'toml':
+            if not isinstance(result_data, dict):
+                json.dump(result_data, out, indent=2)
+            else:
+                try:
+                    # Note: Using the same logic as _yield_structured_docs for toml availability
+                    if _TOMLLIB_AVAILABLE:
+                        # tomllib is read-only. We need 'toml' or similar for writing.
+                        import toml
+                        toml.dump(result_data, out)
+                    elif _TOML_AVAILABLE:
+                        import toml
+                        toml.dump(result_data, out)
+                    else:
+                        json.dump(result_data, out, indent=2)
+                except Exception:
+                    json.dump(result_data, out, indent=2)
+            out.write('\n')
+        elif output_format == 'xml':
+            def build_xml(parent, data):
+                if isinstance(data, dict):
+                    # Sort keys for deterministic XML output
+                    for k in sorted(data.keys()):
+                        v = data[k]
+                        child = ET.SubElement(parent, k)
+                        build_xml(child, v)
+                elif isinstance(data, list):
+                    for item in data:
+                        child = ET.SubElement(parent, "item")
+                        build_xml(child, item)
+                else:
+                    parent.text = str(data)
+
+            root_tag = key if key else "root"
+            xml_root = ET.Element(root_tag)
+            build_xml(xml_root, result_data)
+            xml_str = ET.tostring(xml_root, encoding='utf-8')
+            pretty_xml = xml.dom.minidom.parseString(xml_str).toprettyxml(indent="  ")
+            out.write(pretty_xml)
+        else:
+            # Fallback to JSON
+            json.dump(result_data, out, indent=2)
+            out.write('\n')
+
+    print_processing_stats(len(raw_pairs), filtered_paths, item_label="path", start_time=start_time)
+    logging.info(f"[Unflatten Mode] Structure reconstructed. Output written to '{output_file}'.")
+
+
 def toml_mode(
     input_files: Sequence[str],
     output_file: str,
@@ -5759,6 +5890,12 @@ MODE_DETAILS = {
         "example": "python multitool.py flatten config.json --output-format table",
         "flags": "[-k KEY]",
     },
+    "unflatten": {
+        "summary": "Reconstructs nested structures",
+        "description": "Transforms dot-separated 'key.path = value' pairs back into nested JSON, YAML, or TOML structures. It automatically converts numeric path segments into lists if they form a continuous sequence.",
+        "example": "python multitool.py unflatten data.txt --output-format json",
+        "flags": "[-k KEY]",
+    },
     "line": {
         "summary": "Extracts every line from a file",
         "description": "Reads every line from a file, cleans the text, and writes it to the output. Useful for simple cleaning and filtering.",
@@ -5988,7 +6125,7 @@ def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
         "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "toml", "xml", "flatten", "line", "words", "ngrams", "regex"],
-        "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
+        "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
 
@@ -6548,6 +6685,22 @@ def _build_parser() -> argparse.ArgumentParser:
         help="The key path to start flattening from (for example 'users'). If not provided, flattens from the root.",
     )
     _add_common_mode_arguments(flatten_parser)
+
+    unflatten_parser = subparsers.add_parser(
+        'unflatten',
+        help=MODE_DETAILS['unflatten']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['unflatten']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['unflatten']['example']}{RESET}",
+    )
+    unflatten_options = unflatten_parser.add_argument_group(f"{BLUE}UNFLATTEN OPTIONS{RESET}")
+    unflatten_options.add_argument(
+        '-k', '--key',
+        type=str,
+        default='',
+        help="The key path to unflatten under (for example 'users'). Only paths starting with this key will be processed, and the prefix will be removed.",
+    )
+    _add_common_mode_arguments(unflatten_parser)
 
     toml_parser = subparsers.add_parser(
         'toml',
@@ -7829,6 +7982,14 @@ def main() -> None:
             {
                 **common_kwargs,
                 'right_side': right_side,
+                'output_format': output_format,
+            },
+        ),
+        'unflatten': (
+            unflatten_mode,
+            {
+                **common_kwargs,
+                'key': getattr(args, 'key', ''),
                 'output_format': output_format,
             },
         ),

--- a/tests/test_multitool_unflatten.py
+++ b/tests/test_multitool_unflatten.py
@@ -1,0 +1,72 @@
+
+import json
+import subprocess
+import os
+import traceback
+
+def test_unflatten_basic():
+    input_content = "user.name -> John\nuser.age -> 30\n"
+    with open("test_input.txt", "w") as f:
+        f.write(input_content)
+
+    result = subprocess.run(
+        ["python3", "multitool.py", "unflatten", "test_input.txt", "--output-format", "json", "--raw"],
+        capture_output=True,
+        text=True
+    )
+
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data == {"user": {"name": "John", "age": "30"}}
+    os.remove("test_input.txt")
+
+def test_unflatten_list():
+    input_content = "items.0 -> apple\nitems.1 -> banana\n"
+    with open("test_input.txt", "w") as f:
+        f.write(input_content)
+
+    result = subprocess.run(
+        ["python3", "multitool.py", "unflatten", "test_input.txt", "--output-format", "json", "--raw"],
+        capture_output=True,
+        text=True
+    )
+
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data == {"items": ["apple", "banana"]}
+    os.remove("test_input.txt")
+
+def test_unflatten_key():
+    input_content = "users.0.name -> Alice\nusers.1.name -> Bob\nother.data -> 123\n"
+    with open("test_input.txt", "w") as f:
+        f.write(input_content)
+
+    result = subprocess.run(
+        ["python3", "multitool.py", "unflatten", "test_input.txt", "-k", "users", "--output-format", "json", "--raw"],
+        capture_output=True,
+        text=True
+    )
+
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data == [{"name": "Alice"}, {"name": "Bob"}]
+    os.remove("test_input.txt")
+
+if __name__ == "__main__":
+    try:
+        test_unflatten_basic()
+        print("Basic test passed!")
+        test_unflatten_list()
+        print("List test passed!")
+        test_unflatten_key()
+        print("Key test passed!")
+    except Exception as e:
+        print(f"Test failed: {e}")
+        traceback.print_exc()
+        exit(1)


### PR DESCRIPTION
This PR adds a new `unflatten` mode to the `multitool.py` utility.

### What:
The `unflatten` mode is the symmetric counterpart to the existing `flatten` mode. It takes dot-separated `key.path = value` pairs (from files or stdin) and reconstructs the original nested data structure.

Key features include:
- **Automatic List Reconstruction:** Continuous numeric keys (0, 1, 2...) are automatically converted back into arrays.
- **Format Support:** Can output the reconstructed data in JSON, YAML, TOML, or XML.
- **Prefix Filtering:** An optional `-k/--key` flag allows unflattening only a specific sub-tree, stripping the prefix in the process.
- **Integration:** Fully integrated with Multitool's existing stats reporting, format detection, and help system.

### Why:
Symmetry in data processing tools is a high-value heuristic. Since Multitool can already `flatten` complex configurations for easy grep-based analysis or line-based editing, providing an `unflatten` mode completes the workflow, enabling users to programmatically rebuild structured files after they have been processed in a flat format.

---
*PR created automatically by Jules for task [17499369605987181151](https://jules.google.com/task/17499369605987181151) started by @RainRat*