### PR TITLE
[UI/UX] [CLI] Prevent interactive hang in diff2typo by auto-detecting git diff

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -584,6 +584,23 @@ def _read_diff_sources(input_files: Optional[Sequence[str]]) -> str:
     """Return concatenated diff text from standard input or the provided file patterns."""
 
     if not input_files:
+        if sys.stdin.isatty():
+            try:
+                res = subprocess.run(
+                    ["git", "rev-parse", "--is-inside-work-tree"],
+                    capture_output=True,
+                    text=True,
+                    check=False
+                )
+                if res.returncode == 0 and res.stdout.strip() == "true":
+                    logging.info("Interactive terminal detected and no input files specified. Defaulting to 'git diff' in active Git repository.")
+                    return _read_git_diff("")
+            except FileNotFoundError:
+                pass
+
+            logging.error("No input files or piped diff specified, and standard input is an interactive terminal.")
+            logging.error("Please provide a diff file, pipe standard input (e.g. 'git diff | python diff2typo.py'), or run inside a Git repository.")
+            sys.exit(1)
         return _read_stdin_text()
 
     contents: List[str] = []

--- a/tests/test_diff2typo_interactive.py
+++ b/tests/test_diff2typo_interactive.py
@@ -1,0 +1,76 @@
+import sys
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import diff2typo
+
+
+def test_read_diff_sources_non_interactive(monkeypatch):
+    """
+    Test when no input files are specified but stdin is not interactive (e.g. piped input).
+    It should read from stdin instead of checking Git or exiting.
+    """
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(diff2typo, "_read_stdin_text", lambda: "piped stdin diff")
+
+    result = diff2typo._read_diff_sources([])
+    assert result == "piped stdin diff"
+
+
+def test_read_diff_sources_interactive_inside_git(monkeypatch):
+    """
+    Test when no input files are specified, stdin is interactive, and we are inside a Git worktree.
+    It should run `git diff` automatically.
+    """
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    def mock_run(args, **kwargs):
+        if args == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return MagicMock(returncode=0, stdout="true\n")
+        return MagicMock(returncode=1)
+
+    monkeypatch.setattr(diff2typo.subprocess, "run", mock_run)
+    monkeypatch.setattr(diff2typo, "_read_git_diff", lambda args: "git diff output")
+
+    result = diff2typo._read_diff_sources([])
+    assert result == "git diff output"
+
+
+def test_read_diff_sources_interactive_outside_git(monkeypatch):
+    """
+    Test when no input files are specified, stdin is interactive, but we are NOT inside a Git worktree.
+    It should print a helpful error message and exit with 1.
+    """
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    def mock_run(args, **kwargs):
+        if args == ["git", "rev-parse", "--is-inside-work-tree"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        return MagicMock(returncode=1)
+
+    monkeypatch.setattr(diff2typo.subprocess, "run", mock_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff2typo._read_diff_sources([])
+    assert excinfo.value.code == 1
+
+
+def test_read_diff_sources_interactive_git_filenotfound(monkeypatch):
+    """
+    Test when no input files are specified, stdin is interactive, but git command itself is not found/available.
+    It should print a helpful error message and exit with 1.
+    """
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    def mock_run(args, **kwargs):
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr(diff2typo.subprocess, "run", mock_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff2typo._read_diff_sources([])
+    assert excinfo.value.code == 1


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** When diff2typo.py is run inside an interactive terminal with no input files or piped data specified, the application blocks on standard input indefinitely (causing a CLI "hang").
* **Solution:** Enhance _read_diff_sources to check if sys.stdin.isatty() is True. If so, check if the current directory is within a Git worktree. If inside Git, automatically execute and use git diff for a seamless, keystroke-efficient workflow. Otherwise, exit immediately with a helpful error message instead of hanging.

---
*PR created automatically by Jules for task [9275478787743996762](https://jules.google.com/task/9275478787743996762) started by @RainRat*