### PR TITLE
[FEAT] Add 'orphans' mode to find unreferenced files in Markdown projects

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -405,6 +405,10 @@ Use these modes to analyze your data.
   - Checks Markdown files for broken internal anchors (like `#missing-heading`) and missing local file references. It builds a project-wide map of all headings to correctly validate cross-file links.
   - **Example:** `python multitool.py brokenlinks docs/ --output-format arrow`
 
+- **`orphans`**
+  - Checks which files in your project are never referenced by any Markdown link or image. Useful for cleaning up unused assets or documentation.
+  - **Example:** `python multitool.py orphans docs/`
+
 - **`fileinfo`**
   - Gathers metadata such as file size, number of lines, word count, and detected encoding for the specified files.
   - **Example:** `python multitool.py fileinfo . --output-format arrow`

--- a/multitool.py
+++ b/multitool.py
@@ -2692,6 +2692,95 @@ def brokenlinks_mode(
     logging.info(f"[BrokenLinks Mode] Found {len(broken_links)} broken links across {len(input_files)} file(s).")
 
 
+def orphans_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    output_format: str = 'arrow',
+    quiet: bool = False,
+    limit: int | None = None,
+) -> None:
+    """Finds files in the input set that are never referenced by any Markdown link or image."""
+    start_time = time.perf_counter()
+
+    # Normalize all input files to absolute paths for reliable tracking
+    # We only track regular files as potential orphans
+    all_files = {os.path.abspath(f) for f in input_files if os.path.isfile(f)}
+    referenced_files = set()
+
+    total_links = 0
+    markdown_files_count = 0
+
+    for input_file in input_files:
+        if input_file == '-' or not input_file.lower().endswith(('.md', '.markdown')):
+            continue
+
+        markdown_files_count += 1
+        base_dir = os.path.dirname(os.path.abspath(input_file))
+
+        for _, url, _ in _extract_markdown_links_detailed(input_file, quiet=quiet):
+            total_links += 1
+
+            # Skip external links and internal anchors
+            if url.startswith(("http://", "https://", "mailto:", "ftp:", "#", "broken-ref:")):
+                continue
+
+            # Local file reference
+            file_path = url.split('#', 1)[0].split('?', 1)[0]
+            if not file_path:
+                continue
+
+            # Resolve relative path
+            target_path = os.path.normpath(os.path.join(base_dir, file_path))
+            referenced_files.add(target_path)
+
+    # Identify orphans: files in our input set that are not in referenced_files
+    # We convert back to relative paths for display if they were provided as such
+    abs_to_orig = {os.path.abspath(f): f for f in input_files if os.path.isfile(f)}
+
+    orphans = []
+    for abs_path in sorted(all_files):
+        if abs_path not in referenced_files:
+            orphans.append(abs_to_orig[abs_path])
+
+    # Apply limit
+    if limit is not None:
+        orphans = orphans[:limit]
+
+    # Handle output
+    if output_format == 'arrow':
+        use_color = _should_enable_color(sys.stdout) if output_file == '-' else ('FORCE_COLOR' in os.environ and 'NO_COLOR' not in os.environ)
+        c_bold = BOLD if use_color else ""
+        c_blue = BLUE if use_color else ""
+        c_green = GREEN if use_color else ""
+        c_reset = RESET if use_color else ""
+
+        with smart_open_output(output_file) as out:
+            if orphans:
+                out.write(f"\n{c_bold}{c_blue}ORPHANED FILES{c_reset}\n")
+                out.write(f"{c_bold}{c_blue}──────────────{c_reset}\n")
+                for orphan in orphans:
+                    out.write(f"{c_green}{orphan}{c_reset}\n")
+
+            extra_metrics = {
+                "Markdown files scanned": markdown_files_count,
+                "Total links analyzed": total_links,
+            }
+            summary = _format_analysis_summary(
+                len(all_files),
+                orphans,
+                item_label="file",
+                start_time=start_time,
+                use_color=use_color,
+                title="ORPHANS ANALYSIS",
+                extra_metrics=extra_metrics
+            )
+            out.write("\n".join(summary) + "\n")
+    else:
+        write_output(orphans, output_file, output_format, quiet, limit=limit)
+
+    logging.info(f"[Orphans Mode] Found {len(orphans)} orphaned file(s) across {len(input_files)} input path(s).")
+
+
 def links_mode(
     input_files: Sequence[str],
     output_file: str,
@@ -7085,6 +7174,12 @@ MODE_DETAILS = {
         "example": "python multitool.py brokenlinks docs/ --output-format arrow",
         "flags": "[FILES...]",
     },
+    "orphans": {
+        "summary": "Finds files not linked by others",
+        "description": "Checks which files in your project are never referenced by any Markdown link or image. Useful for cleaning up unused assets or documentation.",
+        "example": "python multitool.py orphans docs/",
+        "flags": "[FILES...]",
+    },
     "codeblocks": {
         "summary": "Extracts Markdown code blocks",
         "description": "Finds fenced code blocks in Markdown files (using ``` or ~~~). It saves the code content by default. Use --language to filter by a specific language (for example, 'python') or --pairs to see both language and content.",
@@ -7357,7 +7452,7 @@ def get_mode_summary_text() -> str:
     categories = {
         "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "frontmatter", "md-table", "headings", "toc", "links", "codeblocks", "comments", "json", "yaml", "toml", "xml", "paths", "flatten", "line", "words", "ngrams", "regex"],
         "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "convert", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "swap", "pairs", "scrub", "standardize"],
-        "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "anomalies", "search", "scan", "verify", "fileinfo", "brokenlinks"],
+        "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "anomalies", "search", "scan", "verify", "fileinfo", "brokenlinks", "orphans"],
     }
 
     use_color = _should_enable_color(sys.stdout)
@@ -7949,6 +8044,15 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['brokenlinks']['example']}{RESET}",
     )
     _add_common_mode_arguments(brokenlinks_parser, include_process_output=False)
+
+    orphans_parser = subparsers.add_parser(
+        'orphans',
+        help=MODE_DETAILS['orphans']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['orphans']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['orphans']['example']}{RESET}",
+    )
+    _add_common_mode_arguments(orphans_parser, include_process_output=False)
 
     json_parser = subparsers.add_parser(
         'json',
@@ -9454,6 +9558,16 @@ def main() -> None:
         ),
         'brokenlinks': (
             brokenlinks_mode,
+            {
+                'input_files': args.input,
+                'output_file': args.output,
+                'output_format': output_format,
+                'quiet': args.quiet,
+                'limit': limit,
+            },
+        ),
+        'orphans': (
+            orphans_mode,
             {
                 'input_files': args.input,
                 'output_file': args.output,

--- a/tests/test_multitool_orphans.py
+++ b/tests/test_multitool_orphans.py
@@ -1,0 +1,111 @@
+import os
+import json
+import pytest
+from multitool import orphans_mode
+
+def test_orphans_mode_basic(tmp_path):
+    # Create a project structure
+    doc_dir = tmp_path / "docs"
+    doc_dir.mkdir()
+
+    index_md = doc_dir / "index.md"
+    index_md.write_text("See [Guide](guide.md) and ![Logo](img/logo.png)")
+
+    guide_md = doc_dir / "guide.md"
+    guide_md.write_text("Welcome to the guide. [Back home](index.md)")
+
+    orphan_md = doc_dir / "orphan.md"
+    orphan_md.write_text("I am not linked by anyone.")
+
+    img_dir = doc_dir / "img"
+    img_dir.mkdir()
+    logo_png = img_dir / "logo.png"
+    logo_png.write_text("fake png content")
+
+    unused_png = img_dir / "unused.png"
+    unused_png.write_text("unused fake png")
+
+    output_file = tmp_path / "output.json"
+
+    # We pass all files as input_files
+    input_files = [
+        str(index_md),
+        str(guide_md),
+        str(orphan_md),
+        str(logo_png),
+        str(unused_png)
+    ]
+
+    orphans_mode(
+        input_files=input_files,
+        output_file=str(output_file),
+        output_format='json',
+        quiet=True
+    )
+
+    with open(output_file, "r") as f:
+        orphans = json.load(f)
+
+    # Expected orphans: orphan.md and unused.png
+    assert len(orphans) == 2
+    assert any(o.endswith("orphan.md") for o in orphans)
+    assert any(o.endswith("unused.png") for o in orphans)
+    assert not any(o.endswith("index.md") for o in orphans)
+    assert not any(o.endswith("guide.md") for o in orphans)
+    assert not any(o.endswith("logo.png") for o in orphans)
+
+def test_orphans_mode_no_orphans(tmp_path):
+    doc_dir = tmp_path / "docs"
+    doc_dir.mkdir()
+
+    index_md = doc_dir / "index.md"
+    index_md.write_text("[About](about.md)")
+
+    about_md = doc_dir / "about.md"
+    about_md.write_text("[Back](index.md)")
+
+    output_file = tmp_path / "output.json"
+
+    input_files = [str(index_md), str(about_md)]
+
+    orphans_mode(
+        input_files=input_files,
+        output_file=str(output_file),
+        output_format='json',
+        quiet=True
+    )
+
+    with open(output_file, "r") as f:
+        orphans = json.load(f)
+
+    assert orphans == []
+
+def test_orphans_mode_arrow(tmp_path, capsys):
+    doc_dir = tmp_path / "docs"
+    doc_dir.mkdir()
+
+    index_md = doc_dir / "index.md"
+    index_md.write_text("[Link](linked.md)")
+
+    linked_md = doc_dir / "linked.md"
+    linked_md.write_text("Linked")
+
+    orphan_md = doc_dir / "orphan.md"
+    orphan_md.write_text("Orphan")
+
+    input_files = [str(index_md), str(linked_md), str(orphan_md)]
+
+    # Run in arrow mode to stdout
+    orphans_mode(
+        input_files=input_files,
+        output_file='-',
+        output_format='arrow',
+        quiet=True
+    )
+
+    captured = capsys.readouterr()
+    assert "ORPHANED FILES" in captured.out
+    assert "orphan.md" in captured.out
+    assert "index.md" in captured.out
+    assert "linked.md" not in captured.out
+    assert "ORPHANS ANALYSIS" in captured.out


### PR DESCRIPTION
The `orphans` mode is a logical extension of the existing Markdown processing capabilities in `multitool.py`. While `brokenlinks` identifies dead links, `orphans` identifies dead *files*—assets or documentation pages that are no longer being used. 

This tool is zero-configuration and provides immediate value for project hygiene, helping developers keep their documentation directories clean.

Supported features:
- Scan for relative links and image references in Markdown.
- Support for multiple output formats (arrow, json, csv, line).
- Colorized terminal output with analysis metrics.
- Automated path resolution for reliable matching.

---
*PR created automatically by Jules for task [10729174747438966802](https://jules.google.com/task/10729174747438966802) started by @RainRat*