### PR TITLE
[DOCS] Document paragraphs mode and count option in multitool

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -139,6 +139,10 @@ Use these modes to pull specific data from a file.
   - Extracts individual sentences from a file using a regex-based heuristic. It handles multi-line sentences by joining lines with spaces before splitting.
   - **Example:** `python multitool.py sentences report.txt --output sentences.txt`
 
+- **`paragraphs`**
+  - Extracts blocks of text separated by one or more blank lines. It automatically joins multi-line blocks into single lines and cleans up extra whitespace.
+  - **Example:** `python multitool.py paragraphs report.txt --output paragraphs.txt`
+
 - **`ngrams`**
   - Extracts sequences of words. This is useful for finding phrases or context around typos. It supports sequences across line boundaries.
   - **Options:** Use `-n` to pick the number of words in each sequence (default is 2). Like the `words` mode, it supports custom delimiters and smart word splitting.
@@ -312,7 +316,7 @@ Use these modes to analyze your data.
   - **Example:** `python multitool.py conflict mappings.csv`
 
 - **`count`**
-  - Counts how often each word, pair, line, or character appears. It sorts the list by frequency.
+  - Counts how often each word, pair, line, character, or paragraph appears. It sorts the list by frequency.
   - **Options:**
     - `--min-count` and `--max-count`: Filter results by frequency.
     - `-d`, `--delimiter`: The character to split words by (default: whitespace).
@@ -321,6 +325,7 @@ Use these modes to analyze your data.
     - `-l`, `--lines`: Count frequencies of raw lines.
     - `-c`, `--chars`: Count frequencies of individual characters.
     - `-E`, `--sentences`: Count frequencies of individual sentences.
+    - `-G`, `--paragraphs`: Count frequencies of individual paragraphs.
     - `-B`, `--by-file`: Count how many files contain each item.
   - **Visual Report:** Use `--output-format arrow` for a rich report with metrics and bar charts.
   - **Supported Formats:** `arrow`, `json`, `csv`, `markdown`, `md-table`, `line`, and `xml`.
@@ -434,7 +439,7 @@ These options work with most modes:
 - `[INPUT_FILES...]`: One or more files to read. Defaults to **standard input** if not provided.
 - `--output` (or **`-o`**): The file to write results to. Defaults to printing to the screen.
 - `--output-format` (or **`-f`**): The format of the output. Options include `line` (default), `json`, `yaml`, `toml`, `csv`, `markdown`, `md-table`, `arrow`, `table`, and `xml`. The tool automatically detects the format from the output file extension.
-- `--min-length` (or **`-m`**): Skip items shorter than this length (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count', and 10 for sentence-based modes).
+- `--min-length` (or **`-m`**): Skip items shorter than this length (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count', 10 for sentence-based modes, and 20 for paragraph-based modes).
 - `--max-length` (or **`-M`**): Skip words longer than this length (default: 1000).
 - `--process-output` (or **`-P`**): Sorts the final list and removes duplicates. Use this to organize your output or remove redundant entries.
 - `--limit` (or **`-L`**): Limit the number of items in the output.


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated `docs/multitool.md` to include documentation for the `paragraphs` data extraction mode and the corresponding `-G`, `--paragraphs` flag in `count` mode. Also updated the `Common Options` section to clarify the default `--min-length` behavior for paragraph-based modes.
* **Why:** These features were implemented in `multitool.py` but missing from the project documentation. Adding them ensures users can find and use these capabilities for analyzing text blocks.

---
*PR created automatically by Jules for task [12968431466585433734](https://jules.google.com/task/12968431466585433734) started by @RainRat*