### PR TITLE
Remove redundant line stripping in diff reporting logic

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -5449,7 +5449,6 @@ def replace_mode(
                 pbar.set_postfix(file=os.path.basename(input_file), refresh=True)
 
             file_lines = _read_file_lines_robust(input_file)
-            original_lines = [line.rstrip('\n') for line in file_lines]
             modified_lines = []
             file_replacements = 0
 
@@ -5481,7 +5480,7 @@ def replace_mode(
             total_replacements += file_replacements
 
             if diff and file_replacements > 0:
-                _write_diff_report(input_file, original_lines, [l.rstrip('\n') for l in modified_lines], diff_out)
+                _write_diff_report(input_file, file_lines, modified_lines, diff_out)
 
             if in_place is not None and input_file != '-':
                 _write_file_in_place(
@@ -5682,8 +5681,6 @@ def standardize_mode(
                 logging.warning("In-place modification requested for standard input; ignoring.")
 
             file_lines = _read_file_lines_robust(input_file)
-            # Store original lines without newlines for diffing
-            original_lines = [line.rstrip('\n') for line in file_lines]
             modified_lines = []
             file_replacements = 0
 
@@ -5697,7 +5694,7 @@ def standardize_mode(
             total_replacements += file_replacements
 
             if diff and file_replacements > 0:
-                _write_diff_report(input_file, original_lines, modified_lines, diff_out)
+                _write_diff_report(input_file, file_lines, modified_lines, diff_out)
 
             if in_place is not None and input_file != '-':
                 _write_file_in_place(
@@ -5780,8 +5777,6 @@ def scrub_mode(
                 logging.warning("In-place modification requested for standard input; ignoring.")
 
             file_lines = _read_file_lines_robust(input_file)
-            # Store original lines without newlines for diffing
-            original_lines = [line.rstrip('\n') for line in file_lines]
             modified_lines = []
             file_replacements = 0
 
@@ -5795,7 +5790,7 @@ def scrub_mode(
             total_replacements += file_replacements
 
             if diff and file_replacements > 0:
-                _write_diff_report(input_file, original_lines, modified_lines, diff_out)
+                _write_diff_report(input_file, file_lines, modified_lines, diff_out)
 
             if in_place is not None and input_file != '-':
                 _write_file_in_place(


### PR DESCRIPTION
This PR removes redundant newline stripping logic in `multitool.py`.

* **What:** Deleted the `original_lines` list comprehensions in `replace_mode`, `standardize_mode`, and `scrub_mode` that were manually stripping `\n`. Updated the calls to `_write_diff_report` to pass the raw `file_lines` and `modified_lines` directly.
* **Why:** The internal helper `_write_diff_report` already performs `.rstrip('\n')` on all input lines to ensure compatibility with `difflib`. Removing the manual stripping in the calling modes eliminates unnecessary memory allocations and CPU cycles, especially for large files, while keeping the external behavior (the diff report format) identical.

All 983 tests passed, confirming no functional regressions.

---
*PR created automatically by Jules for task [13882262972806073325](https://jules.google.com/task/13882262972806073325) started by @RainRat*