### PR TITLE
[DOCS] Document gentypos options, legacy cmdrunner settings, and clean terminology

### DIFF
--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -26,7 +26,7 @@ python cmdrunner.py --main-folder /home/user/projects --command-to-run "git stat
 
 ## Configuration
 
-The tool uses a YAML file to know where to look and what to do.
+The tool uses a YAML file to know where to look and what to do. Both `main_folder` and the legacy key `base_directory` are fully supported to specify the folder to scan.
 
 ### Example Configuration (`config.yaml`)
 
@@ -48,6 +48,7 @@ excluded_folders:
 
 - `CONFIG_PATH`: (Optional) The path to your YAML configuration file.
 - `-m`, `--main-folder`: The main folder containing your projects. Overrides config file if provided.
+- `-b`, `--base-directory`: Legacy alias for the main folder containing your projects. Overrides config file if provided.
 - `-c`, `--command-to-run`: The command to run in each folder. Overrides config file if provided.
 - `-e`, `--excluded-folders`: A space-separated list of folders to skip. Overrides config file if provided.
 - `--dry-run`: Shows which folders would be processed and which command would run without actually doing it. Use this to test your setup safely.

--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -24,6 +24,21 @@ Use a configuration file to process a large word list and save the results.
 python gentypos.py --config gentypos.yaml
 ```
 
+## Options
+
+| Argument | Default | Description |
+| :--- | :--- | :--- |
+| `words` | None | One or more words to generate typos for. If provided, the tool ignores the input file in your configuration. |
+| `--config`, `-c` | `gentypos.yaml` | The path to your YAML configuration file. |
+| `--output`, `-o` | None | Save results to this file. Use `-` to print to the screen. |
+| `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), or `list` (typo). By default, it is automatically detected from the output file extension. |
+| `--substitutions`, `-s` | None | A file containing custom typo patterns (JSON, CSV, or YAML). Useful for loading your personal typo history from `typostats.py`. |
+| `--min-length`, `-m` | None | Ignore words shorter than this length. |
+| `--max-length` | None | Ignore words longer than this length. |
+| `--no-filter` | Off | Do not check typos against the large dictionary (makes generation faster). |
+| `--verbose`, `-v` | Off | Show more detailed log messages. |
+| `--quiet`, `-q` | Off | Hide progress bars and status messages. |
+
 ## Configuration (`gentypos.yaml`)
 
 The tool uses a YAML file to control how typos are generated.

--- a/gentypos.yaml
+++ b/gentypos.yaml
@@ -1,4 +1,4 @@
-# Configuration for Fake Typo Generator
+# Configuration for Typo Generator
 
 # File Paths
 input_file: "wordlist_small.txt"       # Path to the small dictionary (one per line)


### PR DESCRIPTION
This pull request introduces documentation improvements across gentypos.py and cmdrunner.py:
1. Improved `docs/gentypos.md` by adding a comprehensive CLI Options table mapping all command-line arguments and flags of `gentypos.py`.
2. Clarified `docs/cmdrunner.md` by documenting the legacy base_directory option (`-b`/`--base-directory`) and the fact that both `main_folder` and `base_directory` keys are fully supported in the YAML configuration.
3. Updated `gentypos.yaml` comments to replace outdated "Fake Typo Generator" terminology with "Typo Generator" to align with project and AGENTS.md standards.

---
*PR created automatically by Jules for task [1229173149654134476](https://jules.google.com/task/1229173149654134476) started by @RainRat*