### PR TITLE
Fix item counting logic in `comments_mode` statistics

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2460,8 +2460,6 @@ def comments_mode(
 
     for input_file in input_files:
         for comment in _extract_comment_items(input_file, quiet=quiet):
-            total_found += 1
-
             # For multi-line comments, we split into lines if cleaning is requested
             # to allow filtering specific words/lines within the comment.
             if clean_items:
@@ -2470,6 +2468,7 @@ def comments_mode(
                 sub_items = [comment]
 
             for item in sub_items:
+                total_found += 1
                 text_to_save = filter_to_letters(item) if clean_items else item
                 if not (min_length <= len(text_to_save) <= max_length):
                     continue


### PR DESCRIPTION
### PR Title: Fix item counting logic in `comments_mode` statistics

#### Description:
* **What:** Fixed a logic bug in the `comments_mode` function in `multitool.py` where the "Total analyzed" counter was incremented per comment block instead of per individual line extracted from those blocks.
* **Why:** This ensures that the Analysis Summary reports consistent and logical statistics. Previously, splitting a single multi-line comment into 3 lines would result in "1 Analyzed, 3 Saved (300% Retention)". It now correctly reports "3 Analyzed, 3 Saved (100% Retention)". This is a non-breaking change that only affects informational logging output. All 983 tests passed after the fix.

---
*PR created automatically by Jules for task [9083184604287031005](https://jules.google.com/task/9083184604287031005) started by @RainRat*