### PR TITLE
[DOCS] Clarify multi-letter replacement terminology in typostats

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -34,13 +34,13 @@ The tool automatically recognizes several common ways of listing typos:
 
 ### Analysis Options
 - `-m`, `--min`: Only show patterns that appear at least this many times (Default: 1).
-- `-s`, `--sort`: How to sort the results. Choose `count` (most frequent first), `typo` (alphabetical by typo), or `correct` (alphabetical by fix).
+- `-s`, `--sort`: How to sort the results. Choose `count` (most frequent first), `typo` (alphabetical by typo), or `correct` (alphabetical by correction).
 - `-a`, `--all`: Enable all analysis features at once. This is the default if no other analysis options are chosen.
 - `-n`, `-L`, `--limit`: Only show the top N results.
-- `-2`, `--allow-two-char`: Look for cases where one letter is replaced by two (like `m` -> `rn`) or two by one (like `ph` -> `f`).
-- `--1to2`: Specifically look for single-to-double letter replacements.
-- `--2to1`: Specifically look for double-to-single letter replacements.
-- `--include-deletions`: Include cases where you added an extra letter or missed one (like `aa` -> `a`).
+- `-2`, `--allow-two-char`: Look for cases where you typed two letters instead of one (like `rn` instead of `m`) or one instead of two (like `f` instead of `ph`).
+- `--1to2`: Specifically look for cases where you typed two letters instead of one (like `rn` instead of `m`).
+- `--2to1`: Specifically look for cases where you typed one letter instead of two (like `f` instead of `ph`).
+- `--include-deletions`: Include cases where you added an extra letter or missed one (like typing `aa` instead of `a`).
 - `-t`, `--transposition`: Find swapped letters (like `teh` instead of `the`).
 - `-k`, `--keyboard`: Find typos caused by hitting keys next to each other on the keyboard.
 
@@ -111,8 +111,8 @@ For example, a row showing `eh │ he` means you swapped the letters `h` and `e`
 When you enable analysis features, the tool finds specific patterns in the **Attr** column:
 - **[K]**: Keyboard slip (the keys are next to each other on a QWERTY layout).
 - **[T]**: Transposition (swapped letters, like `teh` instead of `the`).
-- **[1:2]**: One-to-two replacement (for example, typing `rn` instead of `m`).
-- **[2:1]**: Two-to-one replacement (for example, typing `f` instead of `ph`).
+- **[1:2]**: One-to-two replacement (for example, typing `rn` instead of `m`, or `ph` instead of `f`).
+- **[2:1]**: Two-to-one replacement (for example, typing `m` instead of `rn`, or `f` instead of `ph`).
 - **[Ins]**: Insertion (typing an extra letter).
 - **[Del]**: Deletion (missing a letter).
 

--- a/typostats.py
+++ b/typostats.py
@@ -1086,7 +1086,7 @@ def main() -> None:
         '-s', '--sort',
         choices=['count', 'typo', 'correct'],
         default='count',
-        help="How to sort the results: 'count' (most frequent first), 'typo' (alphabetical by the mistake), or 'correct' (alphabetical by the fix)."
+        help="How to sort the results: 'count' (most frequent first), 'typo' (alphabetical by the typo), or 'correct' (alphabetical by the correction)."
     )
     analysis_group.add_argument(
         '-a',
@@ -1099,7 +1099,7 @@ def main() -> None:
         '--allow-two-char',
         dest='allow_two_char',
         action='store_true',
-        help="Allow cases where one letter is replaced by two (like 'm' to 'rn') or two letters are replaced by one (like 'ph' to 'f').",
+        help="Allow cases where you typed two letters instead of one (like 'rn' instead of 'm') or one instead of two (like 'f' instead of 'ph').",
     )
     # Hidden alias for backward compatibility
     parser.add_argument('--allow_two_char', action='store_true', help=argparse.SUPPRESS)
@@ -1108,18 +1108,18 @@ def main() -> None:
         '--1to2',
         dest='allow_1to2',
         action='store_true',
-        help="Allow cases where one letter is replaced by two (like 'm' to 'rn').",
+        help="Allow cases where you typed two letters instead of one (like 'rn' instead of 'm').",
     )
     analysis_group.add_argument(
         '--2to1',
         dest='allow_2to1',
         action='store_true',
-        help="Allow cases where two letters are replaced by one (like 'ph' to 'f').",
+        help="Allow cases where you typed one letter instead of two (like 'f' instead of 'ph').",
     )
     analysis_group.add_argument(
         '--include-deletions',
         action='store_true',
-        help="Include cases where you added an extra letter or missed one (like 'aa' to 'a' or 'o' to 'or').",
+        help="Include cases where you added an extra letter or missed one (like typing 'aa' instead of 'a').",
     )
 
     analysis_group.add_argument(


### PR DESCRIPTION
**PR Title:** [DOCS] Clarify multi-letter replacement terminology in typostats

**Description:**
* **Type:** Documentation / Internal Help
* **What:** Updated `typostats.py` CLI help strings and `docs/typostats.md`.
* **Why:** Clarified the terminology for multi-letter replacements (1-to-2 vs 2-to-1) to ensure it consistently refers to the relationship between the typo and the correction, matching the visual report and making it easier for users to understand which option to use.


---
*PR created automatically by Jules for task [106613129662875553](https://jules.google.com/task/106613129662875553) started by @RainRat*