### PR TITLE
Refine error handling in analysis summary report

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -621,7 +621,7 @@ def _format_analysis_summary(
                 report.append(
                     f"  {c_bold}{c_blue}{'Min/Max/Avg changes:':<{label_width}}{c_reset} {min_dist} / {max_dist} / {avg_dist:.1f}"
                 )
-        except Exception:
+        except (ValueError, TypeError):
             pass
 
     # Extra metrics

--- a/tests/test_multitool_coverage_completion_v2.py
+++ b/tests/test_multitool_coverage_completion_v2.py
@@ -26,7 +26,7 @@ def test_format_analysis_summary_item_error_handling():
 
 def test_format_analysis_summary_distance_calculation_error_handling():
     with patch("multitool.levenshtein_distance") as mock_lev:
-        mock_lev.side_effect = Exception("Levenshtein failed")
+        mock_lev.side_effect = ValueError("Levenshtein failed")
 
         report = multitool._format_analysis_summary(2, [("a", "b")], "item", None, False)
         assert "Min/Max/Avg changes" not in "".join(report)


### PR DESCRIPTION
* **What:** Narrowed a broad `except Exception:` block in the `_format_analysis_summary` function within `multitool.py` to catch only `ValueError` and `TypeError`. Updated the corresponding unit test in `tests/test_multitool_coverage_completion_v2.py` to align with this change.
* **Why:** This reduces "Error Handling Noise" by ensuring that only expected formatting and numeric errors are silently handled, while allowing truly unexpected exceptions to propagate for better debuggability. This change maintains consistency with another refined block in the same function and similar logic in `typostats.py`. It is a non-breaking change that improves code quality without altering external behavior for standard edge cases.

---
*PR created automatically by Jules for task [18385758134905066915](https://jules.google.com/task/18385758134905066915) started by @RainRat*