### PR TITLE
Narrow broad exception in _format_analysis_summary

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -621,7 +621,7 @@ def _format_analysis_summary(
                 report.append(
                     f"  {c_bold}{c_blue}{'Min/Max/Avg changes:':<{label_width}}{c_reset} {min_dist} / {max_dist} / {avg_dist:.1f}"
                 )
-        except Exception:
+        except (ValueError, TypeError):
             pass
 
     # Extra metrics

--- a/tests/test_multitool_coverage_completion_v2.py
+++ b/tests/test_multitool_coverage_completion_v2.py
@@ -26,7 +26,7 @@ def test_format_analysis_summary_item_error_handling():
 
 def test_format_analysis_summary_distance_calculation_error_handling():
     with patch("multitool.levenshtein_distance") as mock_lev:
-        mock_lev.side_effect = Exception("Levenshtein failed")
+        mock_lev.side_effect = ValueError("Levenshtein failed")
 
         report = multitool._format_analysis_summary(2, [("a", "b")], "item", None, False)
         assert "Min/Max/Avg changes" not in "".join(report)


### PR DESCRIPTION
Updated the `_format_analysis_summary` function in `multitool.py` to narrow a broad `except Exception: pass` block to `except (ValueError, TypeError): pass`. The corresponding unit test in `tests/test_multitool_coverage_completion_v2.py` was also updated to align with this change.

This reduces "Error Handling Noise" and prevents the silent swallowing of unexpected critical errors (like `NameError` or `AttributeError`) while still gracefully handling expected data-related failures (like empty sequences or invalid types) during report generation. This change is non-breaking and improves overall code health and maintainability.

---
*PR created automatically by Jules for task [17290320010899394169](https://jules.google.com/task/17290320010899394169) started by @RainRat*