### PR TITLE
[DOCS] Clarify 0-based column indexing in multitool.md

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -60,16 +60,16 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py between input.txt --start '{{' --end '}}'`
 
 - **`csv`**
-  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) to pick specific columns. Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
-  - **Example:** `python multitool.py csv data.csv --column 2`
+  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) to pick specific columns. It uses 0-based indexing (0 is the first column). Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
+  - **Example:** `python multitool.py csv data.csv --column 0 2`
 
 - **`markdown`**
   - Extracts Markdown list items (lines starting with `-`, `*`, or `+`). You can split items by `:` or `->` to get one side of a pair (use the `--right` flag for the second part).
   - **Example:** `python multitool.py markdown notes.md --right`
 
 - **`md-table`**
-  - Extracts text from cells in a Markdown table. It saves the first column by default. Use the `--right` flag for the second column, or `--column` (or `-c`) to pick specific columns. It automatically skips header and divider rows.
-  - **Example:** `python multitool.py md-table readme.md --column 2`
+  - Extracts text from cells in a Markdown table. It saves the first column by default. Use the `--right` flag for the second column, or `--column` (or `-c`) to pick specific columns. It uses 0-based indexing (0 is the first column). It automatically skips header and divider rows.
+  - **Example:** `python multitool.py md-table readme.md --column 0 2`
 
 - **`headings`**
   - Extracts headings from Markdown files (lines starting with `#`). It saves the heading text by default.


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated the `csv` and `md-table` mode descriptions in `docs/multitool.md`.
* **Why:** The `--column` flag uses 0-based indexing (where 0 is the first column), which was not explicitly mentioned. Clarifying this and updating the examples helps users avoid off-by-one errors when selecting columns.

---
*PR created automatically by Jules for task [6593733957981103953](https://jules.google.com/task/6593733957981103953) started by @RainRat*