### PR TITLE
[UI/UX] Add piped standard input and output fallbacks for gentypos.py

### DIFF
--- a/gentypos.py
+++ b/gentypos.py
@@ -948,6 +948,15 @@ def main() -> None:
     if is_cli_mode and not config_loaded:
         config = {}
 
+    if not is_cli_mode and not sys.stdin.isatty():
+        if not config.get('input_file'):
+            config['input_file'] = '-'
+            if not args.output:
+                config['output_file'] = '-'
+            dict_file = config.get('dictionary_file')
+            if dict_file and not os.path.exists(dict_file):
+                config['dictionary_file'] = None
+
     # Prepare defaults for this run
     # Avoid mutating global DEFAULT_CONFIG to ensure thread/process safety and testability
     run_defaults = copy.deepcopy(DEFAULT_CONFIG)
@@ -987,7 +996,7 @@ def main() -> None:
         if args.max_length is not None:
             config['word_length']['max_length'] = args.max_length
 
-    validate_config(config, cli_mode=is_cli_mode, config_defaults=run_defaults)
+    validate_config(config, cli_mode=is_cli_mode or (not is_cli_mode and not sys.stdin.isatty()), config_defaults=run_defaults)
 
     settings = _extract_config_settings(config, quiet=args.quiet)
 

--- a/tests/test_gentypos_coverage_expansion.py
+++ b/tests/test_gentypos_coverage_expansion.py
@@ -302,3 +302,16 @@ def test_generate_typos_by_replacement_multi_char():
     result_multi = gentypos.generate_typos_by_replacement('phph', adjacent, custom)
     assert 'fph' in result_multi
     assert 'phf' in result_multi
+
+def test_main_piped_stdin_fallback(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdin", StringIO("hello\n"))
+    monkeypatch.setattr(sys, "argv", ["gentypos.py"])
+
+    # Mock os.path.exists to return False for config, input, and dictionary files
+    monkeypatch.setattr("os.path.exists", lambda path: False)
+
+    with patch("gentypos._run_typo_generation", return_value={"hallo": "hello"}) as mock_gen:
+        gentypos.main()
+        assert mock_gen.called
+        captured = capsys.readouterr()
+        assert "hallo -> hello" in captured.out


### PR DESCRIPTION
### PR Title: [UI/UX] Add piped standard input and output fallbacks for gentypos.py

### Description:
* **Context:** CLI
* **Problem:** When piping words directly into `gentypos.py` (e.g., via a standard pipeline like `cat words.txt | python gentypos.py`), the tool ignores standard input and attempts to load the default `wordlist_small.txt` file configured in `gentypos.yaml`. If this file is missing, the command crashes with a `FileNotFoundError`, forcing users to modify configuration files or type out explicit flags even for the most common operations.
* **Solution:** Detect when no positional words are provided and standard input is redirected/piped (i.e. `not sys.stdin.isatty()`). Under this state, the tool automatically defaults the input source to stdin (`'-'`) and the output destination to stdout (`'-'`), while seamlessly skipping large dictionary filtering if the configured dictionary file is not present on disk. It also bypasses schema strictness constraints for piped workflows.

### Changes:
* Modified `gentypos.py` to add robust fallback detection when stdin is not a TTY.
* Modified `tests/test_gentypos_coverage_expansion.py` to add a specific unit test `test_main_piped_stdin_fallback` covering this behavior.

---
*PR created automatically by Jules for task [13573012400529718764](https://jules.google.com/task/13573012400529718764) started by @RainRat*