### PR TITLE
[TEST] Add coverage for tqdm fallback class in diff2typo.py

### DIFF
--- a/tests/test_diff2typo_tqdm_fallback.py
+++ b/tests/test_diff2typo_tqdm_fallback.py
@@ -1,0 +1,29 @@
+import sys
+import importlib
+import diff2typo
+
+def test_diff2typo_tqdm_fallback_implementation():
+    real_tqdm = sys.modules.pop("tqdm", None)
+    sys.modules["tqdm"] = None
+    try:
+        importlib.reload(diff2typo)
+        fallback_class = diff2typo.tqdm
+
+        pbar_with_iterable = fallback_class([1, 2, 3])
+        assert list(pbar_with_iterable) == [1, 2, 3]
+
+        pbar_no_iterable = fallback_class()
+        assert list(pbar_no_iterable) == []
+
+        with fallback_class() as pbar:
+            pbar.update(2)
+            pbar.close()
+            pbar.set_description("Loading")
+            pbar.set_postfix(status="done")
+
+    finally:
+        if real_tqdm is not None:
+            sys.modules["tqdm"] = real_tqdm
+        else:
+            sys.modules.pop("tqdm", None)
+        importlib.reload(diff2typo)


### PR DESCRIPTION
This PR adds unit tests to cover the tqdm fallback class in diff2typo.py when tqdm is not available. This brings the statement coverage of diff2typo.py to exactly 100%.

---
*PR created automatically by Jules for task [4224337733219059487](https://jules.google.com/task/4224337733219059487) started by @RainRat*