### PR TITLE
Fix literal backreference interpretation in replace_mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -5838,11 +5838,21 @@ def replace_mode(
             file_replacements = 0
 
             # Define replacement function outside the loop for performance
-            if regex and smart_case:
-                def repl_func(match):
-                    # Handle backreferences by expanding them first
-                    expanded = match.expand(new_text)
-                    return _apply_smart_case(match.group(0), expanded)
+            if regex:
+                if use_regex:
+                    if smart_case:
+                        def repl_func(match):
+                            # Handle backreferences by expanding them first
+                            expanded = match.expand(new_text)
+                            return _apply_smart_case(match.group(0), expanded)
+                    else:
+                        repl_func = new_text
+                else:
+                    # Literal replacement, even if using regex internally for case-insensitivity
+                    if smart_case:
+                        repl_func = lambda m: _apply_smart_case(m.group(0), new_text)
+                    else:
+                        repl_func = lambda _: new_text
             else:
                 repl_func = new_text
 


### PR DESCRIPTION
This PR fixes a bug in the `replace` mode of `multitool.py` where literal replacement strings containing backslashes (e.g., `\1`) were being incorrectly interpreted as regex backreferences when `--ignore-case` or `--smart-case` was enabled.

The fix involves using a lambda function for the replacement argument in `re.subn` when literal replacement is intended. This prevents the regex engine from scanning the replacement string for backreferences.

Key changes:
- Updated `replace_mode` logic to distinguish between explicit regex mode and internal regex usage for literal searches.
- Guaranteed literal replacement behavior when `--regex` is not used, even with case-insensitive or smart-case matching.
- Verified that explicit `--regex` mode still correctly supports backreferences and smart-casing of those backreferences.

This is a non-breaking change that aligns the tool's behavior with user expectations for literal text substitution.

---
*PR created automatically by Jules for task [16204142526148786194](https://jules.google.com/task/16204142526148786194) started by @RainRat*