### PR TITLE
Consolidate Markdown link extraction and support reference links in `links` mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -1793,19 +1793,6 @@ def _extract_markdown_headings(input_file: str, quiet: bool = False) -> Iterable
             yield level, text
 
 
-def _extract_markdown_links(input_file: str, quiet: bool = False) -> Iterable[Tuple[str, str]]:
-    """Yield (text, url) for each Markdown link or image."""
-    lines = _read_file_lines_robust(input_file)
-    # Match [text](url) or ![alt](url)
-    pattern = re.compile(r'!?\[(.*?)\]\((.*?)\)')
-
-    for line in tqdm(lines, desc=f'Processing {input_file} (links)', unit=' lines', disable=quiet):
-        for match in pattern.finditer(line):
-            text = match.group(1).strip()
-            url = match.group(2).strip()
-            yield text, url
-
-
 def _extract_markdown_links_detailed(input_file: str, quiet: bool = False) -> Iterable[Tuple[str, str, int]]:
     """Yield (text, url, line_number) for each Markdown link, image, and reference."""
     lines = _read_file_lines_robust(input_file)
@@ -1822,7 +1809,7 @@ def _extract_markdown_links_detailed(input_file: str, quiet: bool = False) -> It
     references = {}
     extracted_links = []
 
-    for i, line in enumerate(lines):
+    for i, line in enumerate(tqdm(lines, desc=f'Processing {input_file} (links)', unit=' lines', disable=quiet)):
         line_num = i + 1
 
         # Extract reference definitions first
@@ -2887,7 +2874,7 @@ def links_mode(
     total_links = 0
 
     for input_file in input_files:
-        for l_text, l_url in _extract_markdown_links(input_file, quiet=quiet):
+        for l_text, l_url, _ in _extract_markdown_links_detailed(input_file, quiet=quiet):
             total_links += 1
 
             # Apply cleaning and filtering to the text side by default

--- a/tests/test_links_reference.py
+++ b/tests/test_links_reference.py
@@ -1,0 +1,47 @@
+import pytest
+from multitool import main
+import sys
+import os
+
+def test_links_mode_reference(tmp_path, capsys):
+    # Create a test markdown file with reference-style links
+    md_file = tmp_path / "refs.md"
+    md_file.write_text("Check [this][1] and [that][].\n\n[1]: https://example.com\n[that]: https://that.com")
+
+    # Run links mode
+    sys.argv = ["multitool.py", "links", str(md_file), "--raw"]
+    main()
+
+    captured = capsys.readouterr()
+    assert "this" in captured.out
+    assert "that" in captured.out
+
+def test_links_mode_reference_right(tmp_path, capsys):
+    md_file = tmp_path / "refs.md"
+    md_file.write_text("Check [this][1].\n\n[1]: https://example.com")
+
+    sys.argv = ["multitool.py", "links", str(md_file), "--right"]
+    main()
+
+    captured = capsys.readouterr()
+    assert "https://example.com" in captured.out
+
+def test_links_mode_reference_pairs(tmp_path, capsys):
+    md_file = tmp_path / "refs.md"
+    md_file.write_text("[Test][1]\n\n[1]: https://test.com")
+
+    sys.argv = ["multitool.py", "links", str(md_file), "--pairs", "--raw"]
+    main()
+
+    captured = capsys.readouterr()
+    assert "Test -> https://test.com" in captured.out
+
+def test_links_mode_broken_reference(tmp_path, capsys):
+    md_file = tmp_path / "refs.md"
+    md_file.write_text("[Broken][2]")
+
+    sys.argv = ["multitool.py", "links", str(md_file), "--right"]
+    main()
+
+    captured = capsys.readouterr()
+    assert "broken-ref:2" in captured.out


### PR DESCRIPTION
* **What:** Removed the redundant `_extract_markdown_links` function and updated `links_mode` to use `_extract_markdown_links_detailed`. Enhanced `_extract_markdown_links_detailed` with a `tqdm` progress bar to maintain UI consistency. Added a new test suite `tests/test_links_reference.py`.
* **Why:** This consolidation removes code duplication while simultaneously improving the functionality of the `links` mode by adding support for Markdown reference-style links (e.g., `[text][label]`). The external behavior for standard inline links remains identical, ensuring no breaking changes.

---
*PR created automatically by Jules for task [1071644799865444297](https://jules.google.com/task/1071644799865444297) started by @RainRat*