### PR TITLE
[DOCS] Document missing CLI options in diff2typo.md

### DIFF
--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -30,6 +30,9 @@ git diff | python diff2typo.py [OPTIONS]
 | `--mode` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
 | `--min-length`, `-m` | `2` | Ignore words shorter than this length. |
 | `--max-dist` | None | Only include typos with a number of character changes up to this value. Useful for filtering out intentional word changes. |
+| `--min-count` | `1` | Minimum occurrences of a typo in the diff to include it in the output. |
+| `--sort` | `alpha` | How to sort the results: `count` (most frequent first) or `alpha` (alphabetical). |
+| `--limit`, `-L` | None | Limit the number of typos in the output. |
 | `--dictionary`, `-d` | `words.csv` | A file containing the large dictionary of correct words. The tool uses this to make sure the "fix" is a real word. |
 | `--allowed` | `allowed.csv` | A list of words to explicitly ignore, even if they look like typos. |
 | `--typos-path` | `typos` | The path to the external `typos` tool. |


### PR DESCRIPTION
Documents the missing command-line options (`--min-count`, `--sort`, and `--limit` / `-L`) in the CLI parameters table in `docs/diff2typo.md` to make the codebase more comprehensive and helpful for users.

---
*PR created automatically by Jules for task [9987913502863162052](https://jules.google.com/task/9987913502863162052) started by @RainRat*