### PR TITLE
Standardize line ending logic across transformation modes

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -770,7 +770,9 @@ def write_output(
             outfile.write(pretty_xml)
         else:  # 'line' or fallback
             for item in items_list:
-                outfile.write(item + '\n')
+                outfile.write(item)
+                if not item.endswith('\n'):
+                    outfile.write('\n')
 
 
 def _write_structured_data(
@@ -5876,7 +5878,7 @@ def replace_mode(
                     dry_run=dry_run
                 )
             elif not diff:
-                accumulated_lines.extend([l.rstrip('\n') for l in modified_lines])
+                accumulated_lines.extend(modified_lines)
 
     if pbar:
         pbar.close()
@@ -6100,11 +6102,7 @@ def standardize_mode(
         if dry_run:
             logging.warning(f"[Dry Run] Total replacements that would be made: {total_replacements}. Processing time: {duration:.3f}s")
         elif not diff:
-            with smart_open_output(output_file) as out:
-                for line in accumulated_lines:
-                    out.write(line)
-                    if not line.endswith('\n'):
-                        out.write('\n')
+            write_output(accumulated_lines, output_file, 'line', quiet)
 
             c_tag, c_count, c_reset = _get_status_colors()
             logging.info(
@@ -6196,11 +6194,7 @@ def scrub_mode(
         if dry_run:
             logging.warning(f"[Dry Run] Total replacements that would be made: {total_replacements}. Processing time: {duration:.3f}s")
         elif not diff:
-            with smart_open_output(output_file) as out:
-                for line in accumulated_lines:
-                    out.write(line)
-                    if not line.endswith('\n'):
-                        out.write('\n')
+            write_output(accumulated_lines, output_file, 'line', quiet)
 
             c_tag, c_count, c_reset = _get_status_colors()
             logging.info(

--- a/tests/test_multitool_codeblocks.py
+++ b/tests/test_multitool_codeblocks.py
@@ -136,6 +136,6 @@ def test_codeblocks_mode_process_output_and_length_skip(tmp_path):
     # "longblock\n" has length 10. "sh\n" has length 3.
     # min_length=5, so "sh\n" is skipped (triggers line 2258).
     # process_output=True, so "longblock\n" is de-duplicated (triggers line 2266).
-    # Note: write_output appends a newline to each item.
-    # "longblock\n" -> saved as "longblock\n\n"
-    assert content == ["longblock", ""]
+    # Note: write_output ensures each item has a newline.
+    # "longblock\n" already has one, so it is preserved as "longblock\n"
+    assert content == ["longblock"]


### PR DESCRIPTION
This PR refactors `multitool.py` to centralize and standardize how line endings are handled across the `replace`, `scrub`, and `standardize` transformation modes.

### Changes:
- **`write_output` Enhancement:** The 'line' format handler now explicitly checks if a line already ends with a newline character before appending one. This ensures that strings already containing line endings (standard for file-reading operations) are written correctly without doubling the newlines.
- **Redundancy Removal:** Removed a redundant `.rstrip('\n')` call in `replace_mode`. Previously, this mode was stripping newlines only to have them re-added by `write_output`, which was inefficient and inconsistent with other modes.
- **Logic Consolidation:** Replaced manual `out.write` loops in `standardize_mode` and `scrub_mode` with calls to the unified `write_output` helper.
- **Test Alignment:** Updated `tests/test_multitool_codeblocks.py` to reflect the improved and consistent newline handling.

### Benefits:
- **Maintainability:** Reduces code duplication by using a single source of truth for line-writing logic.
- **Correctness:** Fixes a minor logic bug where `write_output` would produce double newlines if input strings already contained them.
- **Consistency:** Ensures all transformation modes behave identically regarding output formatting and line endings.

No breaking changes were introduced, and all 1,030 existing tests pass.

---
*PR created automatically by Jules for task [17395734289526206517](https://jules.google.com/task/17395734289526206517) started by @RainRat*