### PR TITLE
[TEST] Add coverage for rename mode collision handling

### DIFF
--- a/tests/test_multitool_rename_collisions.py
+++ b/tests/test_multitool_rename_collisions.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from multitool import main
+import logging
+from unittest.mock import patch
+import sys
+
+def test_rename_collisions_dry_run_reporting(tmp_path, caplog):
+    (tmp_path / "a.txt").write_text("1")
+    (tmp_path / "b.txt").write_text("2")
+    (tmp_path / "d.txt").write_text("3")
+    (tmp_path / "existing.txt").write_text("e")
+    (tmp_path / "f.txt").write_text("4")
+
+    args = [
+        "multitool.py", "rename", str(tmp_path),
+        "--add", "a:collision", "b:collision", "d:existing", "f:success",
+        "--dry-run"
+    ]
+
+    with patch.object(sys, 'argv', args):
+        with caplog.at_level(logging.WARNING):
+            main()
+
+    assert "Total renames that would be made: 1" in caplog.text
+    assert "Total collisions detected (would be skipped): 3" in caplog.text
+
+def test_rename_collisions_in_place_skipping(tmp_path, caplog):
+    (tmp_path / "a.txt").write_text("1")
+    (tmp_path / "b.txt").write_text("2")
+    (tmp_path / "d.txt").write_text("3")
+    (tmp_path / "existing.txt").write_text("e")
+    (tmp_path / "f.txt").write_text("4")
+
+    args = [
+        "multitool.py", "rename", str(tmp_path),
+        "--add", "a:collision", "b:collision", "d:existing", "f:success",
+        "--in-place"
+    ]
+
+    with patch.object(sys, 'argv', args):
+        with caplog.at_level(logging.INFO):
+            main()
+
+    assert "Successfully made 1 rename(s)." in caplog.text
+    assert "Skipped 3 collision(s)." in caplog.text
+
+    assert (tmp_path / "success.txt").exists()
+    assert (tmp_path / "a.txt").exists()
+    assert (tmp_path / "b.txt").exists()
+    assert (tmp_path / "d.txt").exists()
+    assert (tmp_path / "collision.txt").exists() is False


### PR DESCRIPTION
This Pull Request addresses a coverage gap in the `rename` command of `multitool.py`.

### Changes
*   **Added `tests/test_multitool_rename_collisions.py`**: A new test suite specifically targeting the collision detection and reporting logic in `rename_mode`.
*   **Dry Run Verification**: Confirms that collisions are correctly identified and logged as warnings when using `--dry-run`.
*   **In-Place Verification**: Confirms that collisions are safely skipped and reported in the final summary when using `--in-place`.

### Coverage Impact
Addresses coverage gaps for the following lines in `multitool.py`:
*   `5452`: Detection of multiple files mapping to the same target.
*   `5455`: Detection of targets that already exist on disk.
*   `5497`: Reporting of skipped collisions in the final success message.
*   `5505`: Logging of collision counts during dry runs.

The total test suite now passes with 943 tests, maintaining overall project stability.

---
*PR created automatically by Jules for task [6911813634905223438](https://jules.google.com/task/6911813634905223438) started by @RainRat*