### PR TITLE
Refactor Multitool Modes and Fix Comment Stats

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -1266,6 +1266,7 @@ def _process_items(
     quiet: bool = False,
     clean_items: bool = True,
     limit: int | None = None,
+    item_label: str = "item",
 ) -> None:
     """Generic processing for modes that get raw string items from one or more files."""
     start_time = time.perf_counter()
@@ -1284,7 +1285,7 @@ def _process_items(
 
     write_output(filtered_items, output_file, output_format, quiet, limit=limit)
 
-    print_processing_stats(len(raw_items), filtered_items, start_time=start_time)
+    print_processing_stats(len(raw_items), filtered_items, item_label=item_label, start_time=start_time)
     logging.info(
         f"[{mode_name} Mode] {success_msg} Output written to '{output_file}'."
     )
@@ -2454,32 +2455,30 @@ def comments_mode(
     limit: int | None = None,
 ) -> None:
     """Extracts comments from various file types."""
-    start_time = time.perf_counter()
-    results = []
-    total_found = 0
-
-    for input_file in input_files:
+    def extractor(input_file: str, quiet: bool = False) -> Iterable[str]:
         for comment in _extract_comment_items(input_file, quiet=quiet):
-            total_found += 1
-
             # For multi-line comments, we split into lines if cleaning is requested
             # to allow filtering specific words/lines within the comment.
             if clean_items:
-                sub_items = comment.splitlines()
+                yield from comment.splitlines()
             else:
-                sub_items = [comment]
+                yield comment
 
-            for item in sub_items:
-                text_to_save = filter_to_letters(item) if clean_items else item
-                if not (min_length <= len(text_to_save) <= max_length):
-                    continue
-                results.append(text_to_save)
-
-    if process_output:
-        results = sorted(set(results))
-
-    write_output(results, output_file, output_format, quiet, limit=limit)
-    print_processing_stats(total_found, results, item_label="comment", start_time=start_time)
+    _process_items(
+        extractor,
+        input_files,
+        output_file,
+        min_length,
+        max_length,
+        process_output,
+        'Comments',
+        'Comments extracted successfully.',
+        output_format,
+        quiet,
+        clean_items=clean_items,
+        limit=limit,
+        item_label="comment",
+    )
 
 
 def links_mode(
@@ -4257,31 +4256,30 @@ def paths_mode(
     smart: bool = False,
 ) -> None:
     """Extracts components from file and directory paths."""
-    start_time = time.perf_counter()
-
-    raw_items = []
-    for input_file in input_files:
-        raw_items.extend(
-            _extract_path_items(
-                input_file,
-                basename=basename,
-                dirname=dirname,
-                extension=extension,
-                smart=smart,
-                quiet=quiet,
-            )
+    def extractor(path: str, quiet: bool = False) -> Iterable[str]:
+        return _extract_path_items(
+            path,
+            basename=basename,
+            dirname=dirname,
+            extension=extension,
+            smart=smart,
+            quiet=quiet,
         )
 
-    filtered_items = clean_and_filter(raw_items, min_length, max_length, clean=clean_items)
-
-    if process_output:
-        filtered_items = sorted(set(filtered_items))
-
-    write_output(filtered_items, output_file, output_format, quiet, limit=limit)
-
-    print_processing_stats(len(raw_items), filtered_items, item_label="path", start_time=start_time)
-    logging.info(
-        f"[Paths Mode] Successfully extracted {len(filtered_items)} path components. Output written to '{output_file}'."
+    _process_items(
+        extractor,
+        input_files,
+        output_file,
+        min_length,
+        max_length,
+        process_output,
+        'Paths',
+        'Successfully extracted path components.',
+        output_format,
+        quiet,
+        clean_items=clean_items,
+        limit=limit,
+        item_label="path",
     )
 
 

--- a/tests/test_comments_stats_fixed.py
+++ b/tests/test_comments_stats_fixed.py
@@ -1,0 +1,50 @@
+import logging
+import pytest
+import re
+from multitool import comments_mode
+
+def test_comments_mode_retention_stats(tmp_path, caplog):
+    """Verify that comments_mode correctly counts lines within multi-line comments for its stats."""
+    f = tmp_path / "test.py"
+    f.write_text('"""\nLine 1\nLine 2\nLine 3\n"""\n', encoding='utf-8')
+    out = tmp_path / "out.txt"
+
+    with caplog.at_level(logging.INFO):
+        comments_mode(
+            input_files=[str(f)],
+            output_file=str(out),
+            min_length=1,
+            max_length=1000,
+            process_output=False,
+            clean_items=True
+        )
+
+    # Check the analysis summary in the logs
+    # We expect 3 items analyzed (the 3 lines inside the triple quotes)
+    assert "Total comments analyzed:            3" in caplog.text
+    assert "Total comments after filtering:     3" in caplog.text
+    assert "Retention rate:                     100.0%" in caplog.text
+
+def test_comments_mode_retention_stats_with_filtering(tmp_path, caplog):
+    """Verify stats when some lines in a multi-line comment are filtered out."""
+    f = tmp_path / "test.py"
+    # 'a' will be filtered by min_length=2
+    f.write_text('"""\na\nlong line\n"""\n', encoding='utf-8')
+    out = tmp_path / "out.txt"
+
+    with caplog.at_level(logging.INFO):
+        comments_mode(
+            input_files=[str(f)],
+            output_file=str(out),
+            min_length=2,
+            max_length=1000,
+            process_output=False,
+            clean_items=True
+        )
+
+    # We expect 2 items analyzed ('a' and 'long line')
+    # and 1 item after filtering ('long line' -> 'longline')
+    assert "Total comments analyzed:            2" in caplog.text
+    assert "Total comments after filtering:     1" in caplog.text
+    # Use re.search to handle multiple spaces
+    assert re.search(r"Retention rate:\s+50\.0%", caplog.text)


### PR DESCRIPTION
This PR refactors `paths_mode` and `comments_mode` in `multitool.py` to use the standardized `_process_items` helper, significantly reducing boilerplate code for filtering, cleaning, and reporting. 

Additionally, it resolves a bug in `comments_mode` statistics where 'Total comments analyzed' was undercounted because multi-line comments were treated as single entries during the initial extraction pass but split during processing. The fix ensures that the raw count matches the number of lines extracted from comments, leading to accurate retention rate calculations.

Verification:
- Full test suite passed (985 tests).
- New tests added in `tests/test_comments_stats_fixed.py` specifically targeting the statistics fix.
- Manual verification of `paths_mode` and `comments_mode` outputs confirmed identical behavior with improved internal consistency.

---
*PR created automatically by Jules for task [11397711888245951877](https://jules.google.com/task/11397711888245951877) started by @RainRat*