### PR TITLE
[UI/UX] Fall back to cmdrunner.yaml automatically when config path not specified

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -240,6 +240,10 @@ def main() -> None:
     args = parse_arguments()
     config_file = args.config
 
+    has_cli_run = (args.main_folder or args.base_directory) and args.command_to_run
+    if not config_file and not has_cli_run and os.path.exists('cmdrunner.yaml'):
+        config_file = 'cmdrunner.yaml'
+
     log_level = logging.WARNING if args.quiet else logging.INFO
     # Use a custom handler and formatter to keep output clean
     handler = logging.StreamHandler()

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -547,3 +547,29 @@ def test_cli_missing_options(monkeypatch):
     with pytest.raises(SystemExit) as excinfo:
         cmdrunner.main()
     assert excinfo.value.code == 1
+
+
+def test_default_config_fallback(tmp_path, monkeypatch):
+    base_dir = tmp_path / "projects"
+    base_dir.mkdir()
+
+    proj = base_dir / "proj1"
+    proj.mkdir()
+
+    command = "python3 -c \"from pathlib import Path; Path(\\\"fallback_test.txt\\\").write_text(\\\"fallback_ok\\\")\""
+    config_data = {
+        "main_folder": str(base_dir),
+        "command_to_run": command,
+    }
+
+    # Write cmdrunner.yaml into the current directory
+    monkeypatch.chdir(tmp_path)
+    config_file = tmp_path / "cmdrunner.yaml"
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, "argv", ["cmdrunner.py"])
+
+    cmdrunner.main()
+
+    assert (proj / "fallback_test.txt").exists()
+    assert (proj / "fallback_test.txt").read_text() == "fallback_ok"


### PR DESCRIPTION
* **Context:** CLI (Command Line Interface)
* **Problem:** Users have to type the name of the configuration file even if they are using the default/standard `cmdrunner.yaml` in their directory, leading to redundant keystrokes and friction.
* **Solution:** Enhanced the script to automatically fall back to loading `cmdrunner.yaml` from the current working directory if it is present and no custom config path or direct override run parameters are specified. Added complete unit test coverage to verify this fallback behavior.

---
*PR created automatically by Jules for task [2502094918417054382](https://jules.google.com/task/2502094918417054382) started by @RainRat*