### PR TITLE
[multitool] Fix GitHub-compatible slug generation to preserve underscores

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -149,14 +149,15 @@ def filter_to_letters(text: str) -> str:
 def _slugify(text: str) -> str:
     """
     Converts text into a GitHub-compatible Markdown anchor slug.
-    (lowercase, alphanumeric, spaces become hyphens, remove other symbols).
+    (lowercase, alphanumeric, spaces become hyphens, remove other symbols,
+    preserves underscores).
     """
     # 1. Lowercase
     slug = text.lower()
-    # 2. Replace spaces/underscores with hyphens
-    slug = re.sub(r'[\s_]+', '-', slug)
-    # 3. Remove everything that isn't alphanumeric or a hyphen
-    slug = re.sub(r'[^a-z0-9-]', '', slug)
+    # 2. Replace spaces with hyphens
+    slug = re.sub(r'\s+', '-', slug)
+    # 3. Remove everything that isn't alphanumeric, a hyphen, or an underscore
+    slug = re.sub(r'[^a-z0-9_-]', '', slug)
     # 4. Collapse consecutive hyphens
     slug = re.sub(r'-+', '-', slug)
     # 5. Remove leading/trailing hyphens

--- a/tests/test_multitool_toc.py
+++ b/tests/test_multitool_toc.py
@@ -6,7 +6,7 @@ def test_slugify():
     assert _slugify("Hello World") == "hello-world"
     assert _slugify("Markdown Header!!") == "markdown-header"
     assert _slugify("Multiple   Spaces") == "multiple-spaces"
-    assert _slugify("Underscore_Test") == "underscore-test"
+    assert _slugify("Underscore_Test") == "underscore_test"
     assert _slugify("Numbers 123") == "numbers-123"
     assert _slugify("-Leading and Trailing-") == "leading-and-trailing"
     assert _slugify("Special !@#$%^&*() Characters") == "special-characters"


### PR DESCRIPTION
**What:** Updated `_slugify` in `multitool.py` to stop replacing underscores with hyphens.
**Why:** GitHub's Markdown anchor generation preserves underscores. This change ensures that Table of Contents links generated by `multitool.py` correctly match the anchors generated by GitHub, improving compatibility and fixing broken links in rendered Markdown files. No breaking changes for other platforms were identified as most Markdown renderers follow a similar pattern or specifically allow underscores.

---
*PR created automatically by Jules for task [7367520775098154925](https://jules.google.com/task/7367520775098154925) started by @RainRat*