### PR TITLE
Fix literal backslash handling in replace mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -5838,11 +5838,18 @@ def replace_mode(
             file_replacements = 0
 
             # Define replacement function outside the loop for performance
-            if regex and smart_case:
-                def repl_func(match):
-                    # Handle backreferences by expanding them first
-                    expanded = match.expand(new_text)
-                    return _apply_smart_case(match.group(0), expanded)
+            if regex:
+                if smart_case:
+                    def repl_func(match):
+                        # Handle backreferences by expanding them first if regex mode is on
+                        expanded = match.expand(new_text) if use_regex else new_text
+                        return _apply_smart_case(match.group(0), expanded)
+                elif not use_regex:
+                    # For literal replacement with internal regex (e.g. ignore-case)
+                    # use a lambda to prevent re.sub from interpreting backslashes.
+                    repl_func = lambda m: new_text
+                else:
+                    repl_func = new_text
             else:
                 repl_func = new_text
 


### PR DESCRIPTION
* **What:** Modified `replace_mode` in `multitool.py` to use a lambda function for replacements when `--regex` is not enabled, even if an internal regex is used for `--ignore-case` or `--smart-case`. This ensures that backslashes in the replacement string (e.g., `\1`) are treated as literal characters rather than regex backreferences.
* **Why:** Previously, literal replacements with casing flags would fail or produce incorrect results if the replacement string contained backslashes, because `re.sub` would attempt to interpret them as capturing group references. This fix restores the expected behavior for literal replacements while preserving the intended backreference functionality for explicit regex searches. No breaking changes were introduced.

---
*PR created automatically by Jules for task [17821121619614171267](https://jules.google.com/task/17821121619614171267) started by @RainRat*