### PR TITLE
[FEAT] Add extensions mode to multitool.py

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -427,6 +427,10 @@ Use these modes to analyze your data.
   - Identifies files with identical content by computing SHA-256 hashes. It first groups files by size to quickly filter out unique files, then performs full content hashing on potential candidates. It supports large-scale scans and handles standard input.
   - **Example:** `python multitool.py duplicates . --min-length 1024`
 
+- **`extensions`**
+  - Reports a summary of disk usage aggregated by file extension. It calculates the count of files, total size, and percentage of total project size for each extension.
+  - **Example:** `python multitool.py extensions . --output-format arrow`
+
 ## Common Options
 
 These options work with most modes:

--- a/multitool.py
+++ b/multitool.py
@@ -3734,6 +3734,139 @@ def fileinfo_mode(
         logging.info(f"[FileInfo Mode] Processed {len(results)} files in {duration:.3f}s.")
 
 
+def extensions_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    output_format: str = 'arrow',
+    quiet: bool = False,
+    limit: int | None = None,
+) -> None:
+    """Analyzes disk usage aggregated by file extension."""
+    start_time = time.perf_counter()
+    ext_stats = defaultdict(lambda: {"count": 0, "size": 0})
+    total_size = 0
+    total_files = 0
+
+    for path in input_files:
+        if path == '-':
+            continue
+        if not os.path.isfile(path):
+            continue
+
+        try:
+            size = os.path.getsize(path)
+            ext = os.path.splitext(path)[1].lower()
+            if not ext:
+                ext = "(no extension)"
+
+            ext_stats[ext]["count"] += 1
+            ext_stats[ext]["size"] += size
+            total_size += size
+            total_files += 1
+        except Exception as e:
+            logging.warning(f"Failed to get info for '{path}': {e}")
+
+    # Convert to list for sorting and formatting
+    results = []
+    for ext, stats in ext_stats.items():
+        results.append({
+            "extension": ext,
+            "count": stats["count"],
+            "size": stats["size"],
+            "percentage": (stats["size"] / total_size * 100) if total_size > 0 else 0
+        })
+
+    # Sort by size descending
+    results.sort(key=lambda x: x["size"], reverse=True)
+
+    if limit is not None:
+        results = results[:limit]
+
+    if output_format == 'arrow':
+        with smart_open_output(output_file) as out:
+            if not results:
+                return
+
+            headers = ["Extension", "Files", "Size", "%", "Visual"]
+            cols = ["extension", "count", "size", "percentage"]
+
+            # Prep formatted results for display and width calculation
+            display_results = []
+            for res in results:
+                display_results.append({
+                    "extension": res["extension"],
+                    "count": f"{res['count']:,}",
+                    "size": _format_size(res["size"]),
+                    "percentage": f"{res['percentage']:>5.1f}%",
+                    "bar": _render_visual_bar(res["percentage"], 20)
+                })
+
+            max_widths = [len(h) for h in headers]
+            for res in display_results:
+                max_widths[0] = max(max_widths[0], len(str(res["extension"])))
+                max_widths[1] = max(max_widths[1], len(str(res["count"])))
+                max_widths[2] = max(max_widths[2], len(str(res["size"])))
+                max_widths[3] = max(max_widths[3], len(str(res["percentage"])))
+                # Bar is constant 20
+
+            div_len = sum(max_widths[:4]) + 20 + 14
+
+            show_color = _should_enable_color(out)
+            c_bold = BOLD if show_color else ""
+            c_blue = BLUE if show_color else ""
+            c_green = GREEN if show_color else ""
+            c_yellow = YELLOW if show_color else ""
+            c_reset = RESET if show_color else ""
+
+            padding = "  "
+            sep = f"{c_bold}{c_blue}│{c_reset}"
+
+            header_parts = []
+            for i, h in enumerate(headers):
+                width = max_widths[i] if i < 4 else 20
+                header_parts.append(f"{c_bold}{c_blue}{h:<{width}}{c_reset}")
+
+            out.write(f"\n{padding}" + f" {sep} ".join(header_parts) + "\n")
+            out.write(f"{padding}{c_bold}{c_blue}{'─' * div_len}{c_reset}\n")
+
+            for res in display_results:
+                row = (
+                    f"{padding}{c_green}{res['extension']:<{max_widths[0]}}{c_reset} {sep} "
+                    f"{c_yellow}{res['count']:>{max_widths[1]}}{c_reset} {sep} "
+                    f"{c_yellow}{res['size']:>{max_widths[2]}}{c_reset} {sep} "
+                    f"{c_green}{res['percentage']:>{max_widths[3]}}{c_reset} {sep} "
+                    f"{c_blue}{res['bar']}{c_reset}"
+                )
+                out.write(row + "\n")
+            out.write("\n")
+
+            extra_metrics = {
+                "Total files analyzed": f"{total_files:,}",
+                "Total project size": f"{total_size:,} bytes ({_format_size(total_size)})",
+            }
+            summary_lines = _format_analysis_summary(
+                len(input_files),
+                results,
+                item_label="extension",
+                start_time=start_time,
+                use_color=show_color,
+                extra_metrics=extra_metrics,
+                title="EXTENSIONS ANALYSIS SUMMARY"
+            )
+            out.write("\n".join(summary_lines) + "\n")
+    elif output_format == 'csv':
+        with smart_open_output(output_file, newline='') as out:
+            writer = csv.DictWriter(out, fieldnames=["extension", "count", "size", "percentage"])
+            writer.writeheader()
+            writer.writerows(results)
+    else:
+        _write_structured_data(results, output_file, output_format, root_tag="extensions")
+
+    duration = time.perf_counter() - start_time
+    if not quiet:
+        logging.info(f"[Extensions Mode] Analyzed {total_files} files in {duration:.3f}s.")
+
+
 def duplicates_mode(
     input_files: Sequence[str],
     output_file: str,
@@ -7790,6 +7923,12 @@ MODE_DETAILS = {
         "example": "python multitool.py duplicates . --min-length 1024",
         "flags": "[FILES...]",
     },
+    "extensions": {
+        "summary": "Analyzes disk usage by extension",
+        "description": "Reports a summary of disk usage aggregated by file extension. It calculates the count of files, total size, and percentage of total project size for each extension, helping you see which file types consume the most space.",
+        "example": "python multitool.py extensions . --output-format arrow",
+        "flags": "[FILES...]",
+    },
     "scrub": {
         "summary": "Fixes typos in text files",
         "description": "Performs in-place replacements of typos in your text files using a mapping file or extra pairs provided via --add. It tries to preserve the surrounding context (punctuation, whitespace) while fixing errors. It automatically handles compound words like 'CamelCase' and 'snake_case' variables. Supports CSV, Arrow, Table, JSON, YAML, TOML, and XML mapping formats.",
@@ -7846,7 +7985,7 @@ def get_mode_summary_text() -> str:
     categories = {
         "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "frontmatter", "md-table", "headings", "toc", "links", "codeblocks", "comments", "json", "yaml", "toml", "xml", "paths", "flatten", "line", "words", "sentences", "paragraphs", "ngrams", "regex"],
         "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "convert", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "unzip", "swap", "pairs", "scrub", "standardize"],
-        "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "anomalies", "search", "scan", "verify", "fileinfo", "duplicates", "brokenlinks", "orphans"],
+        "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "anomalies", "search", "scan", "verify", "fileinfo", "duplicates", "extensions", "brokenlinks", "orphans"],
     }
 
     use_color = _should_enable_color(sys.stdout)
@@ -9665,6 +9804,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_common_mode_arguments(duplicates_parser, include_process_output=False, include_limit=True)
 
+    extensions_parser = subparsers.add_parser(
+        'extensions',
+        help=MODE_DETAILS['extensions']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['extensions']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['extensions']['example']}{RESET}",
+    )
+    _add_common_mode_arguments(extensions_parser, include_process_output=False, include_limit=True)
+
     resolve_parser = subparsers.add_parser(
         'resolve',
         help=MODE_DETAILS['resolve']['summary'],
@@ -9990,7 +10138,7 @@ def main() -> None:
         # Analysis modes should default to 'arrow' when run in a terminal for better UX
         analysis_modes = {
             'count', 'stats', 'classify', 'similarity', 'near_duplicates',
-            'fuzzymatch', 'discovery', 'casing', 'repeated', 'conflict', 'cycles', 'fileinfo', 'brokenlinks', 'orphans', 'search', 'scan'
+            'fuzzymatch', 'discovery', 'casing', 'repeated', 'conflict', 'cycles', 'fileinfo', 'duplicates', 'extensions', 'brokenlinks', 'orphans', 'search', 'scan'
         }
         if args.mode in analysis_modes and args.output == '-' and sys.stdout.isatty():
             default_format = 'arrow'
@@ -10510,6 +10658,16 @@ def main() -> None:
                 'ignore_case': getattr(args, 'ignore_case', False),
                 'smart_case': getattr(args, 'smart_case', False),
                 'diff': getattr(args, 'diff', False),
+                'limit': limit,
+            }
+        ),
+        'extensions': (
+            extensions_mode,
+            {
+                'input_files': args.input,
+                'output_file': args.output,
+                'output_format': output_format,
+                'quiet': args.quiet,
                 'limit': limit,
             }
         ),

--- a/tests/test_multitool_extensions.py
+++ b/tests/test_multitool_extensions.py
@@ -1,0 +1,135 @@
+import os
+import json
+import csv
+import sys
+from io import StringIO
+import pytest
+from unittest.mock import patch
+import multitool
+from multitool import main
+
+def setup_module(module):
+    # Ensure standard input cache is reset before tests
+    multitool._STDIN_CACHE = None
+
+@pytest.fixture
+def temp_files(tmp_path):
+    # Create some test files with different extensions and sizes
+    d = tmp_path / "test_dir"
+    d.mkdir()
+
+    f1 = d / "file1.txt"
+    f1.write_text("Hello world") # 11 bytes
+
+    f2 = d / "file2.txt"
+    f2.write_text("Test file") # 9 bytes
+
+    f3 = d / "script.py"
+    f3.write_text("print('test')") # 13 bytes
+
+    f4 = d / "no_ext"
+    f4.write_text("Some data") # 9 bytes
+
+    return d
+
+def test_extensions_json_output(temp_files, capsys):
+    test_args = ["multitool.py", "extensions", str(temp_files), "-f", "json"]
+    with patch.object(sys, 'argv', test_args):
+        main()
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    data = json.loads(output)
+    # 3 unique extensions: .py, .txt, (no extension)
+    assert len(data) == 3
+
+    # Sort by extension for consistent testing
+    data.sort(key=lambda x: x["extension"])
+
+    # (no extension) comes before .py because '(' < '.'
+    assert data[0]["extension"] == "(no extension)"
+    assert data[0]["count"] == 1
+    assert data[0]["size"] == 9
+
+    assert data[1]["extension"] == ".py"
+    assert data[1]["count"] == 1
+    assert data[1]["size"] == 13
+
+    assert data[2]["extension"] == ".txt"
+    assert data[2]["count"] == 2
+    assert data[2]["size"] == 20
+
+def test_extensions_csv_output(temp_files, capsys):
+    test_args = ["multitool.py", "extensions", str(temp_files), "-f", "csv"]
+    with patch.object(sys, 'argv', test_args):
+        main()
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    reader = csv.DictReader(StringIO(output))
+    rows = list(reader)
+
+    assert len(rows) == 3
+
+    # Check for presence of expected extensions
+    exts = {row["extension"] for row in rows}
+    assert ".py" in exts
+    assert ".txt" in exts
+    assert "(no extension)" in exts
+
+def test_extensions_arrow_output(temp_files, capsys):
+    test_args = ["multitool.py", "extensions", str(temp_files), "-f", "arrow"]
+    with patch.object(sys, 'argv', test_args):
+        main()
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    assert "Extension" in output
+    assert "Files" in output
+    assert "Size" in output
+    assert ".py" in output
+    assert ".txt" in output
+    assert "(no extension)" in output
+    assert "EXTENSIONS ANALYSIS SUMMARY" in output
+    assert "Total files analyzed:               4" in output
+
+def test_extensions_limit(temp_files, capsys):
+    test_args = ["multitool.py", "extensions", str(temp_files), "-f", "json", "-L", "1"]
+    with patch.object(sys, 'argv', test_args):
+        main()
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    data = json.loads(output)
+    assert len(data) == 1
+    # The largest should be .txt (20 bytes)
+    assert data[0]["extension"] == ".txt"
+
+def test_extensions_no_files(tmp_path, capsys):
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    test_args = ["multitool.py", "extensions", str(empty_dir), "-f", "json"]
+    with patch.object(sys, 'argv', test_args):
+        main()
+
+    captured = capsys.readouterr()
+    # Structured data helper outputs [] for empty list
+    assert captured.out.strip() == "[]"
+
+def test_extensions_help(capsys):
+    test_args = ["multitool.py", "help", "extensions"]
+    with pytest.raises(SystemExit):
+        with patch.object(sys, 'argv', test_args):
+            main()
+
+    captured = capsys.readouterr()
+    # show_mode_help outputs to stderr via parser.exit
+    help_text = captured.err
+    assert "Analyzes disk usage by extension" in help_text
+    assert "USAGE:" in help_text
+    assert "python multitool.py extensions [FILES...] [OPTIONS]" in help_text


### PR DESCRIPTION
This PR introduces a new `extensions` mode to `multitool.py`. This mode provides a summary of disk usage aggregated by file extension, helping users understand the composition of their projects and identify which file types are consuming the most space.

Key features:
- Aggregates file count and total size by extension.
- Calculates the percentage of total project size for each extension.
- Supports rich visual output (`arrow` format) with high-res progress bars.
- Supports structured output formats: `json`, `csv`, `yaml`, etc.
- Handles files without extensions gracefully (labeled as `(no extension)`).
- Case-insensitive extension matching.

Changes:
- Modified `multitool.py`:
  - Added `extensions_mode` function.
  - Updated `MODE_DETAILS` with metadata for the new mode.
  - Added `extensions` to the "CHECK & ANALYZE" category in the global help.
  - Added `extensions` subcommand to the argument parser.
  - Registered `extensions_mode` in the main handler map.
  - Included `extensions` in the list of modes that default to the `arrow` format when run interactively.
- Modified `docs/multitool.md`:
  - Added documentation for the `extensions` mode.
- Added `tests/test_multitool_extensions.py`:
  - New test suite covering various output formats, limits, and edge cases.

---
*PR created automatically by Jules for task [3439678066786436033](https://jules.google.com/task/3439678066786436033) started by @RainRat*