### PR TITLE
[FEAT] Add 'paths' mode for path component extraction in multitool

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The **diff2typo Suite** is a set of tools to help you find and fix typos in your
 | :--- | :--- | :--- |
 | **diff2typo** | Finds typos you fixed in your Git history. | [Read Docs](docs/diff2typo.md) |
 | **gentypos** | Creates lists of likely typos based on common typing errors. | [Read Docs](docs/gentypos.md) |
-| **multitool** | A multipurpose tool for cleaning, getting, and analyzing text files. | [Read Docs](docs/multitool.md) |
+| **multitool** | A multipurpose tool for cleaning, getting, and analyzing text, files, and paths. | [Read Docs](docs/multitool.md) |
 | **cmdrunner** | Runs commands across many folders at once. | [Read Docs](docs/cmdrunner.md) |
 | **typostats** | Analyzes your typos to find common finger-slips. | [Read Docs](docs/typostats.md) |
 

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -1,0 +1,43 @@
+# paths mode
+
+Extract components from file and directory paths.
+
+## Summary
+The `paths` mode allows you to list and analyze the structure of your project by extracting specific parts of file and folder paths. It supports getting the filename (basename), the directory path (dirname), or the file extension. It also integrates with the suite's smart splitting functionality to identify words within filenames.
+
+## Usage
+```bash
+python multitool.py paths [FILES...] [OPTIONS]
+```
+
+## Options
+| Flag | Description |
+| :--- | :--- |
+| `--basename` | Extract the final component of the path (the filename). |
+| `--dirname` | Extract the directory part of the path. |
+| `--extension` | Extract the file extension. |
+| `-S`, `--smart` | Split path components by symbols and capital letters. |
+| `-R`, `--raw` | Keep original text (preserve casing and punctuation in paths). |
+| `-P`, `--process-output` | Sort the results and remove duplicates. |
+
+## Examples
+
+### List all filenames in a directory
+```bash
+python multitool.py paths src/ --basename --raw
+```
+
+### Extract all unique file extensions
+```bash
+python multitool.py paths . --extension --process-output
+```
+
+### Find all words used in filenames (Smart Splitting)
+```bash
+python multitool.py paths src/ --basename --smart --process-output
+```
+
+### Get unique folder names in a project
+```bash
+python multitool.py paths . --dirname --basename --process-output --raw
+```

--- a/multitool.py
+++ b/multitool.py
@@ -4220,6 +4220,82 @@ def line_mode(
     )
 
 
+def _extract_path_items(
+    path: str,
+    basename: bool = False,
+    dirname: bool = False,
+    extension: bool = False,
+    smart: bool = False,
+    quiet: bool = False,
+) -> Iterable[str]:
+    """Yield components of the provided path."""
+    if path == '-':
+        return
+
+    # Determine which component(s) to yield
+    components = []
+    if basename:
+        components.append(os.path.basename(path))
+    if dirname:
+        components.append(os.path.dirname(path))
+    if extension:
+        components.append(os.path.splitext(path)[1])
+
+    # Default to full path if no flags specified
+    if not (basename or dirname or extension):
+        components.append(path)
+
+    for component in components:
+        if smart:
+            yield from _smart_split(component)
+        else:
+            yield component
+
+
+def paths_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    basename: bool = False,
+    dirname: bool = False,
+    extension: bool = False,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+    smart: bool = False,
+) -> None:
+    """Extracts components from file and directory paths."""
+    start_time = time.perf_counter()
+
+    raw_items = []
+    for input_file in input_files:
+        raw_items.extend(
+            _extract_path_items(
+                input_file,
+                basename=basename,
+                dirname=dirname,
+                extension=extension,
+                smart=smart,
+                quiet=quiet,
+            )
+        )
+
+    filtered_items = clean_and_filter(raw_items, min_length, max_length, clean=clean_items)
+
+    if process_output:
+        filtered_items = sorted(set(filtered_items))
+
+    write_output(filtered_items, output_file, output_format, quiet, limit=limit)
+
+    print_processing_stats(len(raw_items), filtered_items, item_label="path", start_time=start_time)
+    logging.info(
+        f"[Paths Mode] Successfully extracted {len(filtered_items)} path components. Output written to '{output_file}'."
+    )
+
+
 def words_mode(
     input_files: Sequence[str],
     output_file: str,
@@ -6569,6 +6645,12 @@ MODE_DETAILS = {
         "example": "python multitool.py json list.json -o items.txt",
         "flags": "[FILES...] [-k KEY]",
     },
+    "paths": {
+        "summary": "Extracts path components",
+        "description": "Finds and extracts specific parts of file and directory paths. You can get just the filename (basename), the folder path (dirname), or the file extension. It also supports smart splitting to find words within filenames.",
+        "example": "python multitool.py paths src/ --basename --smart --output wordlist.txt",
+        "flags": "[FILES...] [--basename] [--dirname] [--extension] [-S]",
+    },
     "yaml": {
         "summary": "Extracts YAML values by key",
         "description": "Finds values for a specific key in a YAML file. Use dots for nested keys (like 'config.items'). If no key is provided, it gets items from the top level. It automatically handles lists.",
@@ -6851,7 +6933,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "frontmatter", "md-table", "headings", "toc", "links", "codeblocks", "comments", "json", "yaml", "toml", "xml", "flatten", "line", "words", "ngrams", "regex"],
+        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "frontmatter", "md-table", "headings", "toc", "links", "codeblocks", "comments", "json", "yaml", "toml", "xml", "paths", "flatten", "line", "words", "ngrams", "regex"],
         "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "convert", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
@@ -7505,6 +7587,36 @@ def _build_parser() -> argparse.ArgumentParser:
         help="The tag name or XPath expression to match (for example './/item/name').",
     )
     _add_common_mode_arguments(xml_parser)
+
+    paths_parser = subparsers.add_parser(
+        'paths',
+        help=MODE_DETAILS['paths']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['paths']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['paths']['example']}{RESET}",
+    )
+    paths_options = paths_parser.add_argument_group(f"{BLUE}PATH EXTRACTION OPTIONS{RESET}")
+    paths_options.add_argument(
+        '--basename',
+        action='store_true',
+        help="Extract the final component of the path (the filename).",
+    )
+    paths_options.add_argument(
+        '--dirname',
+        action='store_true',
+        help="Extract the directory part of the path.",
+    )
+    paths_options.add_argument(
+        '--extension',
+        action='store_true',
+        help="Extract the file extension.",
+    )
+    paths_options.add_argument(
+        '-S', '--smart',
+        action='store_true',
+        help='Split path components by symbols and capital letters.',
+    )
+    _add_common_mode_arguments(paths_parser)
 
     flatten_parser = subparsers.add_parser(
         'flatten',
@@ -8738,24 +8850,24 @@ def main() -> None:
                 # to ensure contents are processed before their parent directories.
                 # Skip common noise folders for performance and to reduce clutter.
                 exclude = {'.git', '__pycache__', 'node_modules', '.venv', 'venv', '.pytest_cache', '.ruff_cache', '.vscode', '.idea', 'dist', 'build'}
-                for root, dirs, files in os.walk(match, topdown=(args.mode != 'rename')):
+                for root, dirs, files in os.walk(match, topdown=(args.mode not in ('rename', 'paths'))):
                     # If we encounter an excluded folder in the path, skip it and its contents
                     if any(part in exclude for part in root.split(os.sep)):
                         dirs[:] = []  # Don't recurse further if topdown=True
                         continue
-                    
-                    if args.mode != 'rename':
+
+                    if args.mode not in ('rename', 'paths'):
                         # Prune directories in-place for efficiency when topdown=True
                         dirs[:] = [d for d in dirs if d not in exclude]
 
-                    if args.mode == 'rename':
+                    if args.mode in ('rename', 'paths'):
                         for d in sorted(dirs):
                             if d not in exclude:
                                 expanded_paths.append(os.path.join(root, d))
                     for f in sorted(files):
                         expanded_paths.append(os.path.join(root, f))
 
-                if args.mode == 'rename':
+                if args.mode in ('rename', 'paths'):
                     expanded_paths.append(match)
             else:
                 expanded_paths.append(match)
@@ -9083,6 +9195,17 @@ def main() -> None:
                 **common_kwargs,
                 'key': getattr(args, 'key', ''),
                 'output_format': output_format,
+            },
+        ),
+        'paths': (
+            paths_mode,
+            {
+                **common_kwargs,
+                'basename': getattr(args, 'basename', False),
+                'dirname': getattr(args, 'dirname', False),
+                'extension': getattr(args, 'extension', False),
+                'output_format': output_format,
+                'smart': getattr(args, 'smart', False),
             },
         ),
         'flatten': (

--- a/tests/test_multitool_paths.py
+++ b/tests/test_multitool_paths.py
@@ -1,0 +1,160 @@
+import pytest
+import os
+from multitool import paths_mode
+
+def test_paths_mode_basic(tmp_path):
+    output_file = tmp_path / "output.txt"
+    input_files = ["src/main.py", "docs/readme.md"]
+
+    paths_mode(
+        input_files=input_files,
+        output_file=str(output_file),
+        min_length=1,
+        max_length=1000,
+        process_output=False,
+        output_format='line',
+        quiet=True,
+        clean_items=False
+    )
+
+    content = output_file.read_text().splitlines()
+    assert "src/main.py" in content
+    assert "docs/readme.md" in content
+
+def test_paths_mode_components(tmp_path):
+    output_file = tmp_path / "output.txt"
+    input_files = ["src/module/sub.py"]
+
+    # Test basename
+    paths_mode(
+        input_files=input_files,
+        output_file=str(output_file),
+        min_length=1,
+        max_length=1000,
+        process_output=False,
+        basename=True,
+        quiet=True,
+        clean_items=False
+    )
+    assert output_file.read_text().strip() == "sub.py"
+
+    # Test dirname
+    paths_mode(
+        input_files=input_files,
+        output_file=str(output_file),
+        min_length=1,
+        max_length=1000,
+        process_output=False,
+        dirname=True,
+        quiet=True,
+        clean_items=False
+    )
+    assert output_file.read_text().strip() == "src/module"
+
+    # Test extension
+    paths_mode(
+        input_files=input_files,
+        output_file=str(output_file),
+        min_length=1,
+        max_length=1000,
+        process_output=False,
+        extension=True,
+        quiet=True,
+        clean_items=False
+    )
+    assert output_file.read_text().strip() == ".py"
+
+def test_paths_mode_smart_split(tmp_path):
+    output_file = tmp_path / "output.txt"
+    input_files = ["MyCamelCaseFile.txt"]
+
+    paths_mode(
+        input_files=input_files,
+        output_file=str(output_file),
+        min_length=1,
+        max_length=1000,
+        process_output=True,
+        basename=True,
+        smart=True,
+        quiet=True,
+        clean_items=False
+    )
+
+    content = sorted(output_file.read_text().splitlines())
+    assert "My" in content
+    assert "Camel" in content
+    assert "Case" in content
+    assert "File" in content
+
+def test_paths_mode_filtering(tmp_path):
+    output_file = tmp_path / "output.txt"
+    input_files = ["a.py", "abcde.py"]
+
+    # a.py length is 4
+    # abcde.py length is 8
+
+    paths_mode(
+        input_files=input_files,
+        output_file=str(output_file),
+        min_length=5,
+        max_length=1000,
+        process_output=False,
+        basename=True,
+        quiet=True,
+        clean_items=False
+    )
+
+    content = output_file.read_text().splitlines()
+    assert "abcde.py" in content
+    assert "a.py" not in content
+
+def test_paths_mode_cleaning(tmp_path):
+    output_file = tmp_path / "output.txt"
+    input_files = ["My-File_Name.txt"]
+
+    paths_mode(
+        input_files=input_files,
+        output_file=str(output_file),
+        min_length=1,
+        max_length=1000,
+        process_output=False,
+        basename=True,
+        quiet=True,
+        clean_items=True
+    )
+
+    # filter_to_letters removes everything except a-z and lowercases
+    # "My-File_Name.txt" -> "myfilenametxt"
+    assert output_file.read_text().strip() == "myfilenametxt"
+
+def test_paths_mode_directory_inclusion(tmp_path):
+    # Create a structure:
+    # tmp_path/
+    #   dir1/
+    #     file1.txt
+    #     dir2/
+    #       file2.txt
+
+    dir1 = tmp_path / "dir1"
+    dir1.mkdir()
+    (dir1 / "file1.txt").touch()
+    dir2 = dir1 / "dir2"
+    dir2.mkdir()
+    (dir2 / "file2.txt").touch()
+
+    import subprocess
+    import sys
+
+    # Run via subprocess to test main() and directory expansion
+    result = subprocess.run(
+        [sys.executable, "multitool.py", "paths", str(dir1), "--basename", "--raw", "-P"],
+        capture_output=True,
+        text=True
+    )
+
+    output = result.stdout.splitlines()
+    # Expecting: dir1, dir2, file1.txt, file2.txt (sorted due to -P)
+    assert "dir1" in output
+    assert "dir2" in output
+    assert "file1.txt" in output
+    assert "file2.txt" in output


### PR DESCRIPTION
Introduced a new `paths` mode to `multitool.py` that enables users to extract and analyze components of file and directory paths. Key capabilities include extracting `basename`, `dirname`, or file `extension`, and support for "smart splitting" (`-S/--smart`) to identify individual words within filenames. This mode is fully integrated with global processing flags and recursive directory expansion. This addition provides a dedicated way to analyze project structure (file/folder names) which often contain valuable terminology or potential typos, rounding out the suite's extraction capabilities.

---
*PR created automatically by Jules for task [4245253934020010625](https://jules.google.com/task/4245253934020010625) started by @RainRat*