### PR TITLE
[TEST] Add targeted coverage for multitool extraction modes

### DIFF
--- a/tests/test_multitool_extraction_gaps.py
+++ b/tests/test_multitool_extraction_gaps.py
@@ -1,0 +1,58 @@
+import pytest
+from multitool import headings_mode, toc_mode, links_mode
+
+def test_headings_mode_sorting_and_uniqueness(tmp_path):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("# Beta\n# Alpha\n# Beta")
+    output_file = tmp_path / "output.txt"
+
+    headings_mode(
+        input_files=[str(md_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=True,
+        clean_items=False,
+        quiet=True
+    )
+
+    content = output_file.read_text().splitlines()
+    assert content == ["Alpha", "Beta"]
+
+def test_toc_mode_sorting_and_uniqueness(tmp_path):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("# Beta\n# Alpha")
+    output_file = tmp_path / "output.txt"
+
+    toc_mode(
+        input_files=[str(md_file)],
+        output_file=str(output_file),
+        min_length=1,
+        max_length=100,
+        process_output=True,
+        no_links=True,
+        clean_items=False,
+        quiet=True
+    )
+
+    content = output_file.read_text().splitlines()
+    assert content == ["- Alpha", "- Beta"]
+
+def test_links_mode_pairs_filtering_and_sorting(tmp_path):
+    md_file = tmp_path / "test.md"
+    md_file.write_text("[Beta](url2)\n[Alpha](url1)\n[Beta](url2)\n[X](url3)")
+    output_file = tmp_path / "output.txt"
+
+    links_mode(
+        input_files=[str(md_file)],
+        output_file=str(output_file),
+        min_length=3,
+        max_length=100,
+        process_output=True,
+        pairs=True,
+        clean_items=False,
+        quiet=True
+    )
+
+    content = output_file.read_text().splitlines()
+    assert content == ["Alpha -> url1", "Beta -> url2"]


### PR DESCRIPTION
### [TEST] Add targeted coverage for multitool extraction modes

**Type:** New Coverage

**What:** 
This PR adds a new test suite, `tests/test_multitool_extraction_gaps.py`, which provides targeted coverage for several previously untested branches in `multitool.py`. Specifically, it covers:
*   Sorting and deduplication logic (`process_output=True`) in `headings_mode` and `toc_mode`.
*   The `pairs=True` branch and `process_output` logic in `links_mode`.
*   Length filtering (`min_length`) during link extraction.

**Why:** 
A gap analysis revealed that while the core extraction logic for Markdown headers and links was tested, the post-processing options (sorting, deduplication, and paired output) lacked coverage. These additions ensure that these flags function correctly and maintain the intended behavior for Markdown-specific data.

**Verification:**
*   All new tests passed successfully.
*   The full repository test suite (971 tests) passed with 0 failures.
*   Statement coverage for `multitool.py` increased by covering lines 2303, 2360, 2443, and 2453.

---
*PR created automatically by Jules for task [6245604848690844071](https://jules.google.com/task/6245604848690844071) started by @RainRat*