### PR TITLE
Fix KeyError in unflatten mode with ambiguous numeric keys

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2432,11 +2432,10 @@ def unflatten_mode(
         if not new_d:
             return new_d
 
-        # Check if all keys are numeric and form a continuous sequence starting at 0
-        if all(k.isdigit() for k in new_d.keys()):
-            indices = sorted(int(k) for k in new_d.keys())
-            if indices == list(range(len(indices))):
-                return [new_d[str(i)] for i in range(len(indices))]
+        # Check if all keys are exactly the string representations of the indices from 0 to N-1
+        expected_keys = {str(i) for i in range(len(new_d))}
+        if set(new_d.keys()) == expected_keys:
+            return [new_d[str(i)] for i in range(len(new_d))]
 
         return new_d
 

--- a/tests/test_multitool_unflatten.py
+++ b/tests/test_multitool_unflatten.py
@@ -70,3 +70,25 @@ if __name__ == "__main__":
         print(f"Test failed: {e}")
         traceback.print_exc()
         exit(1)
+
+def test_unflatten_ambiguous_numeric_keys():
+    # Test that non-sequential or zero-padded numeric keys do not cause a crash
+    # and are correctly preserved as a dictionary.
+    input_content = 'root.0 -> a\nroot.01 -> b\n'
+    with open("test_input_ambiguous.txt", "w") as f:
+        f.write(input_content)
+
+    result = subprocess.run(
+        ["python3", "multitool.py", "unflatten", "test_input_ambiguous.txt", "--output-format", "json", "--raw"],
+        capture_output=True,
+        text=True
+    )
+
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}")
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    # Since keys are '0' and '01', they don't form a simple [0, 1] sequence of string keys
+    # and should be kept as a dictionary.
+    assert data == {"root": {"0": "a", "01": "b"}}
+    os.remove("test_input_ambiguous.txt")


### PR DESCRIPTION
This PR fixes a logic bug in `multitool.py` where the `unflatten` mode could crash with a `KeyError` when processing dot-separated keys that appeared numeric but were non-sequential (e.g., `item.0` and `item.01`).

The original implementation checked if the integer values of the keys formed a sequence, but then attempted lookups using the string index (e.g., `new_d[str(i)]`). If the original key was `"01"`, it was treated as integer `1`, but the lookup for string `"1"` would fail.

The fix updates `dict_to_lists` to verify that the keys exactly match the set of expected string indices `{str(0), str(1), ..., str(N-1)}`. If they don't match exactly, the structure is preserved as a dictionary.

Changes:
- Modified `dict_to_lists` in `multitool.py` to use a more robust key check.
- Added `test_unflatten_ambiguous_numeric_keys` to `tests/test_multitool_unflatten.py` to prevent regressions.

---
*PR created automatically by Jules for task [4049906415241657530](https://jules.google.com/task/4049906415241657530) started by @RainRat*