### PR TITLE
[UI/UX] Consolidate item labeling and improve logging in `count_mode`

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -3215,6 +3215,20 @@ def count_mode(
         mapping = _resolve_full_mapping(mapping_file, ad_hoc, clean_items, quiet=quiet)
         pairs = True  # Automatically enable pairs for mapping audit
 
+    # Determine item label for reports and logs
+    if pairs:
+        item_label = "pair"
+    elif lines:
+        item_label = "line"
+    elif chars:
+        item_label = "character"
+    elif sentences:
+        item_label = "sentence"
+    elif paragraphs:
+        item_label = "paragraph"
+    else:
+        item_label = "word"
+
     if mapping:
         # Audit mode: Count matches of mapped typos in input files
         for input_file in input_files:
@@ -3408,16 +3422,7 @@ def count_mode(
                 # 3 chars for each " │ " (total 5 * 3 = 15)
                 visible_header_len = max_left + max_right + max_count_len + max_pct + max_attr + max_bar + 15
             else:
-                if lines:
-                    item_header = "Line"
-                elif chars:
-                    item_header = "Character"
-                elif sentences:
-                    item_header = "Sentence"
-                elif paragraphs:
-                    item_header = "Paragraph"
-                else:
-                    item_header = "Word"
+                item_header = item_label.capitalize()
 
                 max_item = max((len(str(item)) for item, _ in final_results), default=len(item_header))
                 max_item = max(max_item, len(item_header))
@@ -3435,20 +3440,6 @@ def count_mode(
 
             divider = f"{padding}{c_out_bold}{c_out_blue}{'─' * visible_header_len}{c_out_reset}"
             header_block = f"\n{header}\n{divider}\n"
-
-            # Determine labels for summary
-            if pairs:
-                item_label = "pair"
-            elif lines:
-                item_label = "line"
-            elif chars:
-                item_label = "character"
-            elif sentences:
-                item_label = "sentence"
-            elif paragraphs:
-                item_label = "paragraph"
-            else:
-                item_label = "word"
 
             # Write the table header for arrow format (suppressed in quiet mode for console)
             if not quiet or output_file != '-':
@@ -3519,19 +3510,6 @@ def count_mode(
                 out_file.write(f"{label}: {count}\n")
 
     if output_format != 'arrow':
-        if pairs:
-            item_label = "pair"
-        elif lines:
-            item_label = "line"
-        elif chars:
-            item_label = "character"
-        elif sentences:
-            item_label = "sentence"
-        elif paragraphs:
-            item_label = "paragraph"
-        else:
-            item_label = "word"
-
         print_processing_stats(
             raw_count,
             filtered_items,
@@ -3540,8 +3518,9 @@ def count_mode(
         )
 
     c_tag, c_count, c_reset = _get_status_colors()
+    label_plural = f"{item_label.capitalize()} frequencies"
     logging.info(
-        f"{c_tag}[Count Mode]{c_reset} Word frequencies ({len(final_results)} items) have been written to '{output_file}' in {output_format} format."
+        f"{c_tag}[Count Mode]{c_reset} {label_plural} ({len(final_results)} items) have been written to '{output_file}' in {output_format} format."
     )
 
 


### PR DESCRIPTION
### Context
CLI

### Problem
`count_mode` in `multitool.py` contained redundant `if/elif` blocks to determine the item label (e.g., "word", "line", "character", "paragraph") in multiple locations (header generation, summary report, and stats printing). Furthermore, the final status message was hardcoded to "Word frequencies", which was misleading when the user was counting other units like lines or characters.

### Solution
I refactored `count_mode` to determine the `item_label` once at the start of the function based on the active flags. This label is now reused throughout the function:
1.  **Arrow Table Header:** Replaced a large `if/elif` block with `item_label.capitalize()`.
2.  **Summary Reports:** Passed the consolidated label to `_format_analysis_summary` and `print_processing_stats`.
3.  **Final Log Output:** Updated the completion message to use the dynamic label (e.g., "Character frequencies (10 items) have been written..."), providing accurate feedback to the user.

This change reduces code duplication and improves the clarity and consistency of the tool's output.

### Changes
Modified `multitool.py` to:
- Add a central `item_label` determination block at the start of `count_mode`.
- Remove three redundant `if/elif` blocks that determined the same label.
- Update the `logging.info` call at the end of `count_mode` to use the dynamic label.

---
*PR created automatically by Jules for task [5384598524648051010](https://jules.google.com/task/5384598524648051010) started by @RainRat*