### PR TITLE
[DOCS] Document missing CLI options in diff2typo.md

### DIFF
--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -30,6 +30,9 @@ git diff | python diff2typo.py [OPTIONS]
 | `--mode` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
 | `--min-length`, `-m` | `2` | Ignore words shorter than this length. |
 | `--max-dist` | None | Only include typos with a number of character changes up to this value. Useful for filtering out intentional word changes. |
+| `--min-count` | `1` | Only include typos that appear at least this many times in the input diff. |
+| `--sort` | `alpha` | Sort the results. Choose 'alpha' (alphabetical order) or 'count' (most frequent first). |
+| `--limit`, `-L` | None | Limit the number of typos in the output. |
 | `--dictionary`, `-d` | `words.csv` | A file containing the large dictionary of correct words. The tool uses this to make sure the "fix" is a real word. |
 | `--allowed` | `allowed.csv` | A list of words to explicitly ignore, even if they look like typos. |
 | `--typos-path` | `typos` | The path to the external `typos` tool. |


### PR DESCRIPTION
This PR adds documentation for three previously undocumented command-line options in `diff2typo.py`: `--min-count`, `--sort`, and `--limit`. The explanations are written in clear, Plain English, following the style guidelines for the repository.

---
*PR created automatically by Jules for task [18334764080311701291](https://jules.google.com/task/18334764080311701291) started by @RainRat*