### PR TITLE
[UI/UX] Improve CLI mode-specific help with descriptive metavars and better alignment

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -7796,9 +7796,15 @@ def show_mode_help(mode_name: str | None, parser: argparse.ArgumentParser) -> No
                     option_flags = ", ".join(action.option_strings)
                     metavar = ""
                     if action.metavar:
-                        metavar = f" {action.metavar}"
+                        if isinstance(action.metavar, tuple):
+                            metavar = f" {' '.join(map(str, action.metavar))}"
+                        else:
+                            metavar = f" {action.metavar}"
                     elif action.choices:
                         metavar = f" {{{','.join(map(str, action.choices))}}}"
+                    elif action.nargs != 0:
+                        # Use destination name as default metavar if it's not a boolean flag
+                        metavar = f" {action.dest.upper().replace('_', '-')}"
 
                     option_help = action.help or ""
                     group_actions.append((option_flags + metavar, option_help))
@@ -7806,8 +7812,8 @@ def show_mode_help(mode_name: str | None, parser: argparse.ArgumentParser) -> No
                 if group_actions:
                     block.append(f"\n{label_color}{group.title + ':':<15}{RESET}")
 
-                    flag_col_width = 30
-                    help_indent_width = 35 # 2 (initial indent) + 30 (flag_col) + 3 (gap)
+                    flag_col_width = 34
+                    help_indent_width = 39 # 2 (initial indent) + 34 (flag_col) + 3 (gap)
                     help_indent = ' ' * help_indent_width
 
                     for flags, help_text in group_actions:


### PR DESCRIPTION
### Context
CLI (multitool.py)

### Problem
The mode-specific help output (e.g., `python multitool.py help scan`) was often missing descriptive placeholders (metavars) for options that require values. This left users guessing whether a flag like `--mapping` needed an argument or was a simple boolean toggle. Furthermore, the previous column widths were too narrow for some flag/metavar combinations, leading to cluttered or wrapped output that broke the visual hierarchy.

### Solution
I implemented exactly one specific UI improvement to the CLI's help system:
1.  **Descriptive Metavars:** Updated the help generation logic to automatically derive metavars from the argument's destination name when an explicit one isn't provided. This aligns with standard POSIX and `argparse` behavior (e.g., `--mapping` now shows as `--mapping MAPPING`).
2.  **Tuple Support:** Added logic to correctly render tuple-based metavars (e.g., `OLD NEW`) used for multi-positional or complex arguments.
3.  **Enhanced Visual Alignment:** Increased the flag column width from 30 to 34 characters and the help indentation from 35 to 39. This provides the necessary breathing room for longer flag-metavar pairs, ensuring that descriptions stay cleanly aligned in their own column without excessive wrapping.

These changes significantly reduce friction for users exploring the tool's many modes by providing immediate, clear feedback on command usage.

---
*PR created automatically by Jules for task [5283344762310257371](https://jules.google.com/task/5283344762310257371) started by @RainRat*