### PR TITLE
[DOCS] Standardize "finger-slips" to "typing errors" for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The **diff2typo Suite** is a set of tools to help you find and fix typos in your
 | **gentypos** | Creates lists of likely typos based on common typing errors. | [Read Docs](docs/gentypos.md) |
 | **multitool** | A multipurpose tool for cleaning, getting, and analyzing text, files, and paths. | [Read Docs](docs/multitool.md) |
 | **cmdrunner** | Runs commands across many folders at once. | [Read Docs](docs/cmdrunner.md) |
-| **typostats** | Analyzes your typos to find common finger-slips. | [Read Docs](docs/typostats.md) |
+| **typostats** | Analyzes your typos to find common typing errors. | [Read Docs](docs/typostats.md) |
 
 ## 🚀 Quick Start
 

--- a/gentypos.py
+++ b/gentypos.py
@@ -8,7 +8,7 @@ Purpose:
 
 Features:
     - Generates typos based on common typing patterns (skipping letters, swapping neighbors, and so on).
-    - Uses keyboard adjacency to predict likely finger-slips on a QWERTY layout.
+    - Uses keyboard adjacency to predict likely typing errors on a QWERTY layout.
     - Supports custom substitution rules for specific character patterns (for example, 'ph' -> 'f').
     - Checks generated typos against the large dictionary and removes any that are correct words.
     - Can process words directly from the command line or from a text file.

--- a/multitool.py
+++ b/multitool.py
@@ -7267,7 +7267,7 @@ MODE_DETAILS = {
     },
     "anomalies": {
         "summary": "Finds structural word errors",
-        "description": "Finds words with structural irregularities like sticky shift (HEllow), accidental caps (gIT), mid-word numbers (w0rd), or bumpy casing (pyTHon). This catches common finger-slips without needing a dictionary.",
+        "description": "Finds words with structural irregularities like sticky shift (HEllow), accidental caps (gIT), mid-word numbers (w0rd), or bumpy casing (pyTHon). This catches common typing errors without needing a dictionary.",
         "example": "python multitool.py anomalies src/ --output-format arrow",
         "flags": "[FILES...] [-d DELIM] [-S]",
     },


### PR DESCRIPTION
**PR Title:** [DOCS] Standardize "finger-slips" to "typing errors" for clarity

**Description:**
* **Type:** Documentation / Internal Help
* **What:** Updated terminology in `README.md`, `multitool.py` (anomalies mode), and `gentypos.py` (features section).
* **Why:** The term "finger-slips" is an idiom that may be confusing for an international audience or non-native English speakers. Replacing it with "typing errors" uses Plain English, making the documentation more accessible and easier to understand.

---
*PR created automatically by Jules for task [6947125228001061043](https://jules.google.com/task/6947125228001061043) started by @RainRat*