### PR TITLE
[DOCS] Simplify and clarify unzip mode documentation

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -262,8 +262,7 @@ Use these modes to transform or combine your data.
   - **Example:** `python multitool.py zip typos.txt --file2 corrections.txt --output-format arrow`
 
 - **`unzip`**
-  - Splits paired data into two lists by extracting one side. It saves the left side by default. By default, it changes the text to lowercase and removes all characters except for lowercase letters.
-  - **Options:** Use the `--right` flag to save the right side instead. Use the `--raw` (or **`-R`**) flag to preserve the original text.
+  - Extracts one side of paired data (like 'typo -> correction'). It saves the left side and cleans the text by default. Use --right for the right side and --raw to keep the original text.
   - **Example:** `python multitool.py unzip typos.csv --right --output corrections.txt`
 
 - **`swap`**

--- a/multitool.py
+++ b/multitool.py
@@ -5874,7 +5874,7 @@ def unzip_mode(
     clean_items: bool = True,
     limit: int | None = None,
 ) -> None:
-    """Splits paired data into two lists (extracts one side). By default, it changes text to lowercase and filters to letters."""
+    """Extracts one side of paired data (like 'typo -> correction'). It saves the left side and cleans the text by default. Use --right for the right side and --raw to keep the original text."""
     def extractor(f, quiet=False):
         for left, right in _extract_pairs([f], quiet=quiet):
             yield right if right_side else left
@@ -7917,7 +7917,7 @@ MODE_DETAILS = {
     },
     "unzip": {
         "summary": "Splits paired data into two lists",
-        "description": "Extracts the left or right side of paired data (like 'typo -> correction', CSV columns, or JSON objects). It saves the left side by default. By default, it changes text to lowercase and removes non-alphabetic characters. Use --right to save the right side instead, and --raw to preserve original text.",
+        "description": "Extracts one side of paired data (like 'typo -> correction'). It saves the left side and cleans the text by default. Use --right for the right side and --raw to keep the original text.",
         "example": "python multitool.py unzip typos.csv --right --output corrections.txt",
         "flags": "[FILES...] [--right] [--raw]",
     },


### PR DESCRIPTION
**PR Title:** [DOCS] Simplify and clarify unzip mode documentation
**Description:**
* **Type:** Documentation / Internal Help
* **What:** Updated `docs/multitool.md`, the `unzip_mode` docstring, and the `unzip` entry in `MODE_DETAILS` within `multitool.py`.
* **Why:** Simplified the description of the `unzip` mode to use plain English and removed redundant phrases. It now clearly explains that the tool extracts one side of paired data and cleans the text by default, making it more accessible for a global audience.

---
*PR created automatically by Jules for task [15122843662997698351](https://jules.google.com/task/15122843662997698351) started by @RainRat*