### PR TITLE
Inline _read_diff_file in diff2typo.py to remove premature abstraction

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -548,18 +548,6 @@ def _read_stdin_text() -> str:
     return _decode_with_fallback(data, "input diff from standard input")
 
 
-def _read_diff_file(file_path: str) -> str:
-    """Return diff text from ``file_path`` with encoding fallback."""
-
-    try:
-        with open(file_path, "rb") as file_handle:
-            data = file_handle.read()
-        return _decode_with_fallback(data, f"input diff file '{file_path}'")
-    except FileNotFoundError:
-        logging.error(f"Input file '{file_path}' not found. Exiting.")
-        sys.exit(1)
-
-
 def _read_git_diff(git_args: Optional[str]) -> str:
     """Fetch diff directly from Git using the provided arguments."""
     command = ["git", "diff"]
@@ -601,7 +589,9 @@ def _read_diff_sources(input_files: Optional[Sequence[str]]) -> str:
             if not os.path.isfile(match):
                 logging.error(f"Input file '{match}' not found. Exiting.")
                 sys.exit(1)
-            contents.append(_read_diff_file(match))
+            with open(match, "rb") as file_handle:
+                data = file_handle.read()
+            contents.append(_decode_with_fallback(data, f"input diff file '{match}'"))
 
     return "\n".join(contents)
 

--- a/tests/test_diff2typo_coverage.py
+++ b/tests/test_diff2typo_coverage.py
@@ -67,9 +67,9 @@ def test_read_stdin_text_str(monkeypatch, caplog):
         assert text == "text input"
         assert "Successfully read input diff from standard input" in caplog.text
 
-def test_read_diff_file_not_found():
+def test_read_diff_sources_missing_file():
     with pytest.raises(SystemExit) as excinfo:
-        diff2typo._read_diff_file("missing.diff")
+        diff2typo._read_diff_sources(["missing.diff"])
     assert excinfo.value.code == 1
 
 def test_read_diff_sources_no_files(monkeypatch):


### PR DESCRIPTION
Improve code quality in `diff2typo.py` by inlining the `_read_diff_file` private function and removing redundant `try/except FileNotFoundError` blocks. The test suite has been cleanly updated to match this refactoring.

---
*PR created automatically by Jules for task [11310134682819608027](https://jules.google.com/task/11310134682819608027) started by @RainRat*