### PR TITLE
Fix shell injection in cmdrunner.py

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import shlex
 try:
     import yaml
     _YAML_AVAILABLE = True
@@ -138,7 +139,7 @@ def run_command_in_folders(
     # Iterate through each item in the main folder
     for item in iterator:
         item_path = os.path.join(main_folder, item)
-        current_command = command.replace("{}", item)
+        current_command = command.replace("{}", shlex.quote(item))
 
         if dry_run:
             logging.warning(f"Dry run: would run command '{current_command}' in '{item}'")


### PR DESCRIPTION
* **What:** Use `shlex.quote` to sanitize folder names before they are substituted into the command string in `run_command_in_folders`.
* **Why:** This prevents shell injection vulnerabilities when `cmdrunner.py` processes directories with malicious names (e.g., containing semicolons or other shell metacharacters). It also improves robustness for directory names containing spaces. No breaking changes were introduced; existing behavior for normal folder names remains identical.

---
*PR created automatically by Jules for task [10308900851612849020](https://jules.google.com/task/10308900851612849020) started by @RainRat*