### PR TITLE
[UI/UX] Improve visual hierarchy and consistency in help output

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -7923,7 +7923,7 @@ def get_mode_summary_text() -> str:
                     display_flags = display_flags[:width_flags-3] + "..."
 
                 row = (
-                    f"{padding}{c_bold}{c_green}{mode:<{width_mode}}{c_reset} {sep} "
+                    f"{padding}{c_bold}{color}{mode:<{width_mode}}{c_reset} {sep} "
                     f"{summary:<{width_summary}} {sep} "
                     f"{c_yellow}{display_flags:<{width_flags}}{c_reset}"
                 )
@@ -7945,7 +7945,7 @@ def get_mode_summary_text() -> str:
         ("--limit (-L)", "Restrict the number of items in the output")
     ]
     for flag, desc in tips:
-        lines.append(f"{padding}{c_bold}{c_green}{flag:<20}{c_reset} {desc}")
+        lines.append(f"{padding}{c_bold}{c_yellow}{flag:<20}{c_reset} {desc}")
 
     lines.append(f"\n{padding}{c_bold}{c_blue}Note:{c_reset} All modes accept one or more {c_bold}FILES{c_reset} as arguments or read from standard input.")
     lines.append(f"\nRun '{c_bold}python multitool.py help <mode>{c_reset}' for details on a specific mode.\n")


### PR DESCRIPTION
### Context
CLI (Command Line Interface)

### Problem
The `multitool.py` global help summary used a hardcoded green color for all mode names, regardless of their category. Additionally, flags in the "Quick Tips" section were green, while flags in the main "Primary Options" column were yellow. This lacked visual consistency and missed an opportunity to use color to reinforce the functional categorization of tools.

### Solution
- **Visual Hierarchy:** Updated the mode summary table to use category-specific colors for mode names. This makes it easier to scan the list and quickly identify tools by their function (e.g., all data extraction tools are green, all transformation tools are yellow).
- **Consistency:** Standardized the color of flags in the "Quick Tips" section to yellow, ensuring they match the styling of the "Primary Options" column. This provides a unified visual language for command-line options across the help output.

### Changes
Modified `get_mode_summary_text` in `multitool.py` to use the existing `color` variable (derived from the category) for mode names and updated the `tips` rendering loop to use `c_yellow`.

---
*PR created automatically by Jules for task [13986743737909000153](https://jules.google.com/task/13986743737909000153) started by @RainRat*