### PR TITLE
Refine error handling in typostats.py to reduce noise

### DIFF
--- a/tests/test_coverage_gaps_final.py
+++ b/tests/test_coverage_gaps_final.py
@@ -85,7 +85,7 @@ def test_generate_report_distance_failure():
     """Test _format_analysis_summary distance calculation failure."""
     # line 187: distances = [levenshtein_distance(str(p[0]), str(p[1])) for p in filtered_items]
 
-    with patch('typostats.levenshtein_distance', side_effect=Exception("Levenshtein failed")):
+    with patch('typostats.levenshtein_distance', side_effect=ValueError("Levenshtein failed")):
         # Must be a tuple of length 2 to enter the distance block
         lines = typostats._format_analysis_summary(1, [('a', 'b')], use_color=False)
     assert any("ANALYSIS SUMMARY" in line for line in lines)

--- a/typostats.py
+++ b/typostats.py
@@ -273,7 +273,7 @@ def _format_analysis_summary(
                 report.append(
                     f"  {c_bold}{c_blue}{'Min/Max/Avg changes:':<{label_width}}{c_reset} {min_dist} / {max_dist} / {avg_dist:.1f}"
                 )
-        except Exception:
+        except (ValueError, TypeError):
             pass
 
     # Extra metrics
@@ -1200,7 +1200,7 @@ def main() -> None:
             else:
                 with open(file_path, 'rb') as f:
                     total_lines_all += sum(1 for _ in f)
-        except Exception:
+        except OSError:
             pass
 
         pairs = _extract_pairs([file_path], quiet=args.quiet)


### PR DESCRIPTION
This PR addresses the "Error Handling Noise" category by refining exception handling in `typostats.py`. 

1. **What:** 
   - Replaced broad `except Exception: pass` blocks with specific exception types (`OSError`, `ValueError`, `TypeError`).
   - Updated the associated test suite (`tests/test_coverage_gaps_final.py`) to use `ValueError` instead of a generic `Exception` when mocking failures, ensuring tests continue to pass with the more precise error handling.

2. **Why:** 
   - Broad `try/except` blocks can hide critical bugs (e.g., `NameError`, `AttributeError`) that should ideally cause the program to fail during development or production. 
   - The changes improve the maintainability and debuggability of the script without altering its external behavior for valid use cases.
   - All 881 existing tests pass, confirming no regressions were introduced.

---
*PR created automatically by Jules for task [10082656793769996709](https://jules.google.com/task/10082656793769996709) started by @RainRat*