### PR TITLE
Fix retention rate calculation in comments mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2460,8 +2460,6 @@ def comments_mode(
 
     for input_file in input_files:
         for comment in _extract_comment_items(input_file, quiet=quiet):
-            total_found += 1
-
             # For multi-line comments, we split into lines if cleaning is requested
             # to allow filtering specific words/lines within the comment.
             if clean_items:
@@ -2470,6 +2468,7 @@ def comments_mode(
                 sub_items = [comment]
 
             for item in sub_items:
+                total_found += 1
                 text_to_save = filter_to_letters(item) if clean_items else item
                 if not (min_length <= len(text_to_save) <= max_length):
                     continue


### PR DESCRIPTION
* **What:** Updated `comments_mode` in `multitool.py` to increment the `total_found` counter for each line of a multi-line comment when `clean_items` is enabled.
* **Why:** Previously, the counter was only incremented once per comment block, but since multi-line comments are split into individual lines for filtering, the "Total comments analyzed" was undercounted. This resulted in retention rates incorrectly exceeding 100%. This change ensures accurate analysis statistics. No breaking changes were introduced.

---
*PR created automatically by Jules for task [1443842894734048842](https://jules.google.com/task/1443842894734048842) started by @RainRat*