### PR TITLE
Refactor `smart_open_output` to remove redundant logic

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -664,14 +664,11 @@ def print_processing_stats(
 def smart_open_output(filename: Any, encoding: str = 'utf-8', newline: str | None = None) -> Iterable[TextIO]:
     """
     Context manager that yields a file object for writing.
-    If filename is a stream, yields it directly.
     If filename is '-', yields the main output (the screen).
-    If filename has a 'write' attribute, yields it directly.
+    If filename has a 'write' attribute (like a stream), yields it directly.
     Otherwise, opens the file for writing.
     """
-    if not isinstance(filename, str) and hasattr(filename, 'write'):
-        yield filename
-    elif filename == '-':
+    if filename == '-':
         yield sys.stdout
     elif hasattr(filename, 'write'):
         yield filename


### PR DESCRIPTION
* **What:** Refactored the `smart_open_output` context manager in `multitool.py`. The original implementation had overlapping and redundant checks for file-like objects and the standard output shorthand (`'-'`). The new version streamlines this into three clear, non-overlapping branches: (1) check for the `'-'` shorthand, (2) check for a `write` attribute (stream/file-like objects), and (3) default to opening a file path.
* **Why:** This change improves code readability and maintainability by eliminating redundant `hasattr` calls and unnecessary `isinstance` checks. It standardizes the logic without altering external behavior, as verified by targeted testing and the existing test suite.

---
*PR created automatically by Jules for task [4933749589573726851](https://jules.google.com/task/4933749589573726851) started by @RainRat*