### PR TITLE
[DOCS] [Improve Multitool documentation and internal help strings]

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -62,15 +62,19 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py between input.txt --start '{{' --end '}}'`
 
 - **`csv`**
-  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) to pick specific columns (using 0-based indexing). Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
+  - Extracts columns from CSV files. By default, it picks **every column except the first one**. Use `--first-column` to get *only* the first column, or `--column` (or `-c`) to pick specific columns (starting from 0). Use `--delimiter` (or `-d`) to set a different separator (for example, `;`).
   - **Example:** `python multitool.py csv data.csv --column 1  # Get the second column`
 
 - **`markdown`**
   - Extracts Markdown list items (lines starting with `-`, `*`, or `+`). You can split items by `:` or `->` to get one side of a pair (use the `--right` flag for the second part).
   - **Example:** `python multitool.py markdown notes.md --right`
 
+- **`frontmatter`**
+  - Extracts YAML frontmatter from Markdown files (text between '---' delimiters at the start of the file). Use dots for nested keys (like 'metadata.tags'). If you don't provide a key, it gets items from the top level.
+  - **Example:** `python multitool.py frontmatter post.md --key 'tags'`
+
 - **`md-table`**
-  - Extracts text from cells in a Markdown table. It saves the first column by default. Use the `--right` flag for the second column, or `--column` (or `-c`) to pick specific columns (using 0-based indexing). It automatically skips header and divider rows.
+  - Extracts text from cells in a Markdown table. It saves the first column by default. Use the `--right` flag for the second column, or `--column` (or `-c`) to pick specific columns (starting from 0). It automatically skips header and divider rows.
   - **Example:** `python multitool.py md-table readme.md --column 1  # Get the second column`
 
 - **`headings`**
@@ -93,6 +97,10 @@ Use these modes to pull specific data from a file.
   - **Options:** Use `--language` (or `-l`) to filter by a specific language (for example, `python`). Use `--pairs` (or `-p`) to see both the language and the code content.
   - **Example:** `python multitool.py codeblocks readme.md --language python`
 
+- **`comments`**
+  - Extracts comments from source files. It identifies single-line comments (`#`, `//`, `--`) and multi-line comments (`/* */`, `<!-- -->`, and triple quotes) in various programming and markup languages.
+  - **Example:** `python multitool.py comments src/ --output comments.txt`
+
 - **`json`**
   - Extracts values from a JSON file by key. Use dot notation for nested keys (for example, `user.name`). If you do not provide a key, it extracts items from the top level. It automatically handles lists and objects.
   - **Example:** `python multitool.py json report.json --key replacements.typo`
@@ -106,8 +114,13 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py toml pyproject.toml --key tool.poetry.dependencies`
 
 - **`xml`**
-  - Extracts values from XML files using a tag name or XPath expression. If you do not provide a key, it extracts text from every element.
+  - Extracts values from XML files using a tag name or XPath expression. If you don't provide a key, it extracts text from every element.
   - **Example:** `python multitool.py xml data.xml -k './/item/name'`
+
+- **`paths`**
+  - Extracts path components (basename, dirname, extension) from file and directory paths. It also supports smart splitting to find words within filenames.
+  - **Options:** Use `--basename`, `--dirname`, or `--extension` to pick specific parts. Use `--smart` to split components into words.
+  - **Example:** `python multitool.py paths src/ --basename --smart`
 
 - **`flatten`**
   - Transforms nested JSON, YAML, or TOML structures into dot-separated `key.path = value` pairs. It supports multi-document YAML and JSON Lines (JSONL). The default output format is `arrow`.

--- a/multitool.py
+++ b/multitool.py
@@ -6594,7 +6594,7 @@ MODE_DETAILS = {
     },
     "csv": {
         "summary": "Extracts columns from CSV",
-        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, --column to pick specific 0-based numbers, or --delimiter to use a custom separator.",
+        "description": "Gets data from CSV files. By default, it gets every column except the first one. Use --first-column to get only the first column, --column to pick specific numbers starting from 0, or --delimiter to use a custom separator.",
         "example": "python multitool.py csv typos.csv --column 1 --delimiter ';'  # Get the second column",
         "flags": "[FILES...] [-d DELIM] [-c N] [--first-column]",
     },
@@ -6606,13 +6606,13 @@ MODE_DETAILS = {
     },
     "frontmatter": {
         "summary": "Extracts Markdown frontmatter",
-        "description": "Finds YAML frontmatter in Markdown files (text between '---' delimiters at the start of the file). Use dots for nested keys (like 'metadata.tags'). If no key is provided, it gets items from the top level.",
+        "description": "Finds YAML frontmatter in Markdown files (text between '---' delimiters at the start of the file). Use dots for nested keys (like 'metadata.tags'). If you don't provide a key, it gets items from the top level.",
         "example": "python multitool.py frontmatter post.md --key 'tags'",
         "flags": "[FILES...] [-k KEY]",
     },
     "md-table": {
         "summary": "Extracts Markdown table items",
-        "description": "Finds text in cells of a Markdown table. It saves the first column by default. Use --right to save the second column instead, or --column to pick specific 0-based numbers. It automatically skips header and divider rows.",
+        "description": "Finds text in cells of a Markdown table. It saves the first column by default. Use --right to save the second column instead, or --column to pick specific numbers starting from 0. It automatically skips header and divider rows.",
         "example": "python multitool.py md-table readme.md --column 1  # Get the second column",
         "flags": "[FILES...] [-c N] [--right]",
     },
@@ -6630,7 +6630,7 @@ MODE_DETAILS = {
     },
     "json": {
         "summary": "Extracts JSON values by key",
-        "description": "Finds values for a specific key in a JSON file. Use dots for nested keys (like 'user.name'). If no key is provided, it gets items from the top level. It automatically handles lists of objects.",
+        "description": "Finds values for a specific key in a JSON file. Use dots for nested keys (like 'user.name'). If you don't provide a key, it gets items from the top level. It automatically handles lists of objects.",
         "example": "python multitool.py json list.json -o items.txt",
         "flags": "[FILES...] [-k KEY]",
     },
@@ -6642,19 +6642,19 @@ MODE_DETAILS = {
     },
     "yaml": {
         "summary": "Extracts YAML values by key",
-        "description": "Finds values for a specific key in a YAML file. Use dots for nested keys (like 'config.items'). If no key is provided, it gets items from the top level. It automatically handles lists.",
+        "description": "Finds values for a specific key in a YAML file. Use dots for nested keys (like 'config.items'). If you don't provide a key, it gets items from the top level. It automatically handles lists.",
         "example": "python multitool.py yaml list.yaml -o items.txt",
         "flags": "[FILES...] [-k KEY]",
     },
     "toml": {
         "summary": "Extracts TOML values by key",
-        "description": "Finds values for a specific key in a TOML file. Use dots for nested keys (like 'tool.poetry.dependencies'). If no key is provided, it gets items from the top level. It automatically handles nested tables.",
+        "description": "Finds values for a specific key in a TOML file. Use dots for nested keys (like 'tool.poetry.dependencies'). If you don't provide a key, it gets items from the top level. It automatically handles nested tables.",
         "example": "python multitool.py toml pyproject.toml -k tool.poetry.dependencies --output-format toml",
         "flags": "[FILES...] [-k KEY]",
     },
     "xml": {
         "summary": "Extracts XML values by tag/XPath",
-        "description": "Finds text from elements in an XML file matching a tag name or XPath expression. If no key is provided, it extracts text from every element in the file.",
+        "description": "Finds text from elements in an XML file matching a tag name or XPath expression. If you don't provide a key, it extracts text from every element in the file.",
         "example": "python multitool.py xml data.xml -k './/item/name' --output names.txt",
         "flags": "[FILES...] [-k KEY]",
     },
@@ -7380,7 +7380,7 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         nargs='+',
         metavar='NUMBER',
-        help='One or more 0-based column numbers to get.',
+        help='One or more column numbers to get, starting from 0.',
     )
     _add_common_mode_arguments(csv_parser)
 
@@ -7434,7 +7434,7 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         nargs='+',
         metavar='NUMBER',
-        help='One or more 0-based column numbers to get.',
+        help='One or more column numbers to get, starting from 0.',
     )
     _add_common_mode_arguments(md_table_parser)
 


### PR DESCRIPTION
**PR Title:** [DOCS] [Improve Multitool documentation and internal help strings]
**Description:**
* **Type:** Documentation / Internal Help
* **What:** Updated `docs/multitool.md` and the `MODE_DETAILS` / `argparse` help strings in `multitool.py`.
* **Why:** This change makes the `multitool` utility more accessible and easier to use by:
    1.  Adding documentation for missing modes (`frontmatter`, `comments`, `paths`).
    2.  Replacing technical jargon ("0-based indexing") with plain English ("starting from 0").
    3.  Using active voice in descriptions to improve clarity for a global audience.

---
*PR created automatically by Jules for task [15350362695944064498](https://jules.google.com/task/15350362695944064498) started by @RainRat*