### PR TITLE
[UI/UX] Add shorthand -c for --ignore-case in replace mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -6914,7 +6914,7 @@ MODE_DETAILS = {
         "summary": "Replaces text or patterns",
         "description": "Performs text substitution across files. It supports literal string replacement and regular expressions (with backreferences). You can provide the OLD and NEW text as positional arguments or use the --old and --new flags. Supports in-place editing, dry-runs, and unified diffs. Use --smart-case to automatically match the original casing pattern.",
         "example": "python multitool.py replace 'the' 'that' . --in-place --smart-case",
-        "flags": "[OLD] [NEW] [FILES...] [-rS] [-I EXT] [-D] [--ignore-case] [--dry-run]",
+        "flags": "[OLD] [NEW] [FILES...] [-rcS] [-I EXT] [-D] [--dry-run]",
     },
 }
 
@@ -8700,7 +8700,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Treat '--old' as a regular expression.",
     )
     replace_options.add_argument(
-        '--ignore-case',
+        '-c', '--ignore-case',
         action='store_true',
         help="Perform case-insensitive replacement.",
     )


### PR DESCRIPTION
**PR Title:** [UI/UX] Add shorthand -c for --ignore-case in replace mode

**Description:**
* **Context:** CLI
* **Problem:** Users must type the full `--ignore-case` flag to perform case-insensitive replacements in `replace` mode. The standard `-i` shorthand is unavailable as it's used for the global `--input` flag, creating friction for frequent text processing tasks.
* **Solution:** Introduced the `-c` shorthand (mnemonic for **C**ase) for the `--ignore-case` option in `replace` mode. This aligns with other mode-specific shorthands in the suite and improves efficiency for power users. The change includes updates to the CLI parser and the internal help documentation.

**Changes:**
- Modified `multitool.py` to add `'-c'` as a shorthand for `--ignore-case` in the `replace` subparser.
- Updated the `MODE_DETAILS` dictionary for the `replace` mode to include the new flag in the usage summary and ensure it appears in the `help` output.
- Verified that the new flag correctly triggers case-insensitive replacements and is properly documented in `python3 multitool.py help replace`.

---
*PR created automatically by Jules for task [13777652535223119485](https://jules.google.com/task/13777652535223119485) started by @RainRat*