### PR TITLE
Narrow broad exception in `_format_analysis_summary`

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -621,7 +621,7 @@ def _format_analysis_summary(
                 report.append(
                     f"  {c_bold}{c_blue}{'Min/Max/Avg changes:':<{label_width}}{c_reset} {min_dist} / {max_dist} / {avg_dist:.1f}"
                 )
-        except Exception:
+        except (ValueError, TypeError):
             pass
 
     # Extra metrics

--- a/tests/test_multitool_coverage_completion_v2.py
+++ b/tests/test_multitool_coverage_completion_v2.py
@@ -25,8 +25,10 @@ def test_format_analysis_summary_item_error_handling():
     assert "Longest item" not in full_report
 
 def test_format_analysis_summary_distance_calculation_error_handling():
+    # Update to test that only expected errors (ValueError, TypeError) are caught.
+    # Broad Exceptions should now propagate.
     with patch("multitool.levenshtein_distance") as mock_lev:
-        mock_lev.side_effect = Exception("Levenshtein failed")
+        mock_lev.side_effect = ValueError("Expected failure")
 
         report = multitool._format_analysis_summary(2, [("a", "b")], "item", None, False)
         assert "Min/Max/Avg changes" not in "".join(report)


### PR DESCRIPTION
* **What:** Narrowed a broad `except Exception: pass` block in the `_format_analysis_summary` function within `multitool.py` to specifically catch `(ValueError, TypeError)`.
* **Why:** This resolves an instance of "Error Handling Noise" by ensuring that critical or unexpected failures are no longer silently suppressed, while maintaining identical behavior for expected data-related issues. The change improves the maintainability and debuggability of the codebase.

---
*PR created automatically by Jules for task [13602195967250637184](https://jules.google.com/task/13602195967250637184) started by @RainRat*