### PR TITLE
[DOCS] Standardize and improve CLI internal help strings in multitool.py

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -6365,7 +6365,7 @@ MODE_DETAILS = {
         "summary": "Extracts Markdown links and images",
         "description": "Finds links ([text](url)) and images (![alt](url)) in Markdown files. It saves the link text by default. Use --right to save the URL instead, or --pairs to see both.",
         "example": "python multitool.py links readme.md --right",
-        "flags": "[--right] [-p]",
+        "flags": "[FILES...] [--right] [-p]",
     },
     "codeblocks": {
         "summary": "Extracts Markdown code blocks",
@@ -6413,7 +6413,7 @@ MODE_DETAILS = {
         "summary": "Counts how often items appear",
         "description": "Counts how often each word, pair, line, or character appears and sorts the list by frequency. Use -f arrow for a rich visual report with bar charts. Use --pairs to count word pairs, --lines to count raw lines, or --chars to count individual characters. Use --by-file to count how many files contain each item. You can also provide a mapping (via --mapping or --add) to count matches of specific typos across your files.",
         "example": "python multitool.py count . --lines --min-count 5 -f arrow",
-        "flags": "[FILES...] [-s MAPPING] [-adSplcB]",
+        "flags": "[FILES...] [-s MAPPING] [-a KEY:VALUE] [-d DELIM] [-SplcB]",
     },
     "filterfragments": {
         "summary": "Removes words found inside others",
@@ -6453,9 +6453,9 @@ MODE_DETAILS = {
     },
     "map": {
         "summary": "Replaces items using a mapping",
-        "description": "Replaces items in your list with values from a mapping file or extra pairs provided via --add. Supports CSV, Arrow, Table, JSON, and YAML mapping formats. Use --smart-case to preserve capitalization and --pairs to see both original and changed words. Length filters are re-applied to items after they are changed.",
+        "description": "Replaces items in your list with values from a mapping file or extra pairs provided via --add. Supports CSV, Arrow, Table, JSON, YAML, TOML, and XML mapping formats. Use --smart-case to preserve capitalization and --pairs to see both original and changed words. Length filters are re-applied to items after they are changed.",
         "example": "python multitool.py map input.txt --add teh:the --smart-case --pairs",
-        "flags": "[FILES...] [-s MAPPING] [-apS]",
+        "flags": "[FILES...] [-s MAPPING] [-a KEY:VALUE] [-pS]",
     },
     "case": {
         "summary": "Changes word casing",
@@ -6533,7 +6533,7 @@ MODE_DETAILS = {
         "summary": "Finds loops in typo pairs",
         "description": "Detects cycles in your typo mappings (for example, 'A' maps to 'B' and 'B' maps back to 'A'). Repeated loops can cause issues when automatically fixing typos and represent logic errors in your data.",
         "example": "python multitool.py cycles typos.csv --output-format arrow",
-        "flags": "",
+        "flags": "[FILES...]",
     },
     "repeated": {
         "summary": "Finds doubled words",
@@ -6557,7 +6557,7 @@ MODE_DETAILS = {
         "summary": "Scans project for known typos",
         "description": "Like a batch version of the 'search' mode. It searches for every word in a mapping file or provided via --add and reports all matches with filename, line number, and highlighting. It also supports context lines.",
         "example": "python multitool.py scan . --add teh:the --smart -A 1",
-        "flags": "[FILES...] [-s MAPPING] [-anS] [-B/A/C N]",
+        "flags": "[FILES...] [-s MAPPING] [-a KEY:VALUE] [-nS] [-B/A/C N]",
     },
     "verify": {
         "summary": "Checks if typos exist in project",
@@ -6567,9 +6567,9 @@ MODE_DETAILS = {
     },
     "scrub": {
         "summary": "Fixes typos in text files",
-        "description": "Performs in-place replacements of typos in your text files using a mapping file or extra pairs provided via --add. It tries to preserve the surrounding context (punctuation, whitespace) while fixing errors. It automatically handles compound words like 'CamelCase' and 'snake_case' variables. Supports CSV, Arrow, Table, JSON, and YAML mapping formats.",
+        "description": "Performs in-place replacements of typos in your text files using a mapping file or extra pairs provided via --add. It tries to preserve the surrounding context (punctuation, whitespace) while fixing errors. It automatically handles compound words like 'CamelCase' and 'snake_case' variables. Supports CSV, Arrow, Table, JSON, YAML, TOML, and XML mapping formats.",
         "example": "python multitool.py scrub input.txt --add teh:the --diff",
-        "flags": "[FILES...] [-s MAPPING] [-I EXT] [-aSD]",
+        "flags": "[FILES...] [-s MAPPING] [-a KEY:VALUE] [-I EXT] [-SD]",
     },
     "align": {
         "summary": "Aligns typo-correction pairs",
@@ -6581,7 +6581,7 @@ MODE_DETAILS = {
         "summary": "Batch renames files and folders",
         "description": "Renames files or directories based on a typo mapping or extra pairs provided via --add. It preserves the directory structure and can automatically handle CamelCase or snake_case names using --smart-case. It handles nested renames by processing files before their parent directories.",
         "example": "python multitool.py rename src/ --add teh:the --in-place",
-        "flags": "[FILES...] [-s MAPPING] [-a K:V] [-IS] [--dry-run]",
+        "flags": "[FILES...] [-s MAPPING] [-a KEY:VALUE] [-I] [-S] [--dry-run]",
     },
     "diff": {
         "summary": "Shows differences between files",
@@ -6611,7 +6611,7 @@ MODE_DETAILS = {
         "summary": "Replaces text or patterns",
         "description": "Performs text substitution across files. It supports literal string replacement and regular expressions (with backreferences). You can provide the OLD and NEW text as positional arguments or use the --old and --new flags. Supports in-place editing, dry-runs, and unified diffs. Use --smart-case to automatically match the original casing pattern.",
         "example": "python multitool.py replace 'the' 'that' . --in-place --smart-case",
-        "flags": "[OLD] [NEW] [FILES...] [-rSI] [-D] [--dry-run]",
+        "flags": "[OLD] [NEW] [FILES...] [-rS] [-I EXT] [-D] [--ignore-case] [--dry-run]",
     },
 }
 
@@ -7357,7 +7357,7 @@ def _build_parser() -> argparse.ArgumentParser:
     unit_group.add_argument(
         '-p', '--pairs',
         action='store_true',
-        help='Count frequencies of word pairs (for example, typo -> correction) instead of single words.',
+        help='Count frequencies of word pairs (for example, typo -> correction) and classify them instead of single words.',
     )
     unit_group.add_argument(
         '-l', '--lines',


### PR DESCRIPTION
This PR improves the accessibility and accuracy of the `multitool.py` command-line interface by refining its internal help strings.

Key improvements:
- **Accurate Documentation:** Updated `scrub` and `map` mode descriptions to include TOML and XML as supported mapping input formats, aligning the documentation with the actual code implementation.
- **Improved Syntax Clarity:** Standardized the representation of flags that require values (e.g., using `[-s MAPPING]` and `[-a KEY:VALUE]`) across all modes, making it easier for users to understand how to provide arguments.
- **Enhanced Visibility:** Added explicit `[FILES...]` indicators to modes like `links`, `cycles`, and `replace` to clarify that they operate on multiple input files.
- **Functional Description:** Refined the help text for the `count --pairs` flag to explain that it not only counts pairs but also classifies them (e.g., as Keyboard slips or Transpositions).
- **Global Help Consistency:** Standardized information density in the global help table by ensuring value-taking flags are clearly separated from boolean flag groups.

These changes follow the project's documentation style guidelines: using Plain English, active voice, and avoiding jargon to ensure the tools are easy to use for a global audience.

---
*PR created automatically by Jules for task [4996228936558199820](https://jules.google.com/task/4996228936558199820) started by @RainRat*