### PR TITLE
[UI/UX] Improve CLI help clarity with option metavars

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -7796,9 +7796,15 @@ def show_mode_help(mode_name: str | None, parser: argparse.ArgumentParser) -> No
                     option_flags = ", ".join(action.option_strings)
                     metavar = ""
                     if action.metavar:
-                        metavar = f" {action.metavar}"
+                        if isinstance(action.metavar, tuple):
+                            metavar = f" {' '.join(map(str, action.metavar))}"
+                        else:
+                            metavar = f" {action.metavar}"
                     elif action.choices:
                         metavar = f" {{{','.join(map(str, action.choices))}}}"
+                    elif not isinstance(action, (argparse._StoreTrueAction, argparse._StoreFalseAction, argparse._CountAction, argparse._HelpAction, argparse._VersionAction)):
+                        # Standard argparse behavior: use dest.upper() if no metavar provided
+                        metavar = f" {action.dest.upper()}"
 
                     option_help = action.help or ""
                     group_actions.append((option_flags + metavar, option_help))
@@ -7806,8 +7812,8 @@ def show_mode_help(mode_name: str | None, parser: argparse.ArgumentParser) -> No
                 if group_actions:
                     block.append(f"\n{label_color}{group.title + ':':<15}{RESET}")
 
-                    flag_col_width = 30
-                    help_indent_width = 35 # 2 (initial indent) + 30 (flag_col) + 3 (gap)
+                    flag_col_width = 34
+                    help_indent_width = 39 # 2 (initial indent) + 34 (flag_col) + 3 (gap)
                     help_indent = ' ' * help_indent_width
 
                     for flags, help_text in group_actions:


### PR DESCRIPTION
### context: CLI
### problem:
The mode-specific help output (e.g., `python multitool.py help search`) displayed flags but lacked clear indicators for the arguments those flags expected (missing metavars). For instance, it would show `-Q, --query` instead of the more informative `-Q, --query QUERY`.

### solution:
I updated the `show_mode_help` function in `multitool.py` to extract and display metavars for each option. The implementation:
- Correctly handles tuple metavars (e.g., for modes like `zip`).
- Implements a fallback to the standard `argparse` behavior of using the destination name in uppercase when an explicit metavar is absent.
- Filters out 0-argument actions (like boolean flags) to ensure they don't incorrectly show metavars.
- Increases the layout's column width to maintain clean vertical alignment for the now-longer flag strings.

These changes improve **Feedback & Clarity** by making it immediately obvious what input is required for each command-line option.

---
*PR created automatically by Jules for task [8231439547475782437](https://jules.google.com/task/8231439547475782437) started by @RainRat*