### PR TITLE
Add 'links' mode to multitool for Markdown extraction

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -76,6 +76,11 @@ Use these modes to pull specific data from a file.
   - **Options:** Use `--level` (1-6) to filter by a specific heading level. Use `--pairs` (or `-p`) to see both the level and the text.
   - **Example:** `python multitool.py headings readme.md --level 1`
 
+- **`links`**
+  - Extracts links (`[text](url)`) and images (`![alt](url)`) from Markdown files. It saves the link text by default.
+  - **Options:** Use the `--right` flag to save the URL instead, or `--pairs` (or `-p`) to save both.
+  - **Example:** `python multitool.py links readme.md --pairs`
+
 - **`json`**
   - Extracts values from a JSON file by key. Use dot notation for nested keys (for example, `user.name`). If you do not provide a key, it extracts items from the top level. It automatically handles lists and objects.
   - **Example:** `python multitool.py json report.json --key replacements.typo`

--- a/multitool.py
+++ b/multitool.py
@@ -1090,6 +1090,9 @@ def _write_paired_output(
     elif mode_label == "Repeated":
         left_header = "Repeated Words"
         right_header = "Fix"
+    elif mode_label == "Links":
+        left_header = "Text"
+        right_header = "URL"
 
     with smart_open_output(output_file, newline=newline) as out_file:
         if output_format == 'json':
@@ -1686,6 +1689,19 @@ def _extract_markdown_headings(input_file: str, quiet: bool = False) -> Iterable
             yield level, text
 
 
+def _extract_markdown_links(input_file: str, quiet: bool = False) -> Iterable[Tuple[str, str]]:
+    """Yield (text, url) for each Markdown link and image."""
+    lines = _read_file_lines_robust(input_file)
+    # Matches [text](url) and ![alt](url)
+    pattern = re.compile(r'!?\[(.*?)\]\((.*?)\)')
+
+    for line in tqdm(lines, desc=f'Processing {input_file} (links)', unit=' lines', disable=quiet):
+        for match in pattern.finditer(line):
+            text = match.group(1).strip()
+            url = match.group(2).strip()
+            yield text, url
+
+
 def _extract_md_table_items(
     input_file: str,
     right_side: bool = False,
@@ -2163,6 +2179,56 @@ def headings_mode(
         write_output(results, output_file, output_format, quiet, limit=limit)
 
     print_processing_stats(total_headings, results, item_label="heading", start_time=start_time)
+
+
+def links_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    right_side: bool = False,
+    pairs: bool = False,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Extracts links and images from Markdown files."""
+    start_time = time.perf_counter()
+    results = []
+    total_links = 0
+
+    for input_file in input_files:
+        for l_text, l_url in _extract_markdown_links(input_file, quiet=quiet):
+            total_links += 1
+
+            # Apply cleaning and filtering to the text side if requested
+            # The URL side is always kept raw.
+            text_processed = filter_to_letters(l_text) if clean_items else l_text
+
+            if pairs:
+                # For pairs, we check length of the text (after cleaning)
+                if min_length <= len(text_processed) <= max_length:
+                    results.append((text_processed, l_url))
+            elif right_side:
+                # If only getting URLs, length filtering applies to URL
+                if min_length <= len(l_url) <= max_length:
+                    results.append(l_url)
+            else:
+                # If only getting text, length filtering applies to text
+                if min_length <= len(text_processed) <= max_length:
+                    results.append(text_processed)
+
+    if process_output:
+        results = sorted(set(results))
+
+    if pairs:
+        _write_paired_output(results, output_file, output_format, "Links", quiet, limit=limit)
+    else:
+        write_output(results, output_file, output_format, quiet, limit=limit)
+
+    print_processing_stats(total_links, results, item_label="link", start_time=start_time)
 
 
 def md_table_mode(
@@ -6193,6 +6259,12 @@ MODE_DETAILS = {
         "example": "python multitool.py xml data.xml -k './/item/name' --output names.txt",
         "flags": "[-k KEY]",
     },
+    "links": {
+        "summary": "Extracts Markdown links and images",
+        "description": "Finds links ([text](url)) and images (![alt](url)) in Markdown files. It saves the text by default. Use --right to save the URL instead, or --pairs to save both.",
+        "example": "python multitool.py links readme.md --pairs",
+        "flags": "[--right] [-p]",
+    },
     "flatten": {
         "summary": "Flattens nested data structures",
         "description": "Transforms nested JSON, YAML, or TOML structures into a flat list of dot-separated paths (for example, 'user.name = value'). It supports multi-document YAML and JSON Lines (JSONL).",
@@ -6439,7 +6511,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "headings", "json", "yaml", "toml", "xml", "flatten", "line", "words", "ngrams", "regex"],
+        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "md-table", "headings", "links", "json", "yaml", "toml", "xml", "flatten", "line", "words", "ngrams", "regex"],
         "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "convert", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
@@ -6959,6 +7031,26 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Output the heading level along with the text.",
     )
     _add_common_mode_arguments(headings_parser)
+
+    links_parser = subparsers.add_parser(
+        'links',
+        help=MODE_DETAILS['links']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['links']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['links']['example']}{RESET}",
+    )
+    links_options = links_parser.add_argument_group(f"{BLUE}LINKS OPTIONS{RESET}")
+    links_options.add_argument(
+        '--right',
+        action='store_true',
+        help="Get the URL (right side) instead of the text (left side).",
+    )
+    links_options.add_argument(
+        '-p', '--pairs',
+        action='store_true',
+        help="Output both the text and the URL.",
+    )
+    _add_common_mode_arguments(links_parser)
 
     json_parser = subparsers.add_parser(
         'json',
@@ -8385,6 +8477,15 @@ def main() -> None:
             {
                 **common_kwargs,
                 'right_side': right_side,
+                'output_format': output_format,
+            },
+        ),
+        'links': (
+            links_mode,
+            {
+                **common_kwargs,
+                'right_side': right_side,
+                'pairs': getattr(args, 'pairs', False),
                 'output_format': output_format,
             },
         ),

--- a/tests/test_multitool_links.py
+++ b/tests/test_multitool_links.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+from multitool import main
+import sys
+from io import StringIO
+
+def test_links_extraction(tmp_path, capsys):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("""
+# Test
+This is a [link](https://example.com).
+Here is an image: ![alt text](image.png)
+Another [link with spaces](https://google.com).
+    """)
+
+    # Test default (extract text)
+    sys.argv = ["multitool.py", "links", str(md_file)]
+    main()
+    captured = capsys.readouterr()
+    assert "link" in captured.out
+    assert "alttext" in captured.out
+    assert "linkwithspaces" in captured.out
+    assert "https://example.com" not in captured.out
+
+def test_links_right_side(tmp_path, capsys):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("[link](https://example.com)")
+
+    sys.argv = ["multitool.py", "links", str(md_file), "--right"]
+    main()
+    captured = capsys.readouterr()
+    assert "https://example.com" in captured.out
+    assert "link" not in captured.out
+
+def test_links_pairs(tmp_path, capsys):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("[link](https://example.com)")
+
+    # Test pairs with arrow format
+    sys.argv = ["multitool.py", "links", str(md_file), "--pairs", "--output-format", "line"]
+    main()
+    captured = capsys.readouterr()
+    assert "link -> https://example.com" in captured.out
+
+def test_links_raw(tmp_path, capsys):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("[My Link](https://example.com)")
+
+    # Test without --raw (default cleaning)
+    sys.argv = ["multitool.py", "links", str(md_file)]
+    main()
+    captured = capsys.readouterr()
+    assert "mylink" in captured.out # lowercase and filtered to letters
+
+    # Test with --raw
+    sys.argv = ["multitool.py", "links", str(md_file), "--raw"]
+    main()
+    captured = capsys.readouterr()
+    assert "My Link" in captured.out


### PR DESCRIPTION
Added a new 'links' mode to `multitool.py` that allows users to extract links and images from Markdown files. This feature follows the established pattern of other Markdown-specific extraction tools in the codebase (like `headings` and `md-table`).

Key changes:
- Added `_extract_markdown_links` helper for regex-based extraction.
- Added `links_mode` handler for processing files and managing output.
- Updated `_write_paired_output` with appropriate headers for links.
- Registered the mode in `MODE_DETAILS` and the CLI summary table.
- Added documentation in `docs/multitool.md`.
- Added unit tests in `tests/test_multitool_links.py`.

---
*PR created automatically by Jules for task [6666184120099689141](https://jules.google.com/task/6666184120099689141) started by @RainRat*