### PR TITLE
Clean up redundant dictionary .get() lookups in cmdrunner.py

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -95,16 +95,16 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if not config.get("command_to_run"):
         errors.append("Missing required configuration field: 'command_to_run'.")
 
-    if "main_folder" in config and not isinstance(config.get("main_folder"), str):
+    if "main_folder" in config and not isinstance(config["main_folder"], str):
         errors.append("'main_folder' must be a string.")
 
-    if "base_directory" in config and not isinstance(config.get("base_directory"), str):
+    if "base_directory" in config and not isinstance(config["base_directory"], str):
         errors.append("'base_directory' must be a string.")
 
-    if "command_to_run" in config and not isinstance(config.get("command_to_run"), str):
+    if "command_to_run" in config and not isinstance(config["command_to_run"], str):
         errors.append("'command_to_run' must be a string.")
 
-    if "excluded_folders" in config and not isinstance(config.get("excluded_folders"), list):
+    if "excluded_folders" in config and not isinstance(config["excluded_folders"], list):
         errors.append("'excluded_folders' must be a list if provided.")
 
     if errors:


### PR DESCRIPTION
Refactored load_config in cmdrunner.py to directly use subscript syntax (e.g., config["main_folder"]) instead of calling .get() after already verifying key presence via the in operator. This resolves a redundant validation code smell, reduces lookup overhead, and keeps the external behavior exactly identical.

---
*PR created automatically by Jules for task [134254099308986911](https://jules.google.com/task/134254099308986911) started by @RainRat*