### PR TITLE
[FEAT] Add Markdown headings extraction mode

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -71,6 +71,11 @@ Use these modes to pull specific data from a file.
   - Extracts text from cells in a Markdown table. It saves the first column by default. Use the `--right` flag for the second column, or `--column` (or `-c`) to pick specific columns. It automatically skips header and divider rows.
   - **Example:** `python multitool.py md-table readme.md --column 2`
 
+- **`headings`**
+  - Extracts headings from Markdown files (lines starting with `#`). It saves the heading text by default.
+  - **Options:** Use `--level` (1-6) to filter by a specific heading level. Use `--pairs` (or `-p`) to see both the level and the text.
+  - **Example:** `python multitool.py headings readme.md --level 1`
+
 - **`json`**
   - Extracts values from a JSON file by key. Use dot notation for nested keys (for example, `user.name`). If you do not provide a key, it extracts items from the top level. It automatically handles lists and objects.
   - **Example:** `python multitool.py json report.json --key replacements.typo`

--- a/multitool.py
+++ b/multitool.py
@@ -1662,6 +1662,22 @@ def _extract_markdown_items(input_file: str, right_side: bool = False, quiet: bo
                 yield content
 
 
+def _extract_markdown_headings(input_file: str, quiet: bool = False) -> Iterable[Tuple[int, str]]:
+    """Yield (level, text) for each Markdown heading."""
+    lines = _read_file_lines_robust(input_file)
+    # Match ATX headings: # Title, ## Subtitle, etc.
+    # Pattern matches 1-6 hashes, then whitespace, then content.
+    # It optionally strips trailing hashes.
+    pattern = re.compile(r'^(#{1,6})\s+(.*?)(?:\s+#+)?$')
+
+    for line in tqdm(lines, desc=f'Processing {input_file} (headings)', unit=' lines', disable=quiet):
+        match = pattern.match(line.strip())
+        if match:
+            level = len(match.group(1))
+            text = match.group(2).strip()
+            yield level, text
+
+
 def _extract_md_table_items(
     input_file: str,
     right_side: bool = False,
@@ -2094,6 +2110,51 @@ def markdown_mode(
         clean_items=clean_items,
         limit=limit,
     )
+
+
+def headings_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    level: int | None = None,
+    pairs: bool = False,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Extracts headings from Markdown files."""
+    start_time = time.perf_counter()
+    results = []
+    total_headings = 0
+
+    for input_file in input_files:
+        for h_level, h_text in _extract_markdown_headings(input_file, quiet=quiet):
+            total_headings += 1
+            if level is not None and h_level != level:
+                continue
+
+            # Apply cleaning and filtering to the text
+            text_to_save = filter_to_letters(h_text) if clean_items else h_text
+            if not (min_length <= len(text_to_save) <= max_length):
+                continue
+
+            if pairs:
+                results.append((str(h_level), text_to_save))
+            else:
+                results.append(text_to_save)
+
+    if process_output:
+        results = sorted(set(results))
+
+    if pairs:
+        _write_paired_output(results, output_file, output_format, "Headings", quiet, limit=limit)
+    else:
+        write_output(results, output_file, output_format, quiet, limit=limit)
+
+    print_processing_stats(total_headings, results, item_label="heading", start_time=start_time)
 
 
 def md_table_mode(
@@ -5975,6 +6036,12 @@ MODE_DETAILS = {
         "example": "python multitool.py md-table readme.md --column 2 --output corrections.txt",
         "flags": "[--right] [-c N]",
     },
+    "headings": {
+        "summary": "Extracts Markdown headings",
+        "description": "Finds headings in Markdown files (like '# Title'). It saves the heading text by default. Use --level to filter by heading level (1-6) or --pairs to see both level and text.",
+        "example": "python multitool.py headings readme.md --level 1",
+        "flags": "[--level N] [-p]",
+    },
     "json": {
         "summary": "Extracts JSON values by key",
         "description": "Finds values for a specific key in a JSON file. Use dots for nested keys (like 'user.name'). If no key is provided, it gets items from the top level. It automatically handles lists of objects.",
@@ -6245,7 +6312,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "json", "yaml", "toml", "xml", "flatten", "line", "words", "ngrams", "regex"],
+        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "headings", "json", "yaml", "toml", "xml", "flatten", "line", "words", "ngrams", "regex"],
         "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "convert", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
@@ -6744,6 +6811,27 @@ def _build_parser() -> argparse.ArgumentParser:
         help='One or more 0-based column numbers to get.',
     )
     _add_common_mode_arguments(md_table_parser)
+
+    headings_parser = subparsers.add_parser(
+        'headings',
+        help=MODE_DETAILS['headings']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['headings']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['headings']['example']}{RESET}",
+    )
+    headings_options = headings_parser.add_argument_group(f"{BLUE}HEADINGS OPTIONS{RESET}")
+    headings_options.add_argument(
+        '--level',
+        type=int,
+        choices=range(1, 7),
+        help="Filter by heading level (1-6).",
+    )
+    headings_options.add_argument(
+        '-p', '--pairs',
+        action='store_true',
+        help="Output the heading level along with the text.",
+    )
+    _add_common_mode_arguments(headings_parser)
 
     json_parser = subparsers.add_parser(
         'json',
@@ -8223,6 +8311,15 @@ def main() -> None:
                 'right_side': right_side,
                 'output_format': output_format,
                 'columns': getattr(args, 'columns', None),
+            },
+        ),
+        'headings': (
+            headings_mode,
+            {
+                **common_kwargs,
+                'level': getattr(args, 'level', None),
+                'pairs': getattr(args, 'pairs', False),
+                'output_format': output_format,
             },
         ),
         'table': (

--- a/tests/test_multitool_headings.py
+++ b/tests/test_multitool_headings.py
@@ -1,0 +1,85 @@
+import os
+import pytest
+from multitool import headings_mode
+
+def test_headings_mode_basic(tmp_path, capsys):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("# H1 Title\nSome text\n## H2 Subtitle\n### H3 Another\n# Another H1 #")
+
+    output_file = tmp_path / "output.txt"
+
+    # Test all headings
+    headings_mode(
+        input_files=[str(md_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        clean_items=False,
+    )
+
+    content = output_file.read_text().splitlines()
+    assert content == ["H1 Title", "H2 Subtitle", "H3 Another", "Another H1"]
+
+def test_headings_mode_level_filter(tmp_path):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("# H1\n## H2\n# H1 again")
+
+    output_file = tmp_path / "output.txt"
+
+    # Test level 1 only
+    headings_mode(
+        input_files=[str(md_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        level=1,
+        clean_items=False,
+    )
+
+    content = output_file.read_text().splitlines()
+    assert content == ["H1", "H1 again"]
+
+def test_headings_mode_pairs(tmp_path):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("# H1\n## H2")
+
+    output_file = tmp_path / "output.txt"
+
+    # Test pairs (default format is line which uses -> for pairs)
+    headings_mode(
+        input_files=[str(md_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=False,
+        pairs=True,
+        clean_items=False,
+        output_format='line'
+    )
+
+    content = output_file.read_text().splitlines()
+    assert content == ["1 -> H1", "2 -> H2"]
+
+def test_headings_mode_clean_and_length(tmp_path):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("# Title 1\n## AB\n### Very Long Heading Here")
+
+    output_file = tmp_path / "output.txt"
+
+    # Test length filter (min 3) and cleaning (remove numbers/spaces)
+    headings_mode(
+        input_files=[str(md_file)],
+        output_file=str(output_file),
+        min_length=3,
+        max_length=10,
+        process_output=False,
+        clean_items=True, # filter_to_letters
+    )
+
+    content = output_file.read_text().splitlines()
+    # "Title 1" -> "title" (length 5) -> OK
+    # "AB" -> "ab" (length 2) -> filtered out
+    # "Very Long Heading Here" -> "verylongheadinghere" (length > 10) -> filtered out
+    assert content == ["title"]


### PR DESCRIPTION
I identified a logical gap in the Markdown processing capabilities of `multitool.py`. While it supported extracting list items and table data, it lacked a way to extract headings.

I have implemented a new `headings` mode that:
1. Extracts text from ATX-style headings (`# Title`).
2. Supports filtering by heading level (e.g., `--level 1`).
3. Supports outputting (level, text) pairs (e.g., `--pairs`).
4. Integrates with the existing filtering (`--min-length`, `--max-length`, `--raw`) and output (`--output-format`) systems.

This feature is zero-configuration and fits naturally within the "GET DATA" category of the tool.

---
*PR created automatically by Jules for task [5977997575677220669](https://jules.google.com/task/5977997575677220669) started by @RainRat*