### PR TITLE
[FEAT] Add sentences mode and sentence support to count mode

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -135,6 +135,10 @@ Use these modes to pull specific data from a file.
   - Extracts individual words from a file using whitespace or a custom delimiter. Use the `--smart` (or `-S`) flag to also split by symbols and capital letters (for example, "CamelCase" becomes "Camel" and "Case").
   - **Example:** `python multitool.py words report.txt --smart`
 
+- **`sentences`**
+  - Extracts individual sentences from a file using a regex-based heuristic. It handles multi-line sentences by joining lines with spaces before splitting.
+  - **Example:** `python multitool.py sentences report.txt --output sentences.txt`
+
 - **`ngrams`**
   - Extracts sequences of words. This is useful for finding phrases or context around typos. It supports sequences across line boundaries.
   - **Options:** Use `-n` to pick the number of words in each sequence (default is 2). Like the `words` mode, it supports custom delimiters and smart word splitting.
@@ -311,6 +315,7 @@ Use these modes to analyze your data.
     - `-p`, `--pairs`: Count frequencies of word pairs and classify them.
     - `-l`, `--lines`: Count frequencies of raw lines.
     - `-c`, `--chars`: Count frequencies of individual characters.
+    - `-E`, `--sentences`: Count frequencies of individual sentences.
     - `-B`, `--by-file`: Count how many files contain each item.
   - **Visual Report:** Use `--output-format arrow` for a rich report with metrics and bar charts.
   - **Supported Formats:** `arrow`, `json`, `csv`, `markdown`, `md-table`, `line`, and `xml`.
@@ -416,7 +421,7 @@ These options work with most modes:
 - `[INPUT_FILES...]`: One or more files to read. Defaults to **standard input** if not provided.
 - `--output` (or **`-o`**): The file to write results to. Defaults to printing to the screen.
 - `--output-format` (or **`-f`**): The format of the output. Options include `line` (default), `json`, `yaml`, `toml`, `csv`, `markdown`, `md-table`, `arrow`, `table`, and `xml`. The tool automatically detects the format from the output file extension.
-- `--min-length` (or **`-m`**): Skip items shorter than this length (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count').
+- `--min-length` (or **`-m`**): Skip items shorter than this length (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count', and 10 for sentence-based modes).
 - `--max-length` (or **`-M`**): Skip words longer than this length (default: 1000).
 - `--process-output` (or **`-P`**): Sorts the final list and removes duplicates. Use this to organize your output or remove redundant entries.
 - `--limit` (or **`-L`**): Limit the number of items in the output.

--- a/multitool.py
+++ b/multitool.py
@@ -1666,6 +1666,20 @@ def _extract_words_items(
     )
 
 
+def _extract_sentence_items(input_file: str, quiet: bool = False) -> Iterable[str]:
+    """Yield individual sentences from the file using a regex heuristic."""
+    lines = _read_file_lines_robust(input_file)
+    # Join lines with spaces to handle multi-line sentences, while preserving spacing
+    content = " ".join(line.strip() for line in lines if line.strip())
+    # Heuristic: split by punctuation followed by whitespace and a non-lowercase letter or end of string
+    pattern = re.compile(r'(?<=[.!?])\s+(?=[^a-z]|$)')
+    sentences = pattern.split(content)
+    for s in sentences:
+        trimmed = s.strip()
+        if trimmed:
+            yield trimmed
+
+
 def _extract_frontmatter(input_file: str, key_path: str = '', quiet: bool = False) -> Iterable[str]:
     """Yield values from YAML frontmatter in Markdown files based on a dotted key path."""
     lines = _read_file_lines_robust(input_file)
@@ -2087,6 +2101,35 @@ def arrow_mode(
         quiet,
         clean_items=clean_items,
         limit=limit,
+    )
+
+
+def sentences_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Wrapper for getting individual sentences from file(s)."""
+    _process_items(
+        _extract_sentence_items,
+        input_files,
+        output_file,
+        min_length,
+        max_length,
+        process_output,
+        'Sentences',
+        'Successfully got sentences.',
+        output_format,
+        quiet,
+        clean_items=clean_items,
+        limit=limit,
+        item_label="sentence",
     )
 
 
@@ -2939,6 +2982,7 @@ def count_mode(
     pairs: bool = False,
     lines: bool = False,
     chars: bool = False,
+    sentences: bool = False,
     mapping_file: str | None = None,
     ad_hoc: List[str] | None = None,
     by_file: bool = False,
@@ -3013,6 +3057,8 @@ def count_mode(
                 items_gen = _extract_line_items(input_file, quiet=quiet)
             elif chars:
                 items_gen = _extract_char_items(input_file, quiet=quiet)
+            elif sentences:
+                items_gen = _extract_sentence_items(input_file, quiet=quiet)
             else:
                 items_gen = _extract_words_items(input_file, delimiter=delimiter, quiet=quiet, smart=smart)
 
@@ -3152,6 +3198,8 @@ def count_mode(
                     item_header = "Line"
                 elif chars:
                     item_header = "Character"
+                elif sentences:
+                    item_header = "Sentence"
                 else:
                     item_header = "Word"
 
@@ -3176,6 +3224,8 @@ def count_mode(
                 item_label = "line"
             elif chars:
                 item_label = "character"
+            elif sentences:
+                item_label = "sentence"
             else:
                 item_label = "word"
 
@@ -3254,6 +3304,8 @@ def count_mode(
             item_label = "line"
         elif chars:
             item_label = "character"
+        elif sentences:
+            item_label = "sentence"
         else:
             item_label = "word"
 
@@ -7127,6 +7179,12 @@ MODE_DETAILS = {
         "example": "python multitool.py words report.txt --smart --output wordlist.txt",
         "flags": "[FILES...] [-d DELIM] [-S]",
     },
+    "sentences": {
+        "summary": "Extracts sentences from a file",
+        "description": "Splits a file into individual sentences using a regex-based heuristic that identifies punctuation followed by whitespace and a capital letter. It handles multi-line sentences by joining lines with spaces before splitting.",
+        "example": "python multitool.py sentences report.txt --output sentences.txt",
+        "flags": "[FILES...]",
+    },
     "ngrams": {
         "summary": "Extracts sequences of words",
         "description": "Gets sequences of words from a file. This is useful for finding common phrases or context around typos. It supports sequences across line boundaries.",
@@ -7355,7 +7413,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "frontmatter", "md-table", "headings", "toc", "links", "codeblocks", "comments", "json", "yaml", "toml", "xml", "paths", "flatten", "line", "words", "ngrams", "regex"],
+        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "frontmatter", "md-table", "headings", "toc", "links", "codeblocks", "comments", "json", "yaml", "toml", "xml", "paths", "flatten", "line", "words", "sentences", "ngrams", "regex"],
         "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "convert", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "anomalies", "search", "scan", "verify", "fileinfo", "brokenlinks"],
     }
@@ -8169,6 +8227,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action='store_true',
         help='Count frequencies of individual characters instead of individual words.',
     )
+    unit_group.add_argument(
+        '-E', '--sentences',
+        action='store_true',
+        help='Count frequencies of individual sentences instead of individual words.',
+    )
     count_options.add_argument(
         '-s', '--mapping',
         type=str,
@@ -8652,6 +8715,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help='Split by symbols and capital letters (for example, splitting "CamelCase" into "Camel" and "Case").',
     )
     _add_common_mode_arguments(words_parser)
+
+    sentences_parser = subparsers.add_parser(
+        'sentences',
+        help=MODE_DETAILS['sentences']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['sentences']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['sentences']['example']}{RESET}",
+    )
+    _add_common_mode_arguments(sentences_parser)
 
     ngrams_parser = subparsers.add_parser(
         'ngrams',
@@ -9248,9 +9320,13 @@ def main() -> None:
     if args.min_length is None:
         if args.mode in ('words', 'ngrams', 'stats'):
             args.min_length = 3
+        elif args.mode == 'sentences':
+            args.min_length = 10
         elif args.mode == 'count':
-            # Count mode uses 3 for word extraction, but 1 for auditing, lines, or character counting
-            if any([getattr(args, 'pairs', False), getattr(args, 'chars', False), getattr(args, 'lines', False),
+            # Count mode uses 3 for word extraction, 10 for sentences, but 1 for auditing, lines, or character counting
+            if getattr(args, 'sentences', False):
+                args.min_length = 10
+            elif any([getattr(args, 'pairs', False), getattr(args, 'chars', False), getattr(args, 'lines', False),
                     getattr(args, 'mapping', None), getattr(args, 'ad_hoc', None)]):
                 args.min_length = 1
             else:
@@ -9449,6 +9525,13 @@ def main() -> None:
             {
                 **common_kwargs,
                 'right_side': right_side,
+                'output_format': output_format,
+            },
+        ),
+        'sentences': (
+            sentences_mode,
+            {
+                **common_kwargs,
                 'output_format': output_format,
             },
         ),
@@ -9727,6 +9810,7 @@ def main() -> None:
                 'pairs': getattr(args, 'pairs', False),
                 'lines': getattr(args, 'lines', False),
                 'chars': getattr(args, 'chars', False),
+                'sentences': getattr(args, 'sentences', False),
                 'mapping_file': getattr(args, 'mapping', None),
                 'ad_hoc': getattr(args, 'ad_hoc', None),
                 'by_file': getattr(args, 'by_file', False),

--- a/tests/test_multitool_sentences_feat.py
+++ b/tests/test_multitool_sentences_feat.py
@@ -1,0 +1,106 @@
+import subprocess
+import os
+
+def test_sentences_mode_basic():
+    """Verify that sentences mode extracts simple sentences correctly."""
+    input_content = "This is a sentence. And another one! What about this? Yes."
+    input_file = "test_sentences.txt"
+    with open(input_file, "w") as f:
+        f.write(input_content)
+
+    try:
+        result = subprocess.run(
+            ["python3", "multitool.py", "sentences", input_file, "--raw"],
+            capture_output=True,
+            text=True
+        )
+        assert result.returncode == 0
+        output = result.stdout.strip().split("\n")
+        assert "This is a sentence." in output
+        assert "And another one!" in output
+        assert "What about this?" in output
+        # 'Yes.' might be filtered if it's too short, but we didn't set min_length
+        # default for sentences is 10
+        assert "Yes." not in output # length 4 < 10
+    finally:
+        if os.path.exists(input_file):
+            os.remove(input_file)
+
+def test_sentences_mode_multiline():
+    """Verify that sentences mode handles multi-line sentences."""
+    input_content = "This is a\nmulti-line sentence. It should\nbe joined."
+    input_file = "test_multiline.txt"
+    with open(input_file, "w") as f:
+        f.write(input_content)
+
+    try:
+        result = subprocess.run(
+            ["python3", "multitool.py", "sentences", input_file, "--raw"],
+            capture_output=True,
+            text=True
+        )
+        assert result.returncode == 0
+        output = result.stdout.strip().split("\n")
+        assert "This is a multi-line sentence." in output
+        assert "It should be joined." in output
+    finally:
+        if os.path.exists(input_file):
+            os.remove(input_file)
+
+def test_count_sentences():
+    """Verify that count mode works with sentences."""
+    input_content = "Repeat this sentence. Repeat this sentence. Unique sentence here."
+    input_file = "test_count_sentences.txt"
+    with open(input_file, "w") as f:
+        f.write(input_content)
+
+    try:
+        result = subprocess.run(
+            ["python3", "multitool.py", "count", input_file, "--sentences", "--raw", "--output-format", "json"],
+            capture_output=True,
+            text=True
+        )
+        assert result.returncode == 0
+        import json
+        data = json.loads(result.stdout)
+        # Find "Repeat this sentence."
+        repeat_found = False
+        unique_found = False
+        for item in data:
+            if item["item"] == "Repeat this sentence.":
+                assert item["count"] == 2
+                repeat_found = True
+            if item["item"] == "Unique sentence here.":
+                assert item["count"] == 1
+                unique_found = True
+        assert repeat_found
+        assert unique_found
+    finally:
+        if os.path.exists(input_file):
+            os.remove(input_file)
+
+def test_sentences_abbreviations():
+    """Verify heuristic doesn't over-split on common abbreviations (if it can)."""
+    # Our heuristic: (?<=[.!?])\s+(?=[^a-z]|$)
+    # It splits if there's a space followed by a capital letter.
+    # "e.g. This" will split. "e.g. this" will not.
+    input_content = "Visit the U.S.A. today. It is great."
+    input_file = "test_abbr.txt"
+    with open(input_file, "w") as f:
+        f.write(input_content)
+
+    try:
+        result = subprocess.run(
+            ["python3", "multitool.py", "sentences", input_file, "--raw"],
+            capture_output=True,
+            text=True
+        )
+        assert result.returncode == 0
+        output = result.stdout.strip().split("\n")
+        # "Visit the U.S.A. today." might be split into "Visit the U.S.A." and "today." if "today" was capitalized.
+        # But here it is "today." (lowercase), so it should stay together.
+        assert "Visit the U.S.A. today." in output
+        assert "It is great." in output
+    finally:
+        if os.path.exists(input_file):
+            os.remove(input_file)


### PR DESCRIPTION
Added a new 'sentences' mode and integrated sentence support into the 'count' mode in multitool.py. This feature enables automated sentence extraction and frequency analysis, following the established patterns for words and n-grams. The implementation includes a robust regex heuristic, CLI integration, documentation updates, and comprehensive test coverage.

---
*PR created automatically by Jules for task [389970963570335127](https://jules.google.com/task/389970963570335127) started by @RainRat*