### PR TITLE
[DOCS] Add documentation for convert mode in multitool.md

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -185,6 +185,11 @@ Use these modes to transform or combine your data.
   - **Supported Formats:** `json`, `yaml`, `toml`, and `xml`.
   - **Example:** `python multitool.py unflatten data.txt --output-format json`
 
+- **`convert`**
+  - Transforms structured data between JSON, YAML, TOML, and XML while preserving nested structures. It supports extracting sub-keys using dot notation (for example, `metadata.items`).
+  - **Options:** Use the `-k` (or `--key`) flag to set an optional starting path.
+  - **Example:** `python multitool.py convert input.json --key 'items' --output-format yaml`
+
 - **`replace`**
   - Performs text substitution across multiple files using literal strings or regular expressions.
   - **Options:**


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Added a new section for the `convert` mode in `docs/multitool.md`.
* **Why:** The `convert` mode was missing from the documentation despite being a useful feature for transforming structured data between JSON, YAML, TOML, and XML. Adding this section improves the completeness and usability of the Multitool documentation for a global audience.

---
*PR created automatically by Jules for task [912870762884770764](https://jules.google.com/task/912870762884770764) started by @RainRat*