### PR TITLE
[FEAT] Add ignore-case and smart-case support to replace mode

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -190,8 +190,10 @@ Use these modes to transform or combine your data.
   - **Options:**
     - Use `--old` for the search pattern and `--new` for the replacement.
     - Use the `--regex` flag to treat the pattern as a regular expression.
+    - Use the `--ignore-case` flag for case-insensitive matching.
+    - Use the `--smart-case` (or `-S`) flag to automatically match the original casing pattern (for example, `Teh` -> `The`).
     - Supports `--in-place`, `--dry-run`, and `--diff` flags.
-  - **Example:** `python multitool.py replace . --old 'old-tag' --new 'new-tag' --in-place`
+  - **Example:** `python multitool.py replace . --old 'the' --new 'that' --smart-case --in-place`
 
 - **`set_operation`**
   - Compares two files using set logic: `intersection`, `union`, `difference`, or `symmetric_difference`.

--- a/multitool.py
+++ b/multitool.py
@@ -4894,6 +4894,8 @@ def replace_mode(
     in_place: str | None = None,
     dry_run: bool = False,
     use_regex: bool = False,
+    ignore_case: bool = False,
+    smart_case: bool = False,
     diff: bool = False,
     limit: int | None = None,
 ) -> None:
@@ -4903,13 +4905,15 @@ def replace_mode(
     start_time = time.perf_counter()
     total_replacements = 0
 
-    # Compile regex if needed
+    # Compile regex if needed OR if casing support is enabled
     regex = None
-    if use_regex:
+    if use_regex or ignore_case or smart_case:
+        pattern = old_text if use_regex else re.escape(old_text)
+        flags = re.IGNORECASE if (ignore_case or smart_case) else 0
         try:
-            regex = re.compile(old_text)
+            regex = re.compile(pattern, flags)
         except re.error as e:
-            logging.error(f"Invalid regular expression '{old_text}': {e}")
+            logging.error(f"Invalid regular expression '{pattern}': {e}")
             sys.exit(1)
 
     accumulated_lines = []
@@ -4924,13 +4928,22 @@ def replace_mode(
             modified_lines = []
             file_replacements = 0
 
+            # Define replacement function outside the loop for performance
+            if regex and smart_case:
+                def repl_func(match):
+                    # Handle backreferences by expanding them first
+                    expanded = match.expand(new_text)
+                    return _apply_smart_case(match.group(0), expanded)
+            else:
+                repl_func = new_text
+
             for line in tqdm(file_lines, desc=f"Replacing in {input_file}", unit=" lines", disable=quiet):
                 # We need to handle the newline character carefully to preserve it
                 line_content = line.rstrip('\n')
                 ending = line[len(line_content):]
 
-                if use_regex:
-                    new_line, n = regex.subn(new_text, line_content)
+                if regex:
+                    new_line, n = regex.subn(repl_func, line_content)
                 else:
                     n = line_content.count(old_text)
                     new_line = line_content.replace(old_text, new_text)
@@ -6235,9 +6248,9 @@ MODE_DETAILS = {
     },
     "replace": {
         "summary": "Replaces text or patterns",
-        "description": "Performs text substitution across files. It supports literal string replacement and regular expressions (with backreferences). You can provide the OLD and NEW text as positional arguments or use the --old and --new flags. Supports in-place editing, dry-runs, and unified diffs.",
-        "example": "python multitool.py replace 'old-tag' 'new-tag' . --in-place",
-        "flags": "[OLD] [NEW] [FILES...] [-r] [-I EXT] [-D] [--dry-run]",
+        "description": "Performs text substitution across files. It supports literal string replacement and regular expressions (with backreferences). You can provide the OLD and NEW text as positional arguments or use the --old and --new flags. Supports in-place editing, dry-runs, and unified diffs. Use --smart-case to automatically match the original casing pattern.",
+        "example": "python multitool.py replace 'the' 'that' . --in-place --smart-case",
+        "flags": "[OLD] [NEW] [FILES...] [-rSI] [-D] [--dry-run] [--ignore-case]",
     },
 }
 
@@ -7860,6 +7873,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Treat '--old' as a regular expression.",
     )
     replace_options.add_argument(
+        '--ignore-case',
+        action='store_true',
+        help="Perform case-insensitive replacement.",
+    )
+    replace_options.add_argument(
+        '-S', '--smart-case',
+        action='store_true',
+        help="Automatically match the casing of the original word (for example, 'Teh' -> 'The').",
+    )
+    replace_options.add_argument(
         '-I', '--in-place',
         nargs='?',
         const='',
@@ -8499,6 +8522,8 @@ def main() -> None:
                 'in_place': getattr(args, 'in_place', None),
                 'dry_run': getattr(args, 'dry_run', False),
                 'use_regex': getattr(args, 'regex', False),
+                'ignore_case': getattr(args, 'ignore_case', False),
+                'smart_case': getattr(args, 'smart_case', False),
                 'diff': getattr(args, 'diff', False),
                 'limit': limit,
             }

--- a/tests/test_replace_casing.py
+++ b/tests/test_replace_casing.py
@@ -1,0 +1,115 @@
+import pytest
+import os
+import tempfile
+from multitool import replace_mode
+
+def test_replace_ignore_case():
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
+        f.write("The quick brown fox jumps over the lazy dog.\n")
+        f.flush()
+        temp_name = f.name
+
+    try:
+        output_file = temp_name + ".out"
+        replace_mode(
+            input_files=[temp_name],
+            old_text="the",
+            new_text="that",
+            output_file=output_file,
+            ignore_case=True
+        )
+
+        with open(output_file, 'r') as f:
+            content = f.read()
+            # "The" and "the" should both be replaced by literal "that"
+            assert "that quick brown fox jumps over that lazy dog." in content
+    finally:
+        if os.path.exists(temp_name):
+            os.remove(temp_name)
+        if os.path.exists(output_file):
+            os.remove(output_file)
+
+def test_replace_regex_backref_smart_case():
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
+        f.write("ERROR_code and error_CODE and Error_Code\n")
+        f.flush()
+        temp_name = f.name
+
+    try:
+        output_file = temp_name + ".out"
+        replace_mode(
+            input_files=[temp_name],
+            old_text=r"([a-z]+)_([a-z]+)",
+            new_text=r"\2_\1",
+            output_file=output_file,
+            use_regex=True,
+            smart_case=True
+        )
+
+        with open(output_file, 'r') as f:
+            content = f.read()
+            # "ERROR_code" -> "Code_ERROR" (starts with capital)
+            # "error_CODE" -> "code_error" (starts with lower)
+            # "Error_Code" -> "Code_Error" (starts with capital)
+            assert "Code_ERROR and code_error and Code_Error" in content
+    finally:
+        if os.path.exists(temp_name):
+            os.remove(temp_name)
+        if os.path.exists(output_file):
+            os.remove(output_file)
+
+def test_replace_smart_case():
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
+        f.write("THE quick brown fox jumps over The lazy dog.\n")
+        f.flush()
+        temp_name = f.name
+
+    try:
+        output_file = temp_name + ".out"
+        replace_mode(
+            input_files=[temp_name],
+            old_text="the",
+            new_text="that",
+            output_file=output_file,
+            smart_case=True
+        )
+
+        with open(output_file, 'r') as f:
+            content = f.read()
+            # "THE" -> "THAT", "The" -> "That"
+            assert "THAT quick brown fox jumps over That lazy dog." in content
+    finally:
+        if os.path.exists(temp_name):
+            os.remove(temp_name)
+        if os.path.exists(output_file):
+            os.remove(output_file)
+
+def test_replace_regex_smart_case():
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
+        f.write("FIXme and fixME and FixMe\n")
+        f.flush()
+        temp_name = f.name
+
+    try:
+        output_file = temp_name + ".out"
+        replace_mode(
+            input_files=[temp_name],
+            old_text=r"fixme",
+            new_text="resolved",
+            output_file=output_file,
+            use_regex=True,
+            smart_case=True
+        )
+
+        with open(output_file, 'r') as f:
+            content = f.read()
+            # smart case applies to regex matches too
+            # "FIXme" (starts with capital) -> "Resolved"
+            # "fixME" (starts with lower) -> "resolved"
+            # "FixMe" (starts with capital) -> "Resolved"
+            assert "Resolved and resolved and Resolved" in content
+    finally:
+        if os.path.exists(temp_name):
+            os.remove(temp_name)
+        if os.path.exists(output_file):
+            os.remove(output_file)


### PR DESCRIPTION
This PR adds two highly requested features to the `replace` mode in `multitool.py`: `--ignore-case` and `--smart-case`.

### Changes:
- **`replace_mode` enhancement**: The internal logic now optionally uses a regex-based substitution engine even for literal strings when casing support is requested.
- **Smart-Case support**: When enabled, the tool preserves the capitalization pattern of the original match (ALL-CAPS, Title Case, or lowercase).
- **Regex Backreferences**: The implementation was refined to ensure that regex groups and backreferences in the replacement string work correctly alongside smart-casing.
- **CLI & Documentation**: Added flags to the `replace` subparser and updated `MODE_DETAILS` and `docs/multitool.md` with new options and examples.
- **Tests**: Created `tests/test_replace_casing.py` to verify various scenarios.

These additions bring `replace` mode in line with other transformation modes like `scrub` and `rename`, providing a more consistent and powerful experience for project-wide text manipulation.

---
*PR created automatically by Jules for task [17255742597316202337](https://jules.google.com/task/17255742597316202337) started by @RainRat*