### PR TITLE
[UI/UX] Refine help summary table hierarchy and densify information

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -7143,7 +7143,7 @@ MODE_DETAILS = {
         "summary": "Removes words found inside others",
         "description": "Removes words from your list if they appear anywhere (even as a fragment) inside words in a second file.",
         "example": "python multitool.py filterfragments list.txt reference.txt --output unique.txt",
-        "flags": "[FILES...] [FILE2]",
+        "flags": "[FILES...] FILE2",
     },
     "check": {
         "summary": "Finds word used as typo and fix",
@@ -7155,7 +7155,7 @@ MODE_DETAILS = {
         "summary": "Compares files using set logic",
         "description": "Compares two files to find shared lines (intersection), all lines (union), lines unique to the first file (difference), or lines unique to either file (symmetric_difference).",
         "example": "python multitool.py set_operation fileA.txt fileB.txt --operation difference --output unique.txt",
-        "flags": "[FILES...] [FILE2] --operation OP",
+        "flags": "[FILES...] FILE2 --operation OP",
     },
     "sample": {
         "summary": "Picks a random set of lines",
@@ -7191,7 +7191,7 @@ MODE_DETAILS = {
         "summary": "Pairs lines from two files",
         "description": "Joins two files line-by-line into a paired format like 'typo -> correction'. Useful for creating mapping files from two separate lists. Length filters are applied to both items in each pair.",
         "example": "python multitool.py zip typos.txt corrections.txt --output-format table --output typos.toml",
-        "flags": "[FILES...] [FILE2]",
+        "flags": "[FILES...] FILE2",
     },
     "swap": {
         "summary": "Reverses the order of pairs",
@@ -7227,7 +7227,7 @@ MODE_DETAILS = {
         "summary": "Finds similar words in two lists",
         "description": "Finds words in your list that are similar to words in a second list (large dictionary). It defaults to the rich 'arrow' format when run in a terminal. Use this to find likely corrections for typos. It defaults to a threshold of 1 character change.",
         "example": "python multitool.py fuzzymatch typos.txt words.csv --keyboard --show-dist",
-        "flags": "[FILES...] [FILE2] [--max-dist N] [-k] [-t] [--show-dist]",
+        "flags": "[FILES...] FILE2 [--max-dist N] [-k] [-t] [--show-dist]",
     },
     "stats": {
         "summary": "Shows statistics for a list",
@@ -7281,7 +7281,7 @@ MODE_DETAILS = {
         "summary": "Searches for words or patterns",
         "description": "A typo-aware search tool. It searches for a query in your files and can find similar words (typos) or subword matches. It supports highlighting, line numbers, and context lines.",
         "example": "python multitool.py search 'teh' report.txt --keyboard --line-numbers",
-        "flags": "[QUERY] [FILES...] [-S] [-k] [-t] [-n] [-B/A/C N]",
+        "flags": "QUERY [FILES...] [-S] [-k] [-t] [-n] [-B/A/C N]",
     },
     "scan": {
         "summary": "Scans project for known typos",
@@ -7323,7 +7323,7 @@ MODE_DETAILS = {
         "summary": "Shows differences between files",
         "description": "Finds differences between two files or lists. It can track simple word additions/removals or (with --pairs) find changed corrections for existing typos. Color-coded output highlights what is added (+), what is removed (-), and what changed (~).",
         "example": "python multitool.py diff old_typos.csv new_typos.csv --pairs --output-format json",
-        "flags": "[FILES...] [FILE2] [-p]",
+        "flags": "[FILES...] FILE2 [-p]",
     },
     "highlight": {
         "summary": "Color-codes words from a list",
@@ -7347,7 +7347,7 @@ MODE_DETAILS = {
         "summary": "Replaces text or patterns",
         "description": "Performs text substitution across files. It supports literal string replacement and regular expressions (with backreferences). You can provide the OLD and NEW text as positional arguments or use the --old and --new flags. Supports in-place editing, dry-runs, and unified diffs. Use --smart-case to automatically match the original casing pattern.",
         "example": "python multitool.py replace 'the' 'that' . --in-place --smart-case",
-        "flags": "[OLD] [NEW] [FILES...] [-r] [-c] [-S] [-I EXT] [-D] [--dry-run]",
+        "flags": "OLD NEW [FILES...] [-r] [-c] [-S] [-I EXT] [-D] [--dry-run]",
     },
 }
 
@@ -7365,7 +7365,14 @@ def get_mode_summary_text() -> str:
     c_blue = BLUE if use_color else ""
     c_green = GREEN if use_color else ""
     c_yellow = YELLOW if use_color else ""
+    c_cyan = CYAN if use_color else ""
     c_reset = RESET if use_color else ""
+
+    category_colors = {
+        "GET DATA": c_green,
+        "CHANGE DATA": c_yellow,
+        "CHECK & ANALYZE": c_cyan,
+    }
 
     lines = []
     lines.append(f"{c_bold}Available Modes:{c_reset}")
@@ -7374,11 +7381,16 @@ def get_mode_summary_text() -> str:
     all_modes = [m for cat in categories.values() for m in cat if m in MODE_DETAILS]
     width_mode = max((len(m) for m in all_modes), default=15)
 
-    # Summary width - we allow some growth but cap it to keep the table readable
-    width_summary = 35
+    # Summary width - dynamic based on content
+    width_summary = max((len(MODE_DETAILS[m].get('summary', '').rstrip('.')) for m in all_modes), default=35)
+    width_summary = min(max(width_summary, 30), 45)
 
-    # Flags width - dynamic based on content
-    width_flags = max((len(MODE_DETAILS[m].get('flags', '')) for m in all_modes), default=15)
+    # Flags width - dynamic based on content (stripping redundant [FILES...])
+    def get_clean_flags(m):
+        f = MODE_DETAILS[m].get('flags', '')
+        return f.replace("[FILES...] ", "").replace("[FILES...]", "").strip()
+
+    width_flags = max((len(get_clean_flags(m)) for m in all_modes), default=15)
     width_flags = min(max(width_flags, 15), 70)
 
     # Header and divider elements
@@ -7400,11 +7412,9 @@ def get_mode_summary_text() -> str:
     for i, (category, modes) in enumerate(categories.items()):
         # Category header with themed divider spanning the table width
         cat_visible_width = width_mode + width_summary + width_flags + 6
-        left_len = (cat_visible_width - len(category) - 2) // 2
-        right_len = cat_visible_width - len(category) - 2 - left_len
-
+        cat_color = category_colors.get(category, c_blue)
         cat_header = (
-            f"{padding}{c_bold}{c_blue}{'─' * left_len} {category} {'─' * right_len}{c_reset}"
+            f"{padding}{c_bold}{cat_color}{category}{c_reset} {c_blue}{'─' * (cat_visible_width - len(category) - 1)}{c_reset}"
         )
         lines.append(cat_header)
 
@@ -7412,7 +7422,7 @@ def get_mode_summary_text() -> str:
             if mode in MODE_DETAILS:
                 details = MODE_DETAILS[mode]
                 summary = details['summary'].rstrip('.')
-                flags = details.get('flags', '')
+                flags = get_clean_flags(mode)
 
                 # Truncate summary if it exceeds the calculated width
                 if len(summary) > width_summary:
@@ -7423,8 +7433,9 @@ def get_mode_summary_text() -> str:
                 if len(display_flags) > width_flags:
                     display_flags = display_flags[:width_flags-3] + "..."
 
+                mode_color = category_colors.get(category, c_green)
                 row = (
-                    f"{padding}{c_bold}{c_green}{mode:<{width_mode}}{c_reset} {sep} "
+                    f"{padding}{c_bold}{mode_color}{mode:<{width_mode}}{c_reset} {sep} "
                     f"{summary:<{width_summary}} {sep} "
                     f"{c_yellow}{display_flags:<{width_flags}}{c_reset}"
                 )
@@ -7443,7 +7454,8 @@ def get_mode_summary_text() -> str:
         ("--diff (-D)", "Show unified diff of changes before applying"),
         ("--smart-case (-S)", "Automatically match original casing"),
         ("--raw (-R)", "Keep original text (no lowercase, no cleaning)"),
-        ("--limit (-L)", "Restrict the number of items in the output")
+        ("--limit (-L)", "Restrict the number of items in the output"),
+        ("FILE", "All modes accept one or more files or standard input if FILE is omitted")
     ]
     for flag, desc in tips:
         lines.append(f"{padding}{c_bold}{c_green}{flag:<20}{c_reset} {desc}")

--- a/tests/test_coverage_completion_final.py
+++ b/tests/test_coverage_completion_final.py
@@ -194,7 +194,7 @@ def test_mode_help_action_usage_formatting(capsys):
     output = captured.err + captured.out
     # Strip ANSI codes for comparison
     clean_output = re.sub(r'\x1b\[[0-9;]*m', '', output)
-    assert "USAGE:         python multitool.py search [QUERY] [FILES...] [-S] [-k] [-t] [-n] [-B/A/C N] [OPTIONS]" in clean_output
+    assert "USAGE:         python multitool.py search QUERY [FILES...] [-S] [-k] [-t] [-n] [-B/A/C N] [OPTIONS]" in clean_output
 
 def test_main_search_fallback(tmp_path):
     """Cover multitool.py lines 5673-5674: main() search mode fallbacks."""

--- a/tests/test_multitool_coverage_final_gaps_robust.py
+++ b/tests/test_multitool_coverage_final_gaps_robust.py
@@ -33,7 +33,10 @@ def test_get_mode_summary_text_truncation(monkeypatch):
 
     output = multitool.get_mode_summary_text()
 
-    # The tool now uses a 35-character width for summaries
-    expected_truncated = long_summary[:35-3] + "..."
+    # Calculate dynamic summary width
+    width_summary = max((len(m.get('summary', '').rstrip('.')) for m in new_details.values()), default=35)
+    width_summary = min(max(width_summary, 30), 45)
+
+    expected_truncated = long_summary[:width_summary-3] + "..."
     assert expected_truncated in output
     assert long_summary not in output


### PR DESCRIPTION
This PR significantly improves the CLI usability and visual hierarchy of the `multitool.py` help system.

**Context:** CLI
**Problem:** The global help table suffered from visual clutter due to the repetitive `[FILES...]` placeholder in every row, a lack of clear visual grouping for command categories, and inconsistent usage strings that didn't distinguish between required and optional positional arguments.
**Solution:** 
1. **Enhanced Visual Hierarchy:** Introduced category-based coloring (Green, Yellow, Cyan) and simplified dividers to help users scan for relevant tools faster.
2. **Increased Information Density:** Dynamically stripped the redundant `[FILES...]` string from the options column, making room for actual command flags. A single explanatory note was added to the "Quick Tips" section to maintain clarity.
3. **Improved Correctness:** Updated `MODE_DETAILS` to follow standard POSIX-style notation (e.g., `QUERY` instead of `[QUERY]` for required positional arguments), improving the reliability of the help text.
4. **Dynamic Scaling:** Replaced fixed-width columns with content-aware dynamic widths, preventing awkward spacing in the summary table.

**Changes:**
- Updated `MODE_DETAILS` dictionary in `multitool.py`.
- Refactored `get_mode_summary_text` in `multitool.py`.
- Updated `tests/test_coverage_completion_final.py` and `tests/test_multitool_coverage_final_gaps_robust.py` to match the new output logic.

---
*PR created automatically by Jules for task [10386833302065681906](https://jules.google.com/task/10386833302065681906) started by @RainRat*