### PR TITLE
[FEAT] Add 'todo' mode to multitool.py for task extraction

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -101,6 +101,10 @@ Use these modes to pull specific data from a file.
   - Extracts comments from source files. It identifies single-line comments (`#`, `//`, `--`) and multi-line comments (`/* */`, `<!-- -->`, and triple quotes) in various programming and markup languages.
   - **Example:** `python multitool.py comments src/ --output comments.txt`
 
+- **`todo`**
+  - Extracts TODO, FIXME, XXX, BUG, and HACK items from source files. It identifies the text following these markers and cleans up common comment endings.
+  - **Example:** `python multitool.py todo src/ --output tasks.txt`
+
 - **`json`**
   - Extracts values from a JSON file by key. Use dot notation for nested keys (for example, `user.name`). If you do not provide a key, it extracts items from the top level. It automatically handles lists and objects.
   - **Example:** `python multitool.py json report.json --key replacements.typo`

--- a/multitool.py
+++ b/multitool.py
@@ -1978,6 +1978,25 @@ def _extract_comment_items(input_file: str, quiet: bool = False) -> Iterable[str
             yield match.group(1).strip()
 
 
+def _extract_todo_items(input_file: str, quiet: bool = False) -> Iterable[str]:
+    """Yields TODO and FIXME items extracted from a file."""
+    lines = _read_file_lines_robust(input_file)
+    # Common TODO markers: TODO, FIXME, XXX, BUG, HACK
+    # We look for the marker followed by optional colon/whitespace and then the text.
+    todo_pattern = re.compile(r'\b(TODO|FIXME|XXX|BUG|HACK)[:\s]+(.*)', re.IGNORECASE)
+
+    for line in tqdm(lines, desc=f'Processing {input_file} (todo)', unit=' lines', disable=quiet):
+        match = todo_pattern.search(line)
+        if match:
+            text = match.group(2).strip()
+            # If the TODO is at the end of a comment, it might have trailing comment markers
+            # but _process_items/clean_items usually handles that if requested.
+            # However, common markers like */ or --> should be stripped if they are at the end.
+            text = re.sub(r'\s*(\*/|-->|"{3}|\'{3})$', '', text).strip()
+            if text:
+                yield text
+
+
 def _extract_md_table_items(
     input_file: str,
     right_side: bool = False,
@@ -2686,6 +2705,35 @@ def comments_mode(
         clean_items=clean_items,
         limit=limit,
         item_label="comment",
+    )
+
+
+def todo_mode(
+    input_files: Sequence[str],
+    output_file: str,
+    min_length: int,
+    max_length: int,
+    process_output: bool,
+    output_format: str = 'line',
+    quiet: bool = False,
+    clean_items: bool = True,
+    limit: int | None = None,
+) -> None:
+    """Extracts TODO and FIXME items from source files."""
+    _process_items(
+        _extract_todo_items,
+        input_files,
+        output_file,
+        min_length,
+        max_length,
+        process_output,
+        'TODOs',
+        'TODOs extracted successfully.',
+        output_format,
+        quiet,
+        clean_items=clean_items,
+        limit=limit,
+        item_label="todo",
     )
 
 
@@ -7562,6 +7610,12 @@ MODE_DETAILS = {
         "example": "python multitool.py comments src/ --output comments.txt",
         "flags": "[FILES...]",
     },
+    "todo": {
+        "summary": "Extracts TODO and FIXME items",
+        "description": "Finds TODO, FIXME, XXX, BUG, and HACK items in source files. It extracts the text following the marker, cleaning up common comment endings.",
+        "example": "python multitool.py todo src/ --output tasks.txt",
+        "flags": "[FILES...]",
+    },
     "flatten": {
         "summary": "Flattens nested data structures",
         "description": "Transforms nested JSON, YAML, or TOML structures into a flat list of dot-separated paths (for example, 'user.name = value'). It supports multi-document YAML and JSON Lines (JSONL).",
@@ -7844,7 +7898,7 @@ MODE_DETAILS = {
 def get_mode_summary_text() -> str:
     """Return a formatted summary table of all available modes as a string."""
     categories = {
-        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "frontmatter", "md-table", "headings", "toc", "links", "codeblocks", "comments", "json", "yaml", "toml", "xml", "paths", "flatten", "line", "words", "sentences", "paragraphs", "ngrams", "regex"],
+        "GET DATA": ["arrow", "table", "backtick", "quoted", "between", "csv", "markdown", "frontmatter", "md-table", "headings", "toc", "links", "codeblocks", "comments", "todo", "json", "yaml", "toml", "xml", "paths", "flatten", "line", "words", "sentences", "paragraphs", "ngrams", "regex"],
         "CHANGE DATA": ["combine", "unique", "sort", "shuffle", "replace", "unflatten", "convert", "diff", "highlight", "resolve", "align", "rename", "filterfragments", "set_operation", "sample", "map", "case", "zip", "unzip", "swap", "pairs", "scrub", "standardize"],
         "CHECK & ANALYZE": ["count", "check", "conflict", "cycles", "similarity", "near_duplicates", "fuzzymatch", "stats", "classify", "discovery", "casing", "repeated", "anomalies", "search", "scan", "verify", "fileinfo", "duplicates", "brokenlinks", "orphans"],
     }
@@ -8426,6 +8480,15 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['comments']['example']}{RESET}",
     )
     _add_common_mode_arguments(comments_parser)
+
+    todo_parser = subparsers.add_parser(
+        'todo',
+        help=MODE_DETAILS['todo']['summary'],
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=MODE_DETAILS['todo']['description'],
+        epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['todo']['example']}{RESET}",
+    )
+    _add_common_mode_arguments(todo_parser)
 
     links_parser = subparsers.add_parser(
         'links',
@@ -10024,6 +10087,13 @@ def main() -> None:
             {
                 **common_kwargs,
                 'right_side': right_side,
+                'output_format': output_format,
+            },
+        ),
+        'todo': (
+            todo_mode,
+            {
+                **common_kwargs,
                 'output_format': output_format,
             },
         ),

--- a/tests/test_multitool_todo.py
+++ b/tests/test_multitool_todo.py
@@ -1,0 +1,71 @@
+import sys
+import io
+import pytest
+from multitool import main, _STDIN_CACHE
+
+def test_todo_mode(tmp_path, capsys):
+    # Reset STDIN cache for isolation
+    import multitool
+    multitool._STDIN_CACHE = None
+
+    test_file = tmp_path / "test.py"
+    test_file.write_text("""
+# TODO: Implement this feature
+# FIXME: Fix this bug
+# XXX: Check this
+# BUG: This is a bug
+# HACK: This is a hack
+# Not a todo
+/* TODO: multi-line todo */
+<!-- FIXME: html todo -->
+\"\"\" BUG: docstring todo \"\"\"
+""", encoding="utf-8")
+
+    sys.argv = ["multitool.py", "todo", str(test_file), "--raw"]
+    main()
+
+    captured = capsys.readouterr()
+    output = captured.out.strip().split("\n")
+
+    expected = [
+        "Implement this feature",
+        "Fix this bug",
+        "Check this",
+        "This is a bug",
+        "This is a hack",
+        "multi-line todo",
+        "html todo",
+        "docstring todo"
+    ]
+
+    for item in expected:
+        assert item in output
+
+    assert "Not a todo" not in output
+
+def test_todo_mode_cleaning(tmp_path, capsys):
+    import multitool
+    multitool._STDIN_CACHE = None
+
+    test_file = tmp_path / "test.c"
+    test_file.write_text("/* TODO: clean me */", encoding="utf-8")
+
+    # Default cleaning (lowercase, alphanumeric, spaces removed)
+    sys.argv = ["multitool.py", "todo", str(test_file)]
+    main()
+
+    captured = capsys.readouterr()
+    assert "cleanme" in captured.out
+
+def test_todo_mode_case_insensitive(tmp_path, capsys):
+    import multitool
+    multitool._STDIN_CACHE = None
+
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("todo: lowercase todo", encoding="utf-8")
+
+    sys.argv = ["multitool.py", "todo", str(test_file), "--raw"]
+    main()
+
+    captured = capsys.readouterr()
+    assert "lowercase todo" in captured.out


### PR DESCRIPTION
Added a new `todo` mode to `multitool.py` that extracts `TODO`, `FIXME`, `XXX`, `BUG`, and `HACK` items from source files. It identifies the text following these markers and automatically cleans up common comment endings (like `*/`, `-->`, or triple quotes).

This feature was identified as a logical extension of the existing `comments` mode, providing a convenient way for developers to quickly scan a project for pending tasks or known issues. It follows the symmetry heuristic by providing a specialized extractor for a common development pattern.

The implementation is fully additive, non-breaking, and integrated into the existing CLI structure and documentation. Verified with new tests and checked for regressions in existing help-related tests.

---
*PR created automatically by Jules for task [13267770953723941233](https://jules.google.com/task/13267770953723941233) started by @RainRat*