### PR TITLE
[FEAT] Recursive Directory Scanning in typostats.py

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-Process one or more files or send data directly to the tool using a pipe.
+Process one or more files/directories or send data directly to the tool using a pipe.
 
 ```bash
 # Read from a file
@@ -12,6 +12,11 @@ python typostats.py my_typos.txt
 
 # Read from multiple files
 python typostats.py file1.txt file2.txt
+
+# Read from a directory recursively
+# This scans all supported files (.txt, .csv, .json, .yaml, .yml, .md) under the directory,
+# while ignoring common development and environment folders (like .git, node_modules, .venv).
+python typostats.py my_typos_directory/
 
 # Pipe from another tool
 git diff | python diff2typo.py | python typostats.py

--- a/tests/test_typostats_directory.py
+++ b/tests/test_typostats_directory.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from unittest.mock import patch
+import pytest
+from typostats import main, _STDIN_CACHE
+
+def test_typostats_recursive_directory_scanning(tmp_path, monkeypatch):
+    # Setup directories
+    root = tmp_path / "typostats_test_root"
+    root.mkdir()
+
+    subdir = root / "subdir"
+    subdir.mkdir()
+
+    ignored_dir = root / "node_modules"
+    ignored_dir.mkdir()
+
+    # Supported files in active folders
+    file1 = root / "file1.txt"
+    file1.write_text("teh -> the\n")
+
+    file2 = subdir / "file2.csv"
+    file2.write_text("recived,received\n")
+
+    # JSON file
+    file3 = subdir / "file3.json"
+    file3.write_text('{"replacements": [{"typo": "seperate", "correct": "separate"}]}')
+
+    # Files inside ignored folder (should be ignored)
+    ignored_file = ignored_dir / "ignored.txt"
+    ignored_file.write_text("ignoredtypo -> correction\n")
+
+    # Unsupported extension in active folder (should be ignored)
+    unsupported_file = root / "script.py"
+    unsupported_file.write_text("pytypo -> pycorrect\n")
+
+    # Output file path
+    output_file = tmp_path / "report.json"
+
+    # Clear cache
+    monkeypatch.setattr("typostats._STDIN_CACHE", None)
+
+    # Run typostats with recursive scan on the root folder
+    with patch("sys.argv", ["typostats.py", str(root), "--format", "json", "--output", str(output_file), "--all"]):
+        main()
+
+    assert output_file.exists()
+    content = output_file.read_text()
+
+    # The typos we expect:
+    # 1. teh -> the (e -> h transpose, or e -> h)
+    # 2. recived -> received (i -> ei insertion/1-to-2 or deletion/2-to-1)
+    # 3. seperate -> separate (e -> a replacement)
+    # The ignored files should NOT be processed.
+    assert "ignoredtypo" not in content
+    assert "pytypo" not in content
+
+    # Let's verify standard replacements are processed
+    # separate / seperate -> correct: a, typo: e
+    assert '"typo": "e"' in content
+    assert '"correct": "a"' in content

--- a/typostats.py
+++ b/typostats.py
@@ -1186,6 +1186,30 @@ def main() -> None:
     if not input_files:
         input_files = ['-']
 
+    # Expand directories recursively
+    expanded_files = []
+    ignored_dirs = {
+        '.git', 'node_modules', 'venv', '.venv', '.pytest_cache',
+        '.ruff_cache', '.vscode', '.idea', '__pycache__', 'dist', 'build'
+    }
+    supported_extensions = {'.txt', '.csv', '.json', '.yaml', '.yml', '.md'}
+
+    for file_path in input_files:
+        if file_path == '-':
+            expanded_files.append('-')
+        elif os.path.isdir(file_path):
+            for root, dirs, files in os.walk(file_path):
+                # Prune ignored directories in-place to avoid walking into them
+                dirs[:] = [d for d in dirs if d not in ignored_dirs]
+                for file in files:
+                    ext = os.path.splitext(file)[1].lower()
+                    if ext in supported_extensions:
+                        expanded_files.append(os.path.join(root, file))
+        else:
+            expanded_files.append(file_path)
+
+    input_files = expanded_files
+
     start_time = time.perf_counter()
     all_counts = defaultdict(int)
     total_lines_all = 0


### PR DESCRIPTION
Recursive directory scanning for typostats.py. Supports walking directories for supported file formats, ignores common dev folders, and integrates perfectly with all existing features and piped/file inputs.

---
*PR created automatically by Jules for task [17502097473573316059](https://jules.google.com/task/17502097473573316059) started by @RainRat*