### PR TITLE
[DOCS] Standardize terminology for nearby key errors

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -102,14 +102,14 @@ This section breaks down every mistake:
 - **Correction:** The character you intended to type.
 - **Count:** How many times this specific mistake happened.
 - **%:** What percentage of all found replacements this mistake represents.
-- **Attr:** Special markers showing the type of mistake (for example, `[K]` for keyboard slip).
+- **Attr:** Special markers showing the type of mistake (for example, `[K]` for nearby key error).
 - **Visual:** A high-resolution bar chart for quick comparison.
 
 For example, a row showing `eh │ he` means you swapped the letters `h` and `e`.
 
 ### Typo Attributes (Attr)
 When you enable analysis features, the tool finds specific patterns in the **Attr** column:
-- **[K]**: Keyboard slip (the keys are next to each other on a QWERTY layout).
+- **[K]**: Nearby key error (the keys are next to each other on a QWERTY layout).
 - **[T]**: Transposition (swapped letters, like `teh` instead of `the`).
 - **[1:2]**: One-to-two replacement (for example, typing `rn` instead of `m`, or `ph` instead of `f`).
 - **[2:1]**: Two-to-one replacement (for example, typing `m` instead of `rn`, or `f` instead of `ph`).

--- a/gentypos.py
+++ b/gentypos.py
@@ -831,7 +831,7 @@ def main() -> None:
     """
     # Parse command-line arguments
     parser = argparse.ArgumentParser(
-        description=f"{BOLD}Create lists of common typing mistakes by simulating keyboard slips and common patterns like swapping, skipping, or doubling letters.{RESET}",
+        description=f"{BOLD}Create lists of common typing mistakes by simulating nearby key errors and common patterns like swapping, skipping, or doubling letters.{RESET}",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=f"""{BLUE}Examples:{RESET}
   {GREEN}python gentypos.py "hello" "world"{RESET}

--- a/tests/test_multitool_standardize_filters.py
+++ b/tests/test_multitool_standardize_filters.py
@@ -12,7 +12,7 @@ def run_multitool(args):
 def test_standardize_filters():
     test_file = 'test_standardize.txt'
     with open(test_file, 'w') as f:
-        # 'above' is frequent, 'abovf' is rare and a keyboard slip (f is next to e)
+        # 'above' is frequent, 'abovf' is rare and a nearby key error (f is next to e)
         # 'the' is frequent, 'teh' is rare and a transposition
         content = (
             "above above above above above above above above above above\n"

--- a/typostats.py
+++ b/typostats.py
@@ -327,7 +327,7 @@ def get_adjacent_keys(include_diagonals: bool = True) -> dict[str, set[str]]:
     """
     Creates a map of keys that are next to each other on a QWERTY keyboard.
 
-    This is used to find typos caused by a finger slipping to a nearby key.
+    This is used to find typos caused by hitting a nearby key.
 
     Args:
         include_diagonals: Whether to count keys that are diagonal to each other.
@@ -1050,7 +1050,7 @@ def main() -> None:
         epilog=f"""{BLUE}Examples:{RESET}
   {GREEN}python typostats.py typos.txt -t{RESET}          # Find swapped letters (like 'teh' -> 'the')
   {GREEN}python typostats.py typos.txt --1to2 --2to1{RESET}  # Find multi-letter mistakes (like 'rn' -> 'm')
-  {GREEN}python typostats.py typos.txt -k -n 20{RESET}       # Find top 20 keyboard slips
+  {GREEN}python typostats.py typos.txt -k -n 20{RESET}       # Find top 20 nearby key errors
   {GREEN}python typostats.py typos.txt -a{RESET}             # Run all analysis modes at once
 """,
     )


### PR DESCRIPTION
* **Type:** Documentation / Internal Help / Code Comments
* **What:** Standardized the terminology for typing errors caused by hitting keys next to each other on the keyboard across `typostats.py`, `gentypos.py`, `docs/typostats.md`, and test suite comments.
* **Why:** Replaced idiomatic jargon like "finger-slip" and "keyboard slip" with the clearer, more literal "nearby key error" (or "hitting a nearby key") to improve accessibility for a global audience, following Plain English guidelines.

---
*PR created automatically by Jules for task [443400693961513385](https://jules.google.com/task/443400693961513385) started by @RainRat*