### PR TITLE
[UI/UX] Harmonize mode and flag colors in help summary

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -7923,7 +7923,7 @@ def get_mode_summary_text() -> str:
                     display_flags = display_flags[:width_flags-3] + "..."
 
                 row = (
-                    f"{padding}{c_bold}{c_green}{mode:<{width_mode}}{c_reset} {sep} "
+                    f"{padding}{c_bold}{color}{mode:<{width_mode}}{c_reset} {sep} "
                     f"{summary:<{width_summary}} {sep} "
                     f"{c_yellow}{display_flags:<{width_flags}}{c_reset}"
                 )
@@ -7945,7 +7945,7 @@ def get_mode_summary_text() -> str:
         ("--limit (-L)", "Restrict the number of items in the output")
     ]
     for flag, desc in tips:
-        lines.append(f"{padding}{c_bold}{c_green}{flag:<20}{c_reset} {desc}")
+        lines.append(f"{padding}{c_bold}{c_yellow}{flag:<20}{c_reset} {desc}")
 
     lines.append(f"\n{padding}{c_bold}{c_blue}Note:{c_reset} All modes accept one or more {c_bold}FILES{c_reset} as arguments or read from standard input.")
     lines.append(f"\nRun '{c_bold}python multitool.py help <mode>{c_reset}' for details on a specific mode.\n")


### PR DESCRIPTION
### Context: CLI

### Problem:
The global help table in `multitool.py` displayed all mode names in a hardcoded green color, even though they were grouped into categories with distinct theme colors (Green for 'GET DATA', Yellow for 'CHANGE DATA', and Cyan for 'CHECK & ANALYZE'). This lack of color-coding on the mode names themselves made it harder to visually distinguish between the categories at a glance. Furthermore, flags in the "Quick Tips" section were colored green, while the 'Primary Options' column in the table used yellow, causing a minor visual inconsistency for similar interface elements.

### Solution:
I modified the `get_mode_summary_text` function to harmonize the visual language:
1.  **Semantic Mode Coloring:** The mode names in the summary table now use the color of their respective category. This reinforces the visual hierarchy and makes the table significantly easier to scan for power users looking for a specific type of tool.
2.  **Consistent Flag Coloring:** Flag/option highlighting in the "Quick Tips" section was changed from green to yellow. This ensures that all "parameters" or "options" across the entire help output share the same visual identity (Yellow), distinguishing them from "actions" (Category-colored modes).

These changes adhere to "Invisible Design" and "Efficiency First" principles by polishing the existing interface to improve clarity without adding unnecessary decoration.

---
*PR created automatically by Jules for task [634069504982408787](https://jules.google.com/task/634069504982408787) started by @RainRat*