### PR TITLE
[TEST] Add coverage for _get_best_suggestion tie-breaking logic

### DIFF
--- a/tests/test_multitool_best_suggestion.py
+++ b/tests/test_multitool_best_suggestion.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import multitool
+
+def test_get_best_suggestion_tie_breaking_length():
+    query = "test"
+    candidates = ["tests", "tst"]
+    suggestion = multitool._get_best_suggestion("test", candidates, max_dist=1)
+    assert suggestion == "tst"
+
+def test_get_best_suggestion_tie_breaking_alphabetical():
+    query = "test"
+    candidates = ["west", "best", "rest"]
+    suggestion = multitool._get_best_suggestion("test", candidates, max_dist=1)
+    assert suggestion == "best"
+
+def test_get_best_suggestion_no_match():
+    query = "test"
+    candidates = ["totally", "different", "words"]
+    suggestion = multitool._get_best_suggestion(query, candidates, max_dist=1)
+    assert suggestion is None
+
+def test_get_best_suggestion_exact_match():
+    query = "test"
+    candidates = ["test", "tests", "best"]
+    suggestion = multitool._get_best_suggestion(query, candidates, max_dist=1)
+    assert suggestion == "test"


### PR DESCRIPTION
The `_get_best_suggestion` function in `multitool.py` had untested logic for handling ties in Levenshtein distance. I identified this gap and added a robust test suite covering:
1. Tie-breaking by candidate length.
2. Tie-breaking by alphabetical order when lengths are equal.
3. Exact match handling.
4. Handling cases where no candidates are within the maximum distance.

The tests follow the Lead QA Agent rules: independent, no explanatory comments, and descriptive function names.


---
*PR created automatically by Jules for task [17624401434519928890](https://jules.google.com/task/17624401434519928890) started by @RainRat*