### PR TITLE
[UI/UX] Increase summary width in help table to reduce truncation

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -7802,7 +7802,7 @@ def get_mode_summary_text() -> str:
     width_mode = max((len(m) for m in all_modes), default=15)
 
     # Summary width - we allow some growth but cap it to keep the table readable
-    width_summary = 35
+    width_summary = 45
 
     # Flags width - dynamic based on content
     width_flags = max((len(MODE_DETAILS[m].get('flags', '')) for m in all_modes), default=15)

--- a/tests/test_multitool_coverage_final_gaps_robust.py
+++ b/tests/test_multitool_coverage_final_gaps_robust.py
@@ -22,7 +22,7 @@ def test_count_mode_quiet_stdout_no_stderr(tmp_path, capsys):
     assert captured.err == ""
 
 def test_get_mode_summary_text_truncation(monkeypatch):
-    long_summary = "This is a very long summary that definitely exceeds the thirty-five character limit."
+    long_summary = "This is a very long summary that definitely exceeds the forty-five character limit. It should be truncated."
 
     orig_details = multitool.MODE_DETAILS.copy()
     new_details = orig_details.copy()
@@ -33,7 +33,7 @@ def test_get_mode_summary_text_truncation(monkeypatch):
 
     output = multitool.get_mode_summary_text()
 
-    # The tool now uses a 35-character width for summaries
-    expected_truncated = long_summary[:35-3] + "..."
+    # The tool now uses a 45-character width for summaries
+    expected_truncated = long_summary[:45-3] + "..."
     assert expected_truncated in output
     assert long_summary not in output


### PR DESCRIPTION
This PR improves the visibility of mode descriptions in the global help summary table of `multitool.py`.

* **Context:** CLI (Command Line Interface)
* **Problem:** Many mode descriptions were being aggressively truncated because of a narrow 35-character width limit, leading to loss of context for the user.
* **Solution:** Increased the `width_summary` from 35 to 45 characters. This allows most descriptions to be fully visible while still keeping the overall table well-aligned and readable within standard terminal widths.
* **Consistency:** Updated `tests/test_multitool_coverage_final_gaps_robust.py` to ensure test expectations align with the new width.

---
*PR created automatically by Jules for task [4783594033227112362](https://jules.google.com/task/4783594033227112362) started by @RainRat*