### PR TITLE
[DOCS] Clarify 0-based column indexing in multitool.py

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -60,16 +60,16 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py between input.txt --start '{{' --end '}}'`
 
 - **`csv`**
-  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) to pick specific columns. Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
-  - **Example:** `python multitool.py csv data.csv --column 2`
+  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) to pick specific columns (using 0-based indexing). Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
+  - **Example:** `python multitool.py csv data.csv --column 1  # Get the second column`
 
 - **`markdown`**
   - Extracts Markdown list items (lines starting with `-`, `*`, or `+`). You can split items by `:` or `->` to get one side of a pair (use the `--right` flag for the second part).
   - **Example:** `python multitool.py markdown notes.md --right`
 
 - **`md-table`**
-  - Extracts text from cells in a Markdown table. It saves the first column by default. Use the `--right` flag for the second column, or `--column` (or `-c`) to pick specific columns. It automatically skips header and divider rows.
-  - **Example:** `python multitool.py md-table readme.md --column 2`
+  - Extracts text from cells in a Markdown table. It saves the first column by default. Use the `--right` flag for the second column, or `--column` (or `-c`) to pick specific columns (using 0-based indexing). It automatically skips header and divider rows.
+  - **Example:** `python multitool.py md-table readme.md --column 1  # Get the second column`
 
 - **`headings`**
   - Extracts headings from Markdown files (lines starting with `#`). It saves the heading text by default.

--- a/multitool.py
+++ b/multitool.py
@@ -6147,8 +6147,8 @@ MODE_DETAILS = {
     },
     "csv": {
         "summary": "Extracts columns from CSV",
-        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, --column to pick specific numbers, or --delimiter to use a custom separator.",
-        "example": "python multitool.py csv typos.csv --column 2 --delimiter ';' -o corrections.txt",
+        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, --column to pick specific 0-based numbers, or --delimiter to use a custom separator.",
+        "example": "python multitool.py csv typos.csv --column 1 --delimiter ';'  # Get the second column",
         "flags": "[--first-column] [-c N] [-d DELIM]",
     },
     "markdown": {
@@ -6159,8 +6159,8 @@ MODE_DETAILS = {
     },
     "md-table": {
         "summary": "Extracts Markdown table items",
-        "description": "Finds text in cells of a Markdown table. It saves the first column by default. Use --right to save the second column instead, or --column to pick specific numbers. It automatically skips header and divider rows.",
-        "example": "python multitool.py md-table readme.md --column 2 --output corrections.txt",
+        "description": "Finds text in cells of a Markdown table. It saves the first column by default. Use --right to save the second column instead, or --column to pick specific 0-based numbers. It automatically skips header and divider rows.",
+        "example": "python multitool.py md-table readme.md --column 1  # Get the second column",
         "flags": "[--right] [-c N]",
     },
     "headings": {


### PR DESCRIPTION
* **Type:** Documentation / Internal Help
* **What:** Updated the `csv` and `md-table` sections in `docs/multitool.md` and the corresponding `MODE_DETAILS` in `multitool.py`.
* **Why:** This change clarifies how to use column numbers in Multitool. It removes confusion about whether indexing starts at 0 or 1, helping users extract the correct data from their files.

---
*PR created automatically by Jules for task [3841132607041426916](https://jules.google.com/task/3841132607041426916) started by @RainRat*