### PR TITLE
Simplify smart_open_output context manager in multitool.py

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -664,17 +664,14 @@ def print_processing_stats(
 def smart_open_output(filename: Any, encoding: str = 'utf-8', newline: str | None = None) -> Iterable[TextIO]:
     """
     Context manager that yields a file object for writing.
-    If filename is a stream, yields it directly.
-    If filename is '-', yields the main output (the screen).
-    If filename has a 'write' attribute, yields it directly.
+    If filename has a 'write' attribute (is a stream), yields it directly.
+    If filename is '-', yields standard output.
     Otherwise, opens the file for writing.
     """
-    if not isinstance(filename, str) and hasattr(filename, 'write'):
+    if hasattr(filename, 'write'):
         yield filename
     elif filename == '-':
         yield sys.stdout
-    elif hasattr(filename, 'write'):
-        yield filename
     else:
         with open(filename, 'w', encoding=encoding, newline=newline) as f:
             yield f


### PR DESCRIPTION
* **What:** Simplified the `smart_open_output` context manager in `multitool.py` by removing redundant type checks and unreachable logical branches. The logic now uses a single `hasattr(filename, 'write')` check to identify stream-like objects.
* **Why:** This improvement falls under the "Redundant Validation" category. It enhances code clarity and hygiene while maintaining identical external behavior for all supported input types (file paths, standard output '-', and stream objects).

---
*PR created automatically by Jules for task [632664224232725500](https://jules.google.com/task/632664224232725500) started by @RainRat*