### PR TITLE
Fix literal replacement bug in replace mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -5838,11 +5838,17 @@ def replace_mode(
             file_replacements = 0
 
             # Define replacement function outside the loop for performance
-            if regex and smart_case:
-                def repl_func(match):
-                    # Handle backreferences by expanding them first
-                    expanded = match.expand(new_text)
-                    return _apply_smart_case(match.group(0), expanded)
+            if regex:
+                if use_regex:
+                    if smart_case:
+                        repl_func = lambda m: _apply_smart_case(m.group(0), m.expand(new_text))
+                    else:
+                        repl_func = new_text
+                else:
+                    if smart_case:
+                        repl_func = lambda m: _apply_smart_case(m.group(0), new_text)
+                    else:
+                        repl_func = lambda m: new_text
             else:
                 repl_func = new_text
 


### PR DESCRIPTION
Fixed a logic bug in `replace_mode` within `multitool.py` where replacement strings containing backslashes (e.g., `\1`) were incorrectly interpreted as regex backreferences during case-insensitive or smart-case literal replacements. The fix ensures that a lambda returning the literal string is used for `re.subn` when `use_regex` is false. This prevents `re.error: invalid group reference` and incorrect substitutions when users perform literal search-and-replace operations with character sequences that happen to overlap with regex syntax.

---
*PR created automatically by Jules for task [13026837126789506146](https://jules.google.com/task/13026837126789506146) started by @RainRat*