### PR TITLE
Clean up redundant validation in smart_open_output

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -669,12 +669,10 @@ def smart_open_output(filename: Any, encoding: str = 'utf-8', newline: str | Non
     If filename has a 'write' attribute, yields it directly.
     Otherwise, opens the file for writing.
     """
-    if not isinstance(filename, str) and hasattr(filename, 'write'):
+    if hasattr(filename, 'write'):
         yield filename
     elif filename == '-':
         yield sys.stdout
-    elif hasattr(filename, 'write'):
-        yield filename
     else:
         with open(filename, 'w', encoding=encoding, newline=newline) as f:
             yield f


### PR DESCRIPTION
* **What:** Simplified the `smart_open_output` context manager by consolidating redundant logic branches. Removed the unnecessary `elif hasattr(filename, 'write'):` block and simplified the initial `if` condition to rely on duck typing for file-like objects.
* **Why:** Improves code readability and maintainability by removing redundant validation and "noise". The change is non-breaking as the external behavior remains identical for all standard use cases.

---
*PR created automatically by Jules for task [13772643755411099301](https://jules.google.com/task/13772643755411099301) started by @RainRat*