### PR TITLE
[UI/UX] Unify rich report output stream in count mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2899,9 +2899,7 @@ def count_mode(
             max_bar = 20
 
             # Colors for output
-            # We determine color availability independently for stdout and stderr to preserve correct behavior when piping.
             use_color_out = _should_enable_color(out_file)
-            use_color_err = _should_enable_color(sys.stderr)
 
             c_out_bold = BOLD if use_color_out else ""
             c_out_blue = BLUE if use_color_out else ""
@@ -2972,11 +2970,7 @@ def count_mode(
 
             # Write the table header for arrow format (suppressed in quiet mode for console)
             if not quiet or output_file != '-':
-                if output_file == '-':
-                    sys.stderr.write(header_block)
-                    sys.stderr.flush()
-                else:
-                    out_file.write(header_block)
+                out_file.write(header_block)
 
             for res_item in final_results:
                 if pairs:
@@ -3026,18 +3020,12 @@ def count_mode(
                     extra_metrics["Total files processed"] = len(input_files)
 
                 # Use color based on destination
-                summary_color = use_color_err if output_file == '-' else use_color_out
                 summary_lines = _format_analysis_summary(
-                    raw_count, filtered_items, item_label, start_time, summary_color,
+                    raw_count, filtered_items, item_label, start_time, use_color_out,
                     extra_metrics=extra_metrics
                 )
                 summary_text = "\n".join(summary_lines) + "\n"
-
-                if output_file == '-':
-                    sys.stderr.write(summary_text)
-                    sys.stderr.flush()
-                else:
-                    out_file.write(summary_text)
+                out_file.write(summary_text)
         else:  # 'line' or fallback
             for res_item in final_results:
                 if pairs:

--- a/tests/test_multitool_final_gaps.py
+++ b/tests/test_multitool_final_gaps.py
@@ -37,32 +37,30 @@ def test_ngrams_clean_empty_word(tmp_path):
     # Should be "hello world" if !!! was skipped
     assert content == "hello world"
 
-def test_count_mode_arrow_stderr_coverage(tmp_path):
-    """Cover lines 1467-1468 and 1489-1492: stderr metadata in count_mode arrow format."""
+def test_count_mode_arrow_stdout_coverage(tmp_path):
+    """Cover metadata in count_mode arrow format when outputting to stdout."""
     input_file = tmp_path / "input.txt"
     input_file.write_text("apple banana apple")
 
     # We need output_file='-', output_format='arrow', and quiet=False
-    # Also need to mock sys.stderr.write to verify it was called
-    with patch("sys.stderr", new=io.StringIO()) as mock_stderr:
-        with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
-            # Force color and TTY for coverage of the branches
-            with patch("os.environ", {"FORCE_COLOR": "1"}):
-                # Ensure headers are considered colorable by setting TTY mock
-                mock_stdout.isatty = lambda: True
-                multitool.count_mode(
-                    input_files=[str(input_file)],
-                    output_file='-',
-                    min_length=1,
-                    max_length=100,
-                    process_output=False,
-                    output_format='arrow',
-                    quiet=False
-                )
+    with patch("sys.stdout", new=io.StringIO()) as mock_stdout:
+        # Force color and TTY for coverage of the branches
+        with patch("os.environ", {"FORCE_COLOR": "1"}):
+            # Ensure headers are considered colorable by setting TTY mock
+            mock_stdout.isatty = lambda: True
+            multitool.count_mode(
+                input_files=[str(input_file)],
+                output_file='-',
+                min_length=1,
+                max_length=100,
+                process_output=False,
+                output_format='arrow',
+                quiet=False
+            )
 
-                stderr_output = mock_stderr.getvalue()
-                assert "ANALYSIS SUMMARY" in stderr_output
-                assert "Word" in stderr_output # Header
+            stdout_output = mock_stdout.getvalue()
+            assert "ANALYSIS SUMMARY" in stdout_output
+            assert "Word" in stdout_output # Header
 
 def test_highlight_mode_limit(tmp_path):
     """Cover line 3091: limit in highlight_mode."""


### PR DESCRIPTION
### [UI/UX] Unify rich report output stream in count mode

**Context:** CLI

**Problem:** 
In `count` mode with `arrow` format, specifying standard output (`-`) as the destination split the report: data went to `stdout`, but the header and analysis summary went to `stderr`. This created a friction point when users redirected `stdout` to a file (e.g., `multitool count . -f arrow > report.txt`), as the resulting file was missing the metadata (header and summary).

**Solution:** 
Unified the output stream for the visual report. Now, the `header_block` and `summary_text` are always written to the primary output stream (`out_file`), ensuring the entire report is captured together regardless of the destination. Color detection was also standardized to use the destination's color capabilities (`use_color_out`). Status logs, encoding detection messages, and progress bars correctly remain on `stderr`.

**Changes:**
- **multitool.py**: 
    - Unified output logic for `header_block` and `summary_text` to always use `out_file`.
    - Simplified color detection by removing `use_color_err` and consistently using `use_color_out` for the visual report.
- **tests/test_multitool_final_gaps.py**: 
    - Updated and renamed `test_count_mode_arrow_stdout_coverage` to reflect and verify the unified output stream behavior.

---
*PR created automatically by Jules for task [2381992568388740849](https://jules.google.com/task/2381992568388740849) started by @RainRat*