### PR TITLE
[DOCS] Standardize terminology by replacing jargon "finger-slips" with "typing errors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The **diff2typo Suite** is a set of tools to help you find and fix typos in your
 | **gentypos** | Creates lists of likely typos based on common typing errors. | [Read Docs](docs/gentypos.md) |
 | **multitool** | A multipurpose tool for cleaning, getting, and analyzing text, files, and paths. | [Read Docs](docs/multitool.md) |
 | **cmdrunner** | Runs commands across many folders at once. | [Read Docs](docs/cmdrunner.md) |
-| **typostats** | Analyzes your typos to find common finger-slips. | [Read Docs](docs/typostats.md) |
+| **typostats** | Analyzes your typos to find common typing errors. | [Read Docs](docs/typostats.md) |
 
 ## 🚀 Quick Start
 

--- a/gentypos.py
+++ b/gentypos.py
@@ -8,7 +8,7 @@ Purpose:
 
 Features:
     - Generates typos based on common typing patterns (skipping letters, swapping neighbors, and so on).
-    - Uses keyboard adjacency to predict likely finger-slips on a QWERTY layout.
+    - Uses keyboard adjacency to predict likely typing errors on a QWERTY layout.
     - Supports custom substitution rules for specific character patterns (for example, 'ph' -> 'f').
     - Checks generated typos against the large dictionary and removes any that are correct words.
     - Can process words directly from the command line or from a text file.

--- a/multitool.py
+++ b/multitool.py
@@ -7267,7 +7267,7 @@ MODE_DETAILS = {
     },
     "anomalies": {
         "summary": "Finds structural word errors",
-        "description": "Finds words with structural irregularities like sticky shift (HEllow), accidental caps (gIT), mid-word numbers (w0rd), or bumpy casing (pyTHon). This catches common finger-slips without needing a dictionary.",
+        "description": "Finds words with structural irregularities like sticky shift (HEllow), accidental caps (gIT), mid-word numbers (w0rd), or bumpy casing (pyTHon). This catches common typing errors without needing a dictionary.",
         "example": "python multitool.py anomalies src/ --output-format arrow",
         "flags": "[FILES...] [-d DELIM] [-S]",
     },


### PR DESCRIPTION
This PR standardizes the project's terminology by replacing the technical jargon "finger-slips" with "typing errors" across documentation and internal help strings.

### Changes:
- **README.md:** Updated the tools overview table.
- **multitool.py:** Updated the description for the `anomalies` mode in the `MODE_DETAILS` dictionary.
- **gentypos.py:** Updated the module docstring.

### Reasoning:
The term "finger-slips" is a colloquial idiom that may be confusing for non-native English speakers. "Typing errors" is simpler, clearer, and aligns with the project's goal of maintaining professional, accessible documentation for a global audience. This change was verified using the full test suite (1029 tests passing).

---
*PR created automatically by Jules for task [18132945856481329072](https://jules.google.com/task/18132945856481329072) started by @RainRat*