### PR TITLE
[FEAT] Add Markdown links extraction mode to multitool.py

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -76,6 +76,11 @@ Use these modes to pull specific data from a file.
   - **Options:** Use `--level` (1-6) to filter by a specific heading level. Use `--pairs` (or `-p`) to see both the level and the text.
   - **Example:** `python multitool.py headings readme.md --level 1`
 
+- **`links`**
+  - Extracts links and images from Markdown files (for example, `[text](url)` or `![alt](url)`). It saves the link text by default.
+  - **Options:** Use the `--right` flag to save the URL instead, or `--pairs` (or `-p`) to see both the text and the URL.
+  - **Example:** `python multitool.py links readme.md --right`
+
 - **`json`**
   - Extracts values from a JSON file by key. Use dot notation for nested keys (for example, `user.name`). If you do not provide a key, it extracts items from the top level. It automatically handles lists and objects.
   - **Example:** `python multitool.py json report.json --key replacements.typo`

--- a/multitool.py
+++ b/multitool.py
@@ -1686,6 +1686,19 @@ def _extract_markdown_headings(input_file: str, quiet: bool = False) -> Iterable
             yield level, text
 
 
+def _extract_markdown_links(input_file: str, quiet: bool = False) -> Iterable[Tuple[str, str]]:
+    """Yield (text, url) for each Markdown link or image."""
+    lines = _read_file_lines_robust(input_file)
+    # Match [text](url) or ![alt](url)
+    pattern = re.compile(r'!?\[(.*?)\]\((.*?)\)')
+
+    for line in tqdm(lines, desc=f'Processing {input_file} (links)', unit=' lines', disable=quiet):
+        for match in pattern.finditer(line):
+            text = match.group(1).strip()
+            url = match.group(2).strip()
+            yield text, url
+
+
 def _extract_md_table_items(
     input_file: str,
     right_side: bool = False,
@@ -2163,6 +2176,54 @@ def headings_mode(
         write_output(results, output_file, output_format, quiet, limit=limit)
 
     print_processing_stats(total_headings, results, item_label="heading", start_time=start_time)
+
+
+def links_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    right_side: bool = False,
+    pairs: bool = False,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Extracts links from Markdown files."""
+    start_time = time.perf_counter()
+    results = []
+    total_links = 0
+
+    for input_file in input_files:
+        for l_text, l_url in _extract_markdown_links(input_file, quiet=quiet):
+            total_links += 1
+
+            # Decide which part to check/save
+            if pairs:
+                val_to_check = l_text  # Check text for length
+                save_text = filter_to_letters(l_text) if clean_items else l_text
+                save_url = l_url # URLs are usually not cleaned
+                if not (min_length <= len(val_to_check) <= max_length):
+                    continue
+                results.append((save_text, save_url))
+            else:
+                val = l_url if right_side else l_text
+                val_to_save = filter_to_letters(val) if clean_items else val
+                if not (min_length <= len(val_to_save) <= max_length):
+                    continue
+                results.append(val_to_save)
+
+    if process_output:
+        results = sorted(set(results))
+
+    if pairs:
+        _write_paired_output(results, output_file, output_format, "Links", quiet, limit=limit)
+    else:
+        write_output(results, output_file, output_format, quiet, limit=limit)
+
+    print_processing_stats(total_links, results, item_label="link", start_time=start_time)
 
 
 def md_table_mode(
@@ -6169,6 +6230,12 @@ MODE_DETAILS = {
         "example": "python multitool.py headings readme.md --level 1",
         "flags": "[--level N] [-p]",
     },
+    "links": {
+        "summary": "Extracts Markdown links",
+        "description": "Finds links and images in Markdown files (like '[text](url)' or '![alt](url)'). It saves the link text by default. Use --right to save the URL instead, or --pairs to see both.",
+        "example": "python multitool.py links readme.md --right",
+        "flags": "[--right] [-p]",
+    },
     "json": {
         "summary": "Extracts JSON values by key",
         "description": "Finds values for a specific key in a JSON file. Use dots for nested keys (like 'user.name'). If no key is provided, it gets items from the top level. It automatically handles lists of objects.",
@@ -6439,7 +6506,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "headings", "json", "yaml", "toml", "xml", "flatten", "line", "words", "ngrams", "regex"],
+        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "headings", "links", "json", "yaml", "toml", "xml", "flatten", "line", "words", "ngrams", "regex"],
         "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "convert", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
@@ -6959,6 +7026,26 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output the heading level along with the text.",
     )
     _add_common_mode_arguments(headings_parser)
+
+    links_parser = subparsers.add_parser(
+        'links',
+        help=MODE_DETAILS['links']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['links']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['links']['example']}{RESET}",
+    )
+    links_options = links_parser.add_argument_group(f"{BLUE}LINKS OPTIONS{RESET}")
+    links_options.add_argument(
+        '--right',
+        action='store_true',
+        help="Get the URL instead of the link text.",
+    )
+    links_options.add_argument(
+        '-p', '--pairs',
+        action='store_true',
+        help="Output both the link text and the URL.",
+    )
+    _add_common_mode_arguments(links_parser)
 
     json_parser = subparsers.add_parser(
         'json',
@@ -8385,6 +8472,15 @@ def main() -> None:
             {
                 **common_kwargs,
                 'right_side': right_side,
+                'output_format': output_format,
+            },
+        ),
+        'links': (
+            links_mode,
+            {
+                **common_kwargs,
+                'right_side': right_side,
+                'pairs': getattr(args, 'pairs', False),
                 'output_format': output_format,
             },
         ),


### PR DESCRIPTION
Implemented a new `links` mode in `multitool.py` to extract Markdown links and images. This feature complements existing Markdown processing modes like `headings` and `md-table`.

Key features of the new mode:
- Extracts `[text](url)` and `![alt](url)` patterns.
- Supports extracting link text (default), URLs (`--right`), or text-URL pairs (`--pairs`).
- Integrates with existing filtering, cleaning, and sorting logic.
- Includes updated CLI help and documentation.

---
*PR created automatically by Jules for task [11745516622357804892](https://jules.google.com/task/11745516622357804892) started by @RainRat*