### PR TITLE
Fix line counting logic in comments mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2460,8 +2460,6 @@ def comments_mode(
 
     for input_file in input_files:
         for comment in _extract_comment_items(input_file, quiet=quiet):
-            total_found += 1
-
             # For multi-line comments, we split into lines if cleaning is requested
             # to allow filtering specific words/lines within the comment.
             if clean_items:
@@ -2470,6 +2468,7 @@ def comments_mode(
                 sub_items = [comment]
 
             for item in sub_items:
+                total_found += 1
                 text_to_save = filter_to_letters(item) if clean_items else item
                 if not (min_length <= len(text_to_save) <= max_length):
                     continue


### PR DESCRIPTION
The `comments_mode` function in `multitool.py` had a logic bug in its reporting statistics. When `clean_items` was enabled (the default), multi-line comment blocks were split into individual lines for processing, but the `total_found` counter was only incremented once per block. This resulted in "Total comments analyzed" reflecting blocks while "Total comments after filtering" reflected lines, leading to misleading retention rates (often over 100%).

This change moves the `total_found += 1` increment into the line-processing loop, ensuring that both "analyzed" and "filtered" counts use the same granularity (lines when splitting is enabled, blocks otherwise). This ensures accurate and logical analysis summaries for the user.

Verified with reproduction cases and existing unit tests. Non-breaking change.

---
*PR created automatically by Jules for task [17517259669903974815](https://jules.google.com/task/17517259669903974815) started by @RainRat*