### PR TITLE
[DOCS] Improve documentation for paragraphs mode and min-length defaults

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -139,6 +139,10 @@ Use these modes to pull specific data from a file.
   - Extracts individual sentences from a file using a regex-based heuristic. It handles multi-line sentences by joining lines with spaces before splitting.
   - **Example:** `python multitool.py sentences report.txt --output sentences.txt`
 
+- **`paragraphs`**
+  - Extracts individual paragraphs from a file using one or more blank lines as delimiters. It automatically joins multi-line paragraphs into single lines and cleans up extra whitespace.
+  - **Example:** `python multitool.py paragraphs report.txt --output paragraphs.txt`
+
 - **`ngrams`**
   - Extracts sequences of words. This is useful for finding phrases or context around typos. It supports sequences across line boundaries.
   - **Options:** Use `-n` to pick the number of words in each sequence (default is 2). Like the `words` mode, it supports custom delimiters and smart word splitting.
@@ -321,6 +325,7 @@ Use these modes to analyze your data.
     - `-l`, `--lines`: Count frequencies of raw lines.
     - `-c`, `--chars`: Count frequencies of individual characters.
     - `-E`, `--sentences`: Count frequencies of individual sentences.
+    - `-G`, `--paragraphs`: Count frequencies of individual paragraphs.
     - `-B`, `--by-file`: Count how many files contain each item.
   - **Visual Report:** Use `--output-format arrow` for a rich report with metrics and bar charts.
   - **Supported Formats:** `arrow`, `json`, `csv`, `markdown`, `md-table`, `line`, and `xml`.
@@ -434,7 +439,7 @@ These options work with most modes:
 - `[INPUT_FILES...]`: One or more files to read. Defaults to **standard input** if not provided.
 - `--output` (or **`-o`**): The file to write results to. Defaults to printing to the screen.
 - `--output-format` (or **`-f`**): The format of the output. Options include `line` (default), `json`, `yaml`, `toml`, `csv`, `markdown`, `md-table`, `arrow`, `table`, and `xml`. The tool automatically detects the format from the output file extension.
-- `--min-length` (or **`-m`**): Skip items shorter than this length (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count', and 10 for sentence-based modes).
+- `--min-length` (or **`-m`**): Skip items shorter than this length (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count', 10 for sentences, and 20 for paragraphs).
 - `--max-length` (or **`-M`**): Skip words longer than this length (default: 1000).
 - `--process-output` (or **`-P`**): Sorts the final list and removes duplicates. Use this to organize your output or remove redundant entries.
 - `--limit` (or **`-L`**): Limit the number of items in the output.

--- a/multitool.py
+++ b/multitool.py
@@ -7243,7 +7243,7 @@ def _add_common_mode_arguments(
         '-m', '--min-length',
         type=int,
         default=argparse.SUPPRESS,
-        help="Skip items shorter than this (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count').",
+        help="Skip items shorter than this (default: 1 for most modes, 3 for words, 10 for sentences, and 20 for paragraphs).",
     )
     proc_group.add_argument(
         '-M', '--max-length',
@@ -8151,7 +8151,7 @@ def _build_parser() -> argparse.ArgumentParser:
         '-m', '--min-length',
         type=int,
         default=None,
-        help="Skip items shorter than this (default: 1 for most modes, 3 for word extraction modes like 'words' and 'count').",
+        help="Skip items shorter than this (default: 1 for most modes, 3 for words, 10 for sentences, and 20 for paragraphs).",
     )
     proc_group.add_argument(
         '-M', '--max-length',


### PR DESCRIPTION
**PR Title:** [DOCS] Improve documentation for paragraphs mode and min-length defaults 
**Description:** 
* **Type:** Documentation / Internal Help 
* **What:** Updated `docs/multitool.md` and `multitool.py` help strings. 
* **Why:** Added missing documentation for the `paragraphs` extraction mode and the `-G` flag in `count` mode. Also corrected the help text for the `--min-length` option to accurately reflect the default values for sentences (10) and paragraphs (20), which improves clarity for users processing different text units.

---
*PR created automatically by Jules for task [9815118444132536000](https://jules.google.com/task/9815118444132536000) started by @RainRat*