### PR TITLE
[UI/UX] Prioritize piped standard input in gentypos.py to reduce friction

### DIFF
--- a/gentypos.py
+++ b/gentypos.py
@@ -988,7 +988,7 @@ def main() -> None:
         config = {}
 
     if not is_cli_mode and not sys.stdin.isatty():
-        if not config.get('input_file'):
+        if args.config == "gentypos.yaml" or not config.get('input_file'):
             config['input_file'] = '-'
             if not args.output:
                 config['output_file'] = '-'

--- a/tests/test_gentypos_interactive.py
+++ b/tests/test_gentypos_interactive.py
@@ -1,0 +1,46 @@
+import io
+import os
+import sys
+import json
+from unittest.mock import patch
+import pytest
+import gentypos
+
+def test_gentypos_non_interactive_reads_stdin_instead_of_default_config(capsys, monkeypatch):
+    # Mock os.path.exists to return True for gentypos.yaml
+    original_exists = os.path.exists
+    def mock_exists(path):
+        if path == "gentypos.yaml":
+            return True
+        return original_exists(path)
+    monkeypatch.setattr(os.path, "exists", mock_exists)
+
+    # Mock parse_yaml_config to return the default config dictionary
+    default_config_data = {
+        "input_file": "wordlist_small.txt",
+        "dictionary_file": None,
+        "output_format": "list",
+    }
+    monkeypatch.setattr(gentypos, "parse_yaml_config", lambda path: default_config_data)
+
+    # Mock stdin content
+    mock_stdin = io.StringIO("hello\n")
+
+    # Mock argv with no config file argument (uses default gentypos.yaml)
+    test_args = [
+        "gentypos.py",
+        "-f", "list",
+        "--no-filter",
+        "-m", "3",
+    ]
+
+    with patch("sys.stdin.isatty", return_value=False), \
+         patch("sys.stdin", mock_stdin), \
+         patch("sys.argv", test_args):
+        gentypos.main()
+
+    captured = capsys.readouterr()
+    stdout_lines = captured.out.splitlines()
+    assert len(stdout_lines) > 0
+    # verify that typos like "ehllo" (transposition) or "gello" (adjacent replacement of 'h') are generated
+    assert "ehllo" in stdout_lines or "gello" in stdout_lines


### PR DESCRIPTION
### PR Title: [UI/UX] Prioritize piped standard input in gentypos.py to reduce friction

### Description:
* **Context:** CLI (Command Line Interface)
* **Problem:** When a user pipes standard input to `gentypos.py` (e.g., `echo "hello" | python gentypos.py`), the command crashes attempting to open the non-existent file `wordlist_small.txt`. This happens because `gentypos.py` loads the default `gentypos.yaml` configuration file automatically, which specifies a default `input_file: "wordlist_small.txt"`. This default overrides the standard input fallback logic and forces users to explicitly pass `-i -` to specify standard input, presenting a major friction point and violating intuitive Unix piping standards.
* **Solution:** Improved the standard input fallback logic in `gentypos.py` to unconditionally prioritize standard input (`'-'`) and standard output (`'-'`) when standard input is non-interactive/piped (`not sys.stdin.isatty()`), provided that standard input is not overridden by explicit CLI arguments and that the default configuration is used. This allows standard pipelines to work seamlessly and intuitively without requiring redundant flags or breaking on default file-based configuration.

### Changes:
```python
    if not is_cli_mode and not sys.stdin.isatty():
        if args.config == "gentypos.yaml" or not config.get('input_file'):
            config['input_file'] = '-'
            if not args.output:
                config['output_file'] = '-'
            dict_file = config.get('dictionary_file')
            if dict_file and not os.path.exists(dict_file):
                config['dictionary_file'] = None
```

---
*PR created automatically by Jules for task [3125225441091129860](https://jules.google.com/task/3125225441091129860) started by @RainRat*