### PR TITLE
[FEAT] FileInfo mode for multitool.py

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -303,6 +303,12 @@ Use these modes to analyze your data.
   - **Note:** This mode has built-in sorting.
   - **Example:** `python multitool.py count all_typos.txt --min-count 5 -f arrow --smart`
 
+- **`fileinfo`**
+  - Gathers and displays metadata (size, lines, words, encoding) for each input file.
+  - **Supported Formats:** `arrow` (visual table), `json`, `csv`, `yaml`, `toml`, and `xml`.
+  - **Example:** `python multitool.py fileinfo *.txt -f arrow`
+
+
 - **`cycles`**
   - Finds loops in typo-correction pairs (for example, "A" maps to "B" and "B" maps back to "A").
   - **Example:** `python multitool.py cycles typos.csv --output-format arrow`

--- a/multitool.py
+++ b/multitool.py
@@ -3123,6 +3123,108 @@ def classify_mode(
     )
 
 
+def fileinfo_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    output_format: str = "arrow",
+    quiet: bool = False,
+    **kwargs
+) -> None:
+    """
+    Gathers and displays metadata (size, lines, words, encoding) for each input file.
+    """
+    start_time = time.perf_counter()
+    results = []
+
+    for input_file in input_files:
+        if input_file == "-":
+            continue
+
+        if not os.path.isfile(input_file):
+            continue
+
+        try:
+            size = os.path.getsize(input_file)
+            lines = _read_file_lines_robust(input_file)
+            line_count = len(lines)
+            word_count = sum(len(line.split()) for line in lines)
+            encoding = detect_encoding(input_file) or "unknown"
+
+            results.append({
+                "file": input_file,
+                "size": size,
+                "lines": line_count,
+                "words": word_count,
+                "encoding": encoding,
+            })
+        except Exception as e:
+            if not quiet:
+                logging.error(f"Failed to get info for '{input_file}': {e}")
+
+    if not results:
+        logging.warning("No file information gathered.")
+        return
+
+    # Structured output formats
+    if output_format in ("json", "yaml", "toml", "xml"):
+        _write_structured_data(results, output_file, output_format, root_tag="fileinfo")
+    elif output_format == "csv":
+        with smart_open_output(output_file, newline="") as out_file:
+            writer = csv.DictWriter(out_file, fieldnames=["file", "size", "lines", "words", "encoding"])
+            writer.writeheader()
+            writer.writerows(results)
+    else:
+        # Visual Table (Arrow/Line fallback)
+        use_color = _should_enable_color(sys.stdout) if output_file == "-" else False
+        c_bold = BOLD if use_color else ""
+        c_blue = BLUE if use_color else ""
+        c_green = GREEN if use_color else ""
+        c_yellow = YELLOW if use_color else ""
+        c_reset = RESET if use_color else ""
+
+        padding = "  "
+        sep = f"{c_bold}{c_blue}│{c_reset}"
+
+        # Determine column widths
+        max_file = max((len(r["file"]) for r in results), default=10)
+        max_file = max(max_file, len("File"))
+        max_size = max((len(str(r["size"])) for r in results), default=4)
+        max_size = max(max_size, len("Size"))
+        max_lines = max((len(str(r["lines"])) for r in results), default=5)
+        max_lines = max(max_lines, len("Lines"))
+        max_words = max((len(str(r["words"])) for r in results), default=5)
+        max_words = max(max_words, len("Words"))
+        max_enc = max((len(r["encoding"]) for r in results), default=8)
+        max_enc = max(max_enc, len("Encoding"))
+
+        header = (
+            f"{padding}{c_bold}{c_blue}{'File':<{max_file}}{c_reset} {sep} "
+            f"{c_bold}{c_blue}{'Size':>{max_size}}{c_reset} {sep} "
+            f"{c_bold}{c_blue}{'Lines':>{max_lines}}{c_reset} {sep} "
+            f"{c_bold}{c_blue}{'Words':>{max_words}}{c_reset} {sep} "
+            f"{c_bold}{c_blue}{'Encoding':<{max_enc}}{c_reset}"
+        )
+        visible_len = max_file + max_size + max_lines + max_words + max_enc + 14
+        divider = f"{padding}{c_bold}{c_blue}{'─' * visible_len}{c_reset}"
+
+        with smart_open_output(output_file) as out:
+            out.write(f"\n{header}\n")
+            out.write(f"{divider}\n")
+            for r in results:
+                row = (
+                    f"{padding}{c_green}{r['file']:<{max_file}}{c_reset} {sep} "
+                    f"{c_yellow}{r['size']:>{max_size}}{c_reset} {sep} "
+                    f"{c_yellow}{r['lines']:>{max_lines}}{c_reset} {sep} "
+                    f"{c_yellow}{r['words']:>{max_words}}{c_reset} {sep} "
+                    f"{c_green}{r['encoding']:<{max_enc}}{c_reset}"
+                )
+                out.write(f"{row}\n")
+            out.write("\n")
+
+    duration = time.perf_counter() - start_time
+    logging.info(f"[FileInfo Mode] Processed {len(results)} file(s) in {duration:.3f}s.")
+
+
 def stats_mode(
     input_files: Sequence[str],
     output_file: str,
@@ -6808,6 +6910,12 @@ MODE_DETAILS = {
         "example": "python multitool.py fuzzymatch typos.txt words.csv --keyboard --show-dist",
         "flags": "[FILES...] [FILE2] [--max-dist N] [-kt] [--show-dist]",
     },
+    "fileinfo": {
+        "summary": "Shows metadata for each file",
+        "description": "Gathers and displays metadata (size, lines, words, encoding) for each input file. Supports structured output like JSON, CSV, and YAML, or a visual table format.",
+        "example": "python multitool.py fileinfo *.txt -f arrow",
+        "flags": "[FILES...]",
+    },
     "stats": {
         "summary": "Shows statistics for a list",
         "description": "Provides a detailed overview of your dataset. It reports counts, unique items, statistics, and (optionally) paired data stats like conflicts, overlaps, and the number of changes between words.",
@@ -6924,7 +7032,7 @@ def get_mode_summary_text() -> str:
     categories = {
         "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "frontmatter", "md-table", "headings", "toc", "links", "codeblocks", "comments", "json", "yaml", "toml", "xml", "paths", "flatten", "line", "words", "ngrams", "regex"],
         "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "convert", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
-        "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
+        "CHECK & ANALYZE": ["count", "fileinfo", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "search", "scan", "verify"],
     }
 
     use_color = _should_enable_color(sys.stdout)
@@ -7922,6 +8030,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Include the number of character changes in the output.",
     )
     _add_common_mode_arguments(fuzzymatch_parser)
+
+    fileinfo_parser = subparsers.add_parser(
+        'fileinfo',
+        help=MODE_DETAILS['fileinfo']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['fileinfo']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['fileinfo']['example']}{RESET}",
+    )
+    _add_common_mode_arguments(fileinfo_parser, include_process_output=False)
 
     stats_parser = subparsers.add_parser(
         'stats',
@@ -9502,6 +9619,15 @@ def main() -> None:
                 'keyboard': getattr(args, 'keyboard', False),
                 'transposition': getattr(args, 'transposition', False),
                 'output_format': output_format,
+            },
+        ),
+        'fileinfo': (
+            fileinfo_mode,
+            {
+                'input_files': args.input,
+                'output_file': args.output,
+                'output_format': output_format,
+                'quiet': args.quiet,
             },
         ),
         'stats': (

--- a/tests/test_multitool_fileinfo.py
+++ b/tests/test_multitool_fileinfo.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+import json
+import csv
+import pytest
+
+def test_fileinfo_mode_visual(tmp_path):
+    # Create a test file
+    test_file = tmp_path / "test.txt"
+    content = "Hello world\nThis is a test file.\nThird line."
+    test_file.write_text(content, encoding='utf-8')
+
+    # Run multitool.py fileinfo
+    result = subprocess.run(
+        ['python3', 'multitool.py', 'fileinfo', str(test_file), '-f', 'arrow'],
+        capture_output=True, text=True, check=True
+    )
+
+    # Assertions
+    output = result.stdout
+    assert "test.txt" in output
+    assert "Lines" in output
+    assert "Words" in output
+    assert "Size" in output
+    assert "3" in output # Lines
+    assert "9" in output # Words (Hello, world, This, is, a, test, file, Third, line) - wait, splitting by line.split()
+    # "Hello world" -> 2
+    # "This is a test file." -> 5
+    # "Third line." -> 2
+    # Total = 9
+
+def test_fileinfo_mode_json(tmp_path):
+    test_file = tmp_path / "test.txt"
+    content = "One two three"
+    test_file.write_text(content, encoding='utf-8')
+
+    result = subprocess.run(
+        ['python3', 'multitool.py', 'fileinfo', str(test_file), '-f', 'json'],
+        capture_output=True, text=True, check=True
+    )
+
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]['file'] == str(test_file)
+    assert data[0]['lines'] == 1
+    assert data[0]['words'] == 3
+    assert data[0]['size'] == len(content)
+
+def test_fileinfo_mode_csv(tmp_path):
+    test_file = tmp_path / "test.txt"
+    content = "Line 1\nLine 2"
+    test_file.write_text(content, encoding='utf-8')
+
+    csv_file = tmp_path / "output.csv"
+    subprocess.run(
+        ['python3', 'multitool.py', 'fileinfo', str(test_file), '-f', 'csv', '-o', str(csv_file)],
+        check=True
+    )
+
+    with open(csv_file, 'r', newline='') as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]['file'] == str(test_file)
+        assert int(rows[0]['lines']) == 2
+        assert int(rows[0]['words']) == 4


### PR DESCRIPTION
### **PR Title:** [FEAT] [FileInfo mode for multitool.py]

**Description:**
* **What:** I have implemented a new `fileinfo` mode for `multitool.py` that allows users to extract metadata from files. Specifically, it reports the file size (in bytes), line count, word count, and detected character encoding for each input file. The feature supports all existing structured output formats (JSON, CSV, YAML, TOML, XML) and provides a rich visual table output (arrow format).
* **Why:** While analyzing the codebase, I noticed that the tool suite is excellent at processing *content* (finding typos, extracting headings, etc.), but lacked a quick way to inspect file-level *metadata*. Following the "Symmetry" heuristic, since the tool can process files in batches, it should also be able to provide a summary of those files. This feature adds immediate value for users who need to audit their datasets or verify file properties before running more intensive processing modes like `standardize` or `scrub`.

**Changes:**
- **multitool.py**:
  - Added `fileinfo_mode` function to gather metadata.
  - Added `fileinfo` entry to `MODE_DETAILS` with summary, description, and examples.
  - Updated `get_mode_summary_text` to include `fileinfo` in the `CHECK & ANALYZE` category.
  - Updated `_build_parser` to register the `fileinfo` subcommand.
  - Integrated the new mode into the `handler_map` in `main()`.
- **docs/multitool.md**: Added documentation and examples for the `fileinfo` mode.
- **tests/test_multitool_fileinfo.py**: New test file verifying visual, JSON, and CSV outputs.


---
*PR created automatically by Jules for task [17910245484393646584](https://jules.google.com/task/17910245484393646584) started by @RainRat*