### PR TITLE
[DOCS] Document unzip mode in multitool.md

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -253,6 +253,11 @@ Use these modes to transform or combine your data.
   - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, `toml`, and `xml`.
   - **Example:** `python multitool.py zip typos.txt --file2 corrections.txt --output-format arrow`
 
+- **`unzip`**
+  - Splits paired data into two lists by extracting one side. It saves the left side by default.
+  - **Options:** Use the `--right` flag to save the right side instead.
+  - **Example:** `python multitool.py unzip typos.csv --right --output corrections.txt`
+
 - **`swap`**
   - Reverses the order of elements in paired data (for example, `typo -> correction` becomes `correction -> typo`).
   - **Supported Formats:** `arrow`, `table`, `csv`, `markdown`, `md-table`, `json`, `yaml`, `toml`, and `xml`.


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Added a new section for the `unzip` mode in `docs/multitool.md`, located in the "CHANGE DATA" category.
* **Why:** To ensure that all available `multitool.py` features are properly documented and discoverable for users. The `unzip` mode was previously missing from the Markdown documentation despite being fully implemented in the code.

---
*PR created automatically by Jules for task [11341476749874846359](https://jules.google.com/task/11341476749874846359) started by @RainRat*