### PR TITLE
Fix transitive chain resolution in `standardize_mode`

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -4969,6 +4969,14 @@ def standardize_mode(
                         fuzzy_groups[rare] = frequent
                         logging.info(f"[Fuzzy] Identified likely typo: '{rare}' ({r_count}) -> '{frequent}' ({f_count})")
 
+        for rare in list(fuzzy_groups.keys()):
+            visited = {rare}
+            frequent = fuzzy_groups[rare]
+            while frequent in fuzzy_groups and fuzzy_groups[frequent] not in visited:
+                visited.add(frequent)
+                frequent = fuzzy_groups[frequent]
+            fuzzy_groups[rare] = frequent
+
         # Build the final mapping using both casing and fuzzy logic
         for norm in norm_totals:
             target_norm = fuzzy_groups.get(norm, norm)


### PR DESCRIPTION
The `standardize_mode` function in `multitool.py` previously only performed a single-level mapping for fuzzy-matched variations. This led to incomplete standardization when variations formed a chain (e.g., A -> B and B -> C).

This change introduces a resolution loop that traverses these chains until a terminal "anchor" word is reached, ensuring all identified variations are replaced by the most frequent representative in a single pass.

The implementation includes a `visited` set to safely handle potential cycles and has been verified with targeted reproduction cases and the full project test suite.

---
*PR created automatically by Jules for task [16864943394243570039](https://jules.google.com/task/16864943394243570039) started by @RainRat*