### PR TITLE
[FEAT] Implement fuzzy suggestions for broken links in multitool

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -269,6 +269,24 @@ def levenshtein_distance(s1: str, s2: str) -> int:
     return previous_row[-1]
 
 
+def _get_best_suggestion(query: str, candidates: Iterable[str], max_dist: int = 2) -> Optional[str]:
+    """Find the closest match for a query among a set of candidates."""
+    best_match = None
+    best_dist = max_dist + 1
+
+    for candidate in candidates:
+        dist = levenshtein_distance(query, candidate)
+        if dist < best_dist:
+            best_dist = dist
+            best_match = candidate
+        elif dist == best_dist and best_match is not None:
+            # If distances are equal, prefer shorter candidate or alphabetical order
+            if len(candidate) < len(best_match) or (len(candidate) == len(best_match) and candidate < best_match):
+                best_match = candidate
+
+    return best_match if best_dist <= max_dist else None
+
+
 def get_adjacent_keys(include_diagonals: bool = True) -> dict[str, set[str]]:
     """
     Returns a dictionary of adjacent keys on a QWERTY keyboard.
@@ -2696,7 +2714,10 @@ def brokenlinks_mode(
     quiet: bool = False,
     limit: int | None = None,
 ) -> None:
-    """Finds broken internal anchors and missing local file references in Markdown."""
+    """
+    Finds broken internal anchors and missing local file references in Markdown.
+    Provides fuzzy suggestions for broken links based on available anchors and filenames.
+    """
     start_time = time.perf_counter()
     anchor_map = _get_markdown_anchor_map(input_files, quiet=quiet)
 
@@ -2724,6 +2745,9 @@ def brokenlinks_mode(
                 slug = url[1:].split('?')[0] # Strip possible query params
                 if slug not in anchor_map.get(input_file, set()):
                     reason = f"Anchor not found: {url}"
+                    suggestion = _get_best_suggestion(slug, anchor_map.get(input_file, set()))
+                    if suggestion:
+                        reason += f" (Did you mean: #{suggestion}?)"
             else:
                 # Local file reference (might include an anchor)
                 parts = url.split('#', 1)
@@ -2748,9 +2772,22 @@ def brokenlinks_mode(
 
                     if not os.path.exists(target_path):
                         reason = f"File not found: {file_path}"
+                        # Try to suggest a correct filename from the same directory
+                        search_dir = os.path.dirname(target_path) or "."
+                        if os.path.isdir(search_dir):
+                            try:
+                                candidates = os.listdir(search_dir)
+                                suggestion = _get_best_suggestion(os.path.basename(file_path), candidates)
+                                if suggestion:
+                                    reason += f" (Did you mean: {suggestion}?)"
+                            except OSError:
+                                pass
                     elif anchor and target_path in anchor_map:
                         if anchor not in anchor_map[target_path]:
                             reason = f"Anchor not found in {file_path}: #{anchor}"
+                            suggestion = _get_best_suggestion(anchor, anchor_map[target_path])
+                            if suggestion:
+                                reason += f" (Did you mean: #{suggestion}?)"
                     elif anchor and target_path.lower().endswith(('.md', '.markdown')):
                         # If the file exists but isn't in our anchor map (maybe it wasn't in input_files),
                         # we can try to scan it on the fly.
@@ -2759,6 +2796,9 @@ def brokenlinks_mode(
                             anchor_map.update(temp_map)
                             if anchor not in anchor_map[target_path]:
                                 reason = f"Anchor not found in {file_path}: #{anchor}"
+                                suggestion = _get_best_suggestion(anchor, anchor_map[target_path])
+                                if suggestion:
+                                    reason += f" (Did you mean: #{suggestion}?)"
 
             if reason:
                 location = f"{input_file}:{line_num}"
@@ -7540,7 +7580,7 @@ MODE_DETAILS = {
     },
     "brokenlinks": {
         "summary": "Finds broken anchors and file links",
-        "description": "Checks Markdown files for broken internal anchors (like '#missing-heading') and missing local file references. It builds a project-wide map of all headings to correctly validate cross-file links.",
+        "description": "Checks Markdown files for broken internal anchors (like '#missing-heading') and missing local file references. It builds a project-wide map of all headings to correctly validate cross-file links and provides fuzzy suggestions for broken links.",
         "example": "python multitool.py brokenlinks docs/ --output-format arrow",
         "flags": "[FILES...]",
     },

--- a/tests/test_multitool_brokenlinks_suggestions.py
+++ b/tests/test_multitool_brokenlinks_suggestions.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import json
+import pytest
+from multitool import main
+
+def test_brokenlinks_suggestions(tmp_path, capsys):
+    # Setup files
+    file1 = tmp_path / "main.md"
+    file1.write_text("# Hello World\n\n[Internal Link](#hello-word)\n[Cross File Link](other.md#target-sectio)\n[Missing File](miss.md)")
+
+    file2 = tmp_path / "other.md"
+    file2.write_text("# Target Section\n")
+
+    # Run brokenlinks mode
+    sys.argv = ["multitool.py", "brokenlinks", str(file1), str(file2), "--output-format", "json"]
+
+    main()
+
+    captured = capsys.readouterr()
+    results = json.loads(captured.out)
+
+    internal_found = False
+    for loc, val in results.items():
+        if "#hello-word" in val:
+            assert "(Did you mean: #hello-world?)" in val
+            internal_found = True
+    assert internal_found
+
+    cross_found = False
+    for loc, val in results.items():
+        if "other.md#target-sectio" in val:
+            assert "(Did you mean: #target-section?)" in val
+            cross_found = True
+    assert cross_found
+
+    # Check for missing file suggestion
+    file_near = tmp_path / "missy.md"
+    file_near.write_text("# Nearby")
+
+    # Run again to pick up the new file
+    sys.argv = ["multitool.py", "brokenlinks", str(file1), str(file2), str(file_near), "--output-format", "json"]
+    main()
+
+    captured = capsys.readouterr()
+    results = json.loads(captured.out)
+    file_found = False
+    for loc, val in results.items():
+        if "miss.md" in val and "File not found" in val:
+            assert "(Did you mean: missy.md?)" in val
+            file_found = True
+    assert file_found
+
+def test_brokenlinks_on_the_fly_scan_suggestions(tmp_path, capsys):
+    # Setup files - file2 is NOT in the input list but is referenced
+    file1 = tmp_path / "main.md"
+    file1.write_text("[Cross File](other.md#target-sectio)")
+
+    file2 = tmp_path / "other.md"
+    file2.write_text("# Target Section\n")
+
+    # Run brokenlinks mode - only file1 is input
+    sys.argv = ["multitool.py", "brokenlinks", str(file1), "--output-format", "json"]
+
+    main()
+
+    captured = capsys.readouterr()
+    results = json.loads(captured.out)
+
+    cross_found = False
+    for loc, val in results.items():
+        if "other.md#target-sectio" in val:
+            assert "(Did you mean: #target-section?)" in val
+            cross_found = True
+    assert cross_found


### PR DESCRIPTION
This PR implements a "Did you mean?" suggestion feature for the `brokenlinks` mode in `multitool.py`. 

### Key Changes:
1.  **New Helper Function**: Added `_get_best_suggestion(query, candidates, max_dist=2)` which uses the existing `levenshtein_distance` to find the closest match among a set of candidates. It includes tie-breaking logic that prefers shorter candidates and alphabetical order.
2.  **Anchor Suggestions**: When an internal or cross-file anchor is not found, the tool now searches the target file's anchor map for a similar slug and appends a suggestion to the 'Reason' field (e.g., "Anchor not found: #hello-word (Did you mean: #hello-world?)").
3.  **File Suggestions**: If a referenced local file is missing, the tool scans the target directory for files with similar names and offers a suggestion.
4.  **On-the-fly Scan Support**: Suggestions also work for Markdown files that are scanned on-the-fly when referenced by a cross-file link but not included in the initial input list.
5.  **Documentation**: Updated the `brokenlinks_mode` docstring and the `MODE_DETAILS` dictionary to reflect the new functionality in the CLI help output.
6.  **Testing**: Added `tests/test_multitool_brokenlinks_suggestions.py` covering all three suggestion types.

This enhancement directly improves user efficiency by automating the search for fixable typos in documentation links.

---
*PR created automatically by Jules for task [11941994876373622173](https://jules.google.com/task/11941994876373622173) started by @RainRat*