### PR TITLE
[TEST] Add coverage for comments_mode multi-line splitting and filtering

### DIFF
--- a/tests/test_multitool_comments.py
+++ b/tests/test_multitool_comments.py
@@ -96,3 +96,28 @@ This is a comment // but this is one
     assert "example.com/some/path" not in lines
     assert "but this is one" in lines
 
+def test_comments_mode_coverage_gap(tmp_path):
+    """Test comments_mode with multi-line splitting, length filtering, and sorting/deduplication."""
+    f = tmp_path / "gap.py"
+    f.write_text("""
+/*
+   Line One
+   Line Two
+*/
+# short
+# unique
+# unique
+""", encoding='utf-8')
+    out = tmp_path / "out.txt"
+    # min_length=6 will filter out "short"
+    comments_mode(
+        input_files=[str(f)],
+        output_file=str(out),
+        min_length=6,
+        max_length=1000,
+        process_output=True,
+        clean_items=True
+    )
+    content = out.read_text(encoding='utf-8')
+    lines = content.splitlines()
+    assert lines == ["lineone", "linetwo", "unique"]


### PR DESCRIPTION
**PR Title:** [TEST] Add coverage for comments_mode multi-line splitting and filtering 
**Description:** 
* **Type:** New Coverage 
* **What:** Added `test_comments_mode_coverage_gap` to `tests/test_multitool_comments.py`. 
* **Why:** This test covers previously untested branches in `multitool.py`'s `comments_mode`, including multi-line comment splitting when cleaning is enabled, length filtering of individual comment lines, and final output sorting/deduplication.

---
*PR created automatically by Jules for task [15920856539776900900](https://jules.google.com/task/15920856539776900900) started by @RainRat*