### PR TITLE
Fix word count logic in standardize mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -6367,7 +6367,6 @@ def standardize_mode(
         for line in tqdm(file_lines, desc=f"Analyzing {input_file}", unit=" lines", disable=quiet):
             parts = pattern.findall(line)
             for part in parts:
-                raw_word_count += 1
                 # Collect candidates for analysis (full word and any sub-parts)
                 candidates = [part]
                 sub_parts = _smart_split(part)
@@ -6375,6 +6374,7 @@ def standardize_mode(
                     candidates.extend(sub_parts)
 
                 for cand in candidates:
+                    raw_word_count += 1
                     norm = filter_to_letters(cand) if clean_items else cand.lower()
                     if norm and min_length <= len(norm) <= max_length:
                         variation_counts[norm][cand] += 1


### PR DESCRIPTION
* **What:** Moved the `raw_word_count` increment from the outer word loop to the inner candidate loop in the `standardize_mode` function of `multitool.py`.
* **Why:** This ensures that all candidates being processed (including sub-words generated from CamelCase or other splitting) are correctly counted as analyzed items. Previously, only the original top-level tokens were counted, leading to misleading "Retention rate" metrics in the analysis summary (sometimes exceeding 100%). This change improves the accuracy of analytical reports without altering the core functional logic.

---
*PR created automatically by Jules for task [2742803731181140888](https://jules.google.com/task/2742803731181140888) started by @RainRat*