### PR TITLE
[DOCS] Update terminology in gentypos config from Fake Typo Generator to Typo Generator

### DIFF
--- a/gentypos.yaml
+++ b/gentypos.yaml
@@ -1,4 +1,4 @@
-# Configuration for Fake Typo Generator
+# Configuration for Typo Generator
 
 # File Paths
 input_file: "wordlist_small.txt"       # Path to the small dictionary (one per line)


### PR DESCRIPTION
We changed 'Fake Typo Generator' to 'Typo Generator' on the first line comment in gentypos.yaml to keep terminology consistent with standard guidelines.

---
*PR created automatically by Jules for task [5976394928407868959](https://jules.google.com/task/5976394928407868959) started by @RainRat*