### PR TITLE
[DOCS] Replace technical jargon '0-based' with simpler language

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -62,7 +62,7 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py between input.txt --start '{{' --end '}}'`
 
 - **`csv`**
-  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) to pick specific columns (using 0-based indexing). Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
+  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) to pick specific columns (starting from 0). Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
   - **Example:** `python multitool.py csv data.csv --column 1  # Get the second column`
 
 - **`markdown`**
@@ -70,7 +70,7 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py markdown notes.md --right`
 
 - **`md-table`**
-  - Extracts text from cells in a Markdown table. It saves the first column by default. Use the `--right` flag for the second column, or `--column` (or `-c`) to pick specific columns (using 0-based indexing). It automatically skips header and divider rows.
+  - Extracts text from cells in a Markdown table. It saves the first column by default. Use the `--right` flag for the second column, or `--column` (or `-c`) to pick specific columns (starting from 0). It automatically skips header and divider rows.
   - **Example:** `python multitool.py md-table readme.md --column 1  # Get the second column`
 
 - **`headings`**

--- a/multitool.py
+++ b/multitool.py
@@ -6594,7 +6594,7 @@ MODE_DETAILS = {
     },
     "csv": {
         "summary": "Extracts columns from CSV",
-        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, --column to pick specific 0-based numbers, or --delimiter to use a custom separator.",
+        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, --column to pick specific numbers (starting from 0), or --delimiter to use a custom separator.",
         "example": "python multitool.py csv typos.csv --column 1 --delimiter ';'  # Get the second column",
         "flags": "[FILES...] [-d DELIM] [-c N] [--first-column]",
     },
@@ -6612,7 +6612,7 @@ MODE_DETAILS = {
     },
     "md-table": {
         "summary": "Extracts Markdown table items",
-        "description": "Finds text in cells of a Markdown table. It saves the first column by default. Use --right to save the second column instead, or --column to pick specific 0-based numbers. It automatically skips header and divider rows.",
+        "description": "Finds text in cells of a Markdown table. It saves the first column by default. Use --right to save the second column instead, or --column to pick specific numbers (starting from 0). It automatically skips header and divider rows.",
         "example": "python multitool.py md-table readme.md --column 1  # Get the second column",
         "flags": "[FILES...] [-c N] [--right]",
     },
@@ -7380,7 +7380,7 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         nargs='+',
         metavar='NUMBER',
-        help='One or more 0-based column numbers to get.',
+        help='One or more column numbers to get (starting from 0).',
     )
     _add_common_mode_arguments(csv_parser)
 
@@ -7434,7 +7434,7 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         nargs='+',
         metavar='NUMBER',
-        help='One or more 0-based column numbers to get.',
+        help='One or more column numbers to get (starting from 0).',
     )
     _add_common_mode_arguments(md_table_parser)
 


### PR DESCRIPTION
* **Type:** Documentation / Internal Help
* **What:** Updated `docs/multitool.md` and help strings in `multitool.py` for the `csv` and `md-table` commands.
* **Why:** Replaced technical terms like "0-based indexing" with "starting from 0" to ensure the tool is understandable for casual users and a global audience, as per the style guidelines.

---
*PR created automatically by Jules for task [10166410482715361938](https://jules.google.com/task/10166410482715361938) started by @RainRat*