### PR TITLE
[FEAT] Add CLI Configuration Overrides and Direct Execution to cmdrunner.py

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -191,7 +191,33 @@ def parse_arguments() -> argparse.Namespace:
         'config',
         metavar='CONFIG_PATH',
         type=str,
+        nargs='?',
         help='The path to your YAML configuration file.'
+    )
+
+    # Direct Execution / Overrides Group
+    direct_group = parser.add_argument_group(f"{BLUE}CLI OVERRIDES / DIRECT OPTIONS{RESET}")
+    direct_group.add_argument(
+        '-m', '--main-folder',
+        type=str,
+        help='The main folder containing your projects. Overrides config file if provided.'
+    )
+    direct_group.add_argument(
+        '-b', '--base-directory',
+        type=str,
+        help='Legacy alias for main folder. Overrides config file if provided.'
+    )
+    direct_group.add_argument(
+        '-c', '--command-to-run',
+        dest='command_to_run',
+        type=str,
+        help='The command you want to run in each folder. Overrides config file if provided.'
+    )
+    direct_group.add_argument(
+        '-e', '--excluded-folders',
+        dest='excluded_folders',
+        nargs='+',
+        help='Folders you want the tool to skip. Overrides config file if provided.'
     )
 
     # Execution Options Group
@@ -220,21 +246,34 @@ def main() -> None:
     handler.setFormatter(MinimalFormatter('%(levelname)s: %(message)s'))
     logging.basicConfig(level=log_level, handlers=[handler])
 
-    # Load configuration
-    try:
-        config = load_config(config_file)
-    except FileNotFoundError:
-        logging.error(f"Configuration file '{config_file}' not found.")
-        sys.exit(1)
-    except ConfigError as exc:
-        logging.error(str(exc))
-        sys.exit(1)
+    config = {}
+    if config_file:
+        # Load configuration
+        try:
+            config = load_config(config_file)
+        except FileNotFoundError:
+            logging.error(f"Configuration file '{config_file}' not found.")
+            sys.exit(1)
+        except ConfigError as exc:
+            logging.error(str(exc))
+            sys.exit(1)
 
     # Extract configuration parameters with defaults
-    # Support both 'main_folder' and the legacy 'base_directory'
-    main_folder = config.get('main_folder') or config.get('base_directory', '')
-    command_to_run = config.get('command_to_run', '')
-    excluded = config.get('excluded_folders', [])
+    # Support both 'main_folder' and the legacy 'base_directory', allowing CLI overrides
+    main_folder = args.main_folder or args.base_directory or config.get('main_folder') or config.get('base_directory', '')
+    command_to_run = args.command_to_run or config.get('command_to_run', '')
+    excluded = args.excluded_folders if args.excluded_folders is not None else config.get('excluded_folders', [])
+
+    # Validate that required options are present
+    errors = []
+    if not main_folder:
+        errors.append("main_folder")
+    if not command_to_run:
+        errors.append("command_to_run")
+
+    if errors:
+        logging.error(f"Missing required option(s): {', '.join(errors)}.")
+        sys.exit(1)
 
     # Run the command in the specified folders
     run_command_in_folders(

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -12,10 +12,16 @@
 
 ## Usage
 
-To use the tool, provide the path to your configuration file:
+You can run the tool either by providing a YAML configuration file or by specifying the parameters directly on the command line.
 
+**Using a configuration file:**
 ```bash
 python cmdrunner.py config.yaml
+```
+
+**Direct execution using command-line arguments:**
+```bash
+python cmdrunner.py --main-folder /home/user/projects --command-to-run "git status"
 ```
 
 ## Configuration
@@ -40,6 +46,10 @@ excluded_folders:
 
 ## Options
 
+- `CONFIG_PATH`: (Optional) The path to your YAML configuration file.
+- `-m`, `--main-folder`: The main folder containing your projects. Overrides config file if provided.
+- `-c`, `--command-to-run`: The command to run in each folder. Overrides config file if provided.
+- `-e`, `--excluded-folders`: A space-separated list of folders to skip. Overrides config file if provided.
 - `--dry-run`: Shows which folders would be processed and which command would run without actually doing it. Use this to test your setup safely.
 - `--quiet`: Hides status messages and progress bars.
 
@@ -64,6 +74,16 @@ In this example, if the tool processes a folder named `my-web-app`, it will run 
 4. **Report:** It shows you the results of each command or any errors that occurred.
 
 ## Examples
+
+**Run a command across your projects directly without a config file:**
+```bash
+python cmdrunner.py --main-folder /home/user/projects --command-to-run "git status"
+```
+
+**Override configuration file settings from the command line:**
+```bash
+python cmdrunner.py config.yaml --command-to-run "git pull"
+```
 
 **Test your configuration without running commands:**
 ```bash

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -486,3 +486,64 @@ def test_tqdm_fallback():
 
     # Restore cmdrunner to original state for other tests
     importlib.reload(cmdrunner)
+
+
+def test_cli_only_execution(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    included = base_dir / 'proj1'
+    excluded = base_dir / 'skip'
+    included.mkdir()
+    excluded.mkdir()
+
+    command = "python3 -c \"from pathlib import Path; Path('cli_test.txt').write_text('cli_ok')\""
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', '-m', str(base_dir), '-c', command, '-e', 'skip'])
+
+    cmdrunner.main()
+
+    assert (included / 'cli_test.txt').exists()
+    assert (included / 'cli_test.txt').read_text() == 'cli_ok'
+    assert not (excluded / 'cli_test.txt').exists()
+
+
+def test_cli_overrides_config(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj = base_dir / 'proj1'
+    proj.mkdir()
+
+    config_data = {
+        'main_folder': str(base_dir),
+        'command_to_run': 'echo dummy',
+    }
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    override_command = "python3 -c \"from pathlib import Path; Path('override_test.txt').write_text('override_ok')\""
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(config_file), '-c', override_command])
+
+    cmdrunner.main()
+
+    assert (proj / 'override_test.txt').exists()
+    assert (proj / 'override_test.txt').read_text() == 'override_ok'
+
+
+def test_cli_missing_options(monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py'])
+    with pytest.raises(SystemExit) as excinfo:
+        cmdrunner.main()
+    assert excinfo.value.code == 1
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', '-m', '/tmp'])
+    with pytest.raises(SystemExit) as excinfo:
+        cmdrunner.main()
+    assert excinfo.value.code == 1
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', '-c', 'echo 1'])
+    with pytest.raises(SystemExit) as excinfo:
+        cmdrunner.main()
+    assert excinfo.value.code == 1


### PR DESCRIPTION
Add CLI override arguments (`-m`/`--main-folder`, `-c`/`--command-to-run`, and `-e`/`--excluded-folders`) to `cmdrunner.py`, making the YAML configuration file completely optional and allowing settings to be overridden directly from the command line. Expand test coverage with new target scenarios and update the documentation accordingly.

---
*PR created automatically by Jules for task [6638480763544793638](https://jules.google.com/task/6638480763544793638) started by @RainRat*