### PR TITLE
[DOCS] Clarify unzip mode default behavior and raw flag

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -254,8 +254,8 @@ Use these modes to transform or combine your data.
   - **Example:** `python multitool.py zip typos.txt --file2 corrections.txt --output-format arrow`
 
 - **`unzip`**
-  - Splits paired data into two lists by extracting one side. It saves the left side by default.
-  - **Options:** Use the `--right` flag to save the right side instead.
+  - Splits paired data into two lists by extracting one side. It saves the left side by default. By default, it changes the text to lowercase and removes all characters except for lowercase letters.
+  - **Options:** Use the `--right` flag to save the right side instead. Use the `--raw` (or **`-R`**) flag to preserve the original text.
   - **Example:** `python multitool.py unzip typos.csv --right --output corrections.txt`
 
 - **`swap`**

--- a/multitool.py
+++ b/multitool.py
@@ -5635,7 +5635,7 @@ def unzip_mode(
     clean_items: bool = True,
     limit: int | None = None,
 ) -> None:
-    """Splits paired data into two lists (extracts one side)."""
+    """Splits paired data into two lists (extracts one side). By default, it changes text to lowercase and filters to letters."""
     def extractor(f, quiet=False):
         for left, right in _extract_pairs([f], quiet=quiet):
             yield right if right_side else left
@@ -7672,9 +7672,9 @@ MODE_DETAILS = {
     },
     "unzip": {
         "summary": "Splits paired data into two lists",
-        "description": "Extracts the left or right side of paired data (like 'typo -> correction', CSV columns, or JSON objects). It saves the left side by default. Use --right to save the right side instead.",
+        "description": "Extracts the left or right side of paired data (like 'typo -> correction', CSV columns, or JSON objects). It saves the left side by default. By default, it changes text to lowercase and removes non-alphabetic characters. Use --right to save the right side instead, and --raw to preserve original text.",
         "example": "python multitool.py unzip typos.csv --right --output corrections.txt",
-        "flags": "[FILES...] [--right]",
+        "flags": "[FILES...] [--right] [--raw]",
     },
     "swap": {
         "summary": "Reverses the order of pairs",


### PR DESCRIPTION
This PR improves the documentation for the `unzip` mode in `multitool.py`.

### Changes:
- **`docs/multitool.md`**: Updated the `unzip` mode description and options to explicitly mention the default cleaning behavior (lowercase conversion and character filtering) and the availability of the `--raw` flag.
- **`multitool.py`**:
    - Updated the `unzip_mode` docstring.
    - Improved the `unzip` mode description in the internal help dictionary.
    - Updated the `flags` metadata for `unzip` to include `[--raw]` in the usage summary.

### Why:
The default text cleaning in `unzip` mode is not immediately obvious from the command name alone. Explicitly documenting this behavior and providing the escape hatch (`--raw`) reduces friction for users who need to preserve the original formatting of their data.

---
*PR created automatically by Jules for task [5453553621638371040](https://jules.google.com/task/5453553621638371040) started by @RainRat*