### PR TITLE
Unify mapping extraction logic in gentypos to eliminate duplication

### DIFF
--- a/gentypos.py
+++ b/gentypos.py
@@ -205,6 +205,14 @@ def get_adjacent_keys(include_diagonals: bool = True) -> dict[str, set[str]]:
     return adjacent
 
 
+def _add_mapping_to_subs(data: dict, subs: dict[str, list[str]]) -> None:
+    for k, v in data.items():
+        if isinstance(v, list):
+            subs[str(k)].extend([str(i) for i in v])
+        else:
+            subs[str(k)].append(str(v))
+
+
 def _load_substitutions_file(path: str) -> dict[str, list[str]]:
     """
     Load substitution rules from a file. Supports JSON, CSV, and YAML.
@@ -227,11 +235,7 @@ def _load_substitutions_file(path: str) -> dict[str, list[str]]:
                             subs[str(item['correct'])].append(str(item['typo']))
                 # Plain mapping: {"a": ["e", "i"], ...}
                 elif isinstance(data, dict):
-                    for k, v in data.items():
-                        if isinstance(v, list):
-                            subs[str(k)].extend([str(i) for i in v])
-                        else:
-                            subs[str(k)].append(str(v))
+                    _add_mapping_to_subs(data, subs)
         elif ext == '.csv':
             with open(path, 'r', encoding='utf-8') as f:
                 # Use a simple check for typostats header instead of complex sniffing
@@ -275,11 +279,7 @@ def _load_substitutions_file(path: str) -> dict[str, list[str]]:
             with open(path, 'r', encoding='utf-8') as f:
                 data = yaml.safe_load(f)
                 if isinstance(data, dict):
-                    for k, v in data.items():
-                        if isinstance(v, list):
-                            subs[str(k)].extend([str(i) for i in v])
-                        else:
-                            subs[str(k)].append(str(v))
+                    _add_mapping_to_subs(data, subs)
     except Exception as e:
         logging.error(f"Error loading substitutions from '{path}': {e}")
         sys.exit(1)


### PR DESCRIPTION
Unifies the duplicate mapping parsing logic from JSON and YAML loader blocks in `_load_substitutions_file` into a new private helper function `_add_mapping_to_subs` in `gentypos.py`. This improves readability and maintainability, ensuring atomic and safe refactoring. All 1,126 existing unit tests pass successfully.

---
*PR created automatically by Jules for task [9234215766326183585](https://jules.google.com/task/9234215766326183585) started by @RainRat*