### PR TITLE
[DOCS] Clarify CSV column selection and 0-based indexing

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -62,8 +62,8 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py between input.txt --start '{{' --end '}}'`
 
 - **`csv`**
-  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) to pick specific columns (using 0-based indexing). Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
-  - **Example:** `python multitool.py csv data.csv --column 1  # Get the second column`
+  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column (index 0). You can also use `--column` (or `-c`) to pick one or more specific columns by their 0-based index. Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
+  - **Example:** `python multitool.py csv data.csv --column 0 2  # Get the first and third columns`
 
 - **`markdown`**
   - Extracts Markdown list items (lines starting with `-`, `*`, or `+`). You can split items by `:` or `->` to get one side of a pair (use the `--right` flag for the second part).

--- a/multitool.py
+++ b/multitool.py
@@ -6594,8 +6594,8 @@ MODE_DETAILS = {
     },
     "csv": {
         "summary": "Extracts columns from CSV",
-        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, --column to pick specific 0-based numbers, or --delimiter to use a custom separator.",
-        "example": "python multitool.py csv typos.csv --column 1 --delimiter ';'  # Get the second column",
+        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column (index 0). You can also use --column to pick one or more specific 0-based column numbers, or --delimiter to use a custom separator.",
+        "example": "python multitool.py csv data.csv --column 0 2 --delimiter ';'  # Get first and third columns",
         "flags": "[FILES...] [-d DELIM] [-c N] [--first-column]",
     },
     "markdown": {


### PR DESCRIPTION
This PR improves the documentation for the `csv` mode in the `multitool` utility.

### Changes:
- **`docs/multitool.md`**: Updated the `csv` mode description to clarify that multiple columns can be selected and that indexing starts at 0.
- **`multitool.py`**: Updated the internal `MODE_DETAILS` for `csv` mode to provide consistent information in the CLI `--help` output.

### Why:
Users might find it unclear how to select multiple columns or whether the indexing starts at 0 or 1. These changes provide explicit guidance and practical examples to resolve this ambiguity.

---
*PR created automatically by Jules for task [11256067792979496487](https://jules.google.com/task/11256067792979496487) started by @RainRat*