### PR TITLE
[DOCS] Add documentation for 'replace' mode in Multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -168,6 +168,15 @@ These modes help you transform or combine your data.
   - **What it does:** Randomly reorders lines. Randomly shuffles the lines in your input files. This is useful for creating randomized test data or breaking up ordered lists.
   - **Example:** `python multitool.py shuffle wordlist.txt -o randomized.txt`
 
+- **`replace`**
+  - **What it does:** Replaces text or patterns. It performs text substitution across multiple files. It supports literal string replacement and regular expressions (including backreferences).
+  - **Options:**
+    - Use `--old` to specify the text or regular expression pattern to search for.
+    - Use `--new` to specify the replacement text.
+    - Use the `--regex` flag to treat the search pattern as a regular expression.
+    - Supports the `--in-place`, `--dry-run`, and `--diff` flags for safe file modification.
+  - **Example:** `python multitool.py replace . --old 'old-tag' --new 'new-tag' --in-place`
+
 - **`set_operation`**
   - **What it does:** Compares files using set logic. It compares two files to find shared lines (intersection), all lines (union), lines unique to the first file (difference), or lines unique to either file (symmetric_difference).
   - **Example:** `python multitool.py set_operation a.txt --file2 b.txt --operation symmetric_difference`


### PR DESCRIPTION
Added missing documentation for the `replace` mode in `docs/multitool.md`.

**Type:** Project Documentation
**What:** Added a new section for the `replace` mode under 'CHANGE DATA' in `docs/multitool.md`.
**Why:** The `replace` mode was implemented in `multitool.py` but not yet documented in the user-facing Markdown documentation. This change ensures users can find and understand how to use the text substitution features, including literal and regex-based replacements.

The update includes:
- A concise summary of the `replace` mode.
- Details on specific flags: `--old`, `--new`, and `--regex`.
- Mention of support for standard modification flags: `--in-place`, `--dry-run`, and `--diff`.
- A clear CLI usage example.

Verified the documentation against the code and confirmed that all `replace` mode tests pass.

---
*PR created automatically by Jules for task [5870395352081107266](https://jules.google.com/task/5870395352081107266) started by @RainRat*