### PR TITLE
[UI/UX] Refine CLI help visual hierarchy and usage clarity

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -6965,18 +6965,15 @@ def get_mode_summary_text() -> str:
     lines.append(divider)
 
     for i, (category, modes) in enumerate(categories.items()):
-        # Add a divider before categories (except the first one) to improve hierarchy
-        if i > 0:
-            lines.append(divider)
+        # Category header with themed divider spanning the table width
+        cat_visible_width = width_mode + width_summary + width_flags + 6
+        left_len = (cat_visible_width - len(category) - 2) // 2
+        right_len = cat_visible_width - len(category) - 2 - left_len
 
-        # Category header aligned with table columns
         cat_header = (
-            f"{padding}{c_bold}{c_blue}{category:<{width_mode}}{c_reset} {sep} "
-            f"{c_bold}{c_blue}{' ' * width_summary}{c_reset} {sep} "
-            f"{c_bold}{c_blue}{' ' * width_flags}{c_reset}"
+            f"{padding}{c_bold}{c_blue}{'─' * left_len} {category} {'─' * right_len}{c_reset}"
         )
         lines.append(cat_header)
-        lines.append(divider)
 
         for mode in modes:
             if mode in MODE_DETAILS:
@@ -7016,7 +7013,7 @@ def get_mode_summary_text() -> str:
         ("--limit (-L)", "Restrict the number of items in the output")
     ]
     for flag, desc in tips:
-        lines.append(f"{padding}{c_bold}{c_green}{flag:<13}{c_reset} {desc}")
+        lines.append(f"{padding}{c_bold}{c_green}{flag:<20}{c_reset} {desc}")
 
     lines.append(f"\nRun '{c_bold}python multitool.py help <mode>{c_reset}' for details on a specific mode.\n")
     return "\n".join(lines)
@@ -7073,25 +7070,7 @@ def show_mode_help(mode_name: str | None, parser: argparse.ArgumentParser) -> No
             block.append(f"{label_color}{'DESCRIPTION:':<15}{RESET}{desc}")
 
         flags_str = details.get("flags", "[FILES...]")
-        all_tokens = flags_str.split()
-
-        # Identify positional arguments (uppercase words not preceded by a flag)
-        pos_args = []
-        for i, token in enumerate(all_tokens):
-            # Positional if it doesn't start with - and is not an argument to a preceding flag
-            if token.startswith('-') or (token.startswith('[') and token[1] == '-'):
-                continue
-            if i > 0:
-                prev = all_tokens[i-1]
-                if prev.startswith('-') or (prev.startswith('[') and prev[1] == '-'):
-                    continue
-
-            clean_token = token.strip('[]().')
-            if clean_token.isupper() and clean_token not in ("FILES...", "FILES"):
-                pos_args.append(token)
-
-        pos_args_str = (" " + " ".join(pos_args)) if pos_args else ""
-        usage_line = f"python {parser.prog} {mode_name}{pos_args_str} [FILES...] [OPTIONS]"
+        usage_line = f"python {parser.prog} {mode_name} {flags_str} [OPTIONS]"
 
         block.append(f"\n{label_color}{'USAGE:':<15}{RESET}{BOLD}{usage_line}{RESET}")
 

--- a/tests/test_coverage_completion_final.py
+++ b/tests/test_coverage_completion_final.py
@@ -194,7 +194,7 @@ def test_mode_help_action_usage_formatting(capsys):
     output = captured.err + captured.out
     # Strip ANSI codes for comparison
     clean_output = re.sub(r'\x1b\[[0-9;]*m', '', output)
-    assert "USAGE:         python multitool.py search [QUERY] [FILES...] [OPTIONS]" in clean_output
+    assert "USAGE:         python multitool.py search [QUERY] [FILES...] [-Sktn] [-B/A/C N] [OPTIONS]" in clean_output
 
 def test_main_search_fallback(tmp_path):
     """Cover multitool.py lines 5673-5674: main() search mode fallbacks."""


### PR DESCRIPTION
### [UI/UX] Refine CLI help visual hierarchy and usage clarity

**Context:** CLI

**Problem:** 
1. The global help table (`multitool.py help`) lacked a strong visual distinction between functional categories (GET DATA, CHANGE DATA, etc.), making it harder to scan.
2. Individual mode help strings used a generic `[FILES...] [OPTIONS]` placeholder in the USAGE line, hiding the most important mode-specific flags (like `--start` for `between` or `--query` for `search`) until the user read the detailed options list.

**Solution:**
1. **Themed Dividers:** Category headers in the global summary now use centered, single-line themed dividers that span the entire table width. This creates a much clearer visual break and improves scanability.
2. **Explicit Usage Strings:** The USAGE line for individual modes now incorporates curated flags from the tool's internal metadata. This provides immediate clarity on the primary expected inputs and flags for every command.
3. **Aligned Tips:** Fixed the alignment of the QUICK TIPS section to ensure a consistent visual vertical line between flags and descriptions.

**Changes:**
- Modified `get_mode_summary_text` in `multitool.py` for themed dividers and tip alignment.
- Modified `show_mode_help` in `multitool.py` to use curated flags in the USAGE line.
- Updated `tests/test_coverage_completion_final.py` to align with the new usage format.

---
*PR created automatically by Jules for task [13498554881609187767](https://jules.google.com/task/13498554881609187767) started by @RainRat*