### PR TITLE
[DOCS] Add convert mode documentation to multitool.md

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -185,6 +185,11 @@ Use these modes to transform or combine your data.
   - **Supported Formats:** `json`, `yaml`, `toml`, and `xml`.
   - **Example:** `python multitool.py unflatten data.txt --output-format json`
 
+- **`convert`**
+  - Transforms structured data between JSON, YAML, TOML, and XML formats. It supports deep sub-key extraction via dot-notation.
+  - **Options:** Use the `-k` (or `--key`) flag to extract a specific part of the data.
+  - **Example:** `python multitool.py convert data.json --output-format yaml`
+
 - **`replace`**
   - Performs text substitution across multiple files using literal strings or regular expressions.
   - **Options:**


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Added the `convert` mode documentation to the `CHANGE DATA` section of `docs/multitool.md`.
* **Why:** The `convert` mode was missing from the documentation. This addition ensures that users are aware of this feature and know how to use it for transforming structured data and extracting sub-keys.

---
*PR created automatically by Jules for task [8386268586462245723](https://jules.google.com/task/8386268586462245723) started by @RainRat*