### PR TITLE
[FEAT] Add require_file filtering option to cmdrunner.py

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -115,6 +115,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if "timeout" in config and (isinstance(config["timeout"], bool) or not isinstance(config["timeout"], (int, float))):
         errors.append("'timeout' must be a number.")
 
+    if "require_file" in config and not isinstance(config["require_file"], str):
+        errors.append("'require_file' must be a string if provided.")
+
     if errors:
         raise ConfigError(" ".join(errors))
 
@@ -130,6 +133,7 @@ def run_command_in_folders(
     timeout: Optional[float] = None,
     output_file: Optional[str] = None,
     output_format: Optional[str] = None,
+    require_file: Optional[str] = None,
 ) -> None:
     """
     Run a specified command in each folder within the main folder,
@@ -143,7 +147,9 @@ def run_command_in_folders(
 
     directories = sorted([
         item for item in os.listdir(main_folder)
-        if os.path.isdir(os.path.join(main_folder, item)) and item not in excluded_folders
+        if os.path.isdir(os.path.join(main_folder, item))
+        and item not in excluded_folders
+        and (not require_file or os.path.isfile(os.path.join(main_folder, item, require_file)))
     ])
 
     iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
@@ -313,6 +319,12 @@ def parse_arguments() -> argparse.Namespace:
         nargs='+',
         help='Folders you want the tool to skip. Overrides config file if provided.'
     )
+    direct_group.add_argument(
+        '-r', '--require-file',
+        dest='require_file',
+        type=str,
+        help='Only process folders that contain this specific file. Overrides config file if provided.'
+    )
 
     # Execution Options Group
     options_group = parser.add_argument_group(f"{BLUE}EXECUTION OPTIONS{RESET}")
@@ -392,6 +404,7 @@ def main() -> None:
     main_folder = args.main_folder or args.base_directory or config.get('main_folder') or config.get('base_directory', '')
     command_to_run = args.command_to_run or config.get('command_to_run', '')
     excluded = args.excluded_folders if args.excluded_folders is not None else config.get('excluded_folders', [])
+    require_file = args.require_file or config.get('require_file', None)
 
     # Prioritize CLI values over config file values
     fail_fast = args.fail_fast if args.fail_fast is not None else config.get('fail_fast', False)
@@ -419,6 +432,7 @@ def main() -> None:
         timeout=timeout,
         output_file=args.output,
         output_format=args.format,
+        require_file=require_file,
     )
 
 if __name__ == "__main__":

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -48,6 +48,9 @@ fail_fast: false
 
 # (Optional) The maximum execution time in seconds for the command in each folder
 timeout: 10.5
+
+# (Optional) Only process folders containing this specific file
+require_file: "package.json"
 ```
 
 ## Options
@@ -61,6 +64,7 @@ timeout: 10.5
 - `--quiet`: Hides status messages and progress bars.
 - `--fail-fast`: Stop execution immediately if any command fails or times out. Overrides config file if provided.
 - `--timeout`: The maximum execution time in seconds for the command in each folder. Overrides config file if provided.
+- `-r`, `--require-file`: Only process folders that contain this specific file. Overrides config file if provided.
 - `-o`, `--output`: Where to save the execution report. If not provided, no report is saved.
 - `-f`, `--format`: Choose the format for the output report (`json`, `csv`, `txt`). If not provided, it is automatically detected from the output file extension.
 

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -832,3 +832,87 @@ def test_main_no_fallback_when_direct_options_provided(tmp_path, monkeypatch):
     # Verify that the direct option was run instead of the bad config file path
     assert (base_dir / 'proj1' / 'direct_test.txt').exists()
     assert (base_dir / 'proj1' / 'direct_test.txt').read_text() == 'direct_ok'
+
+
+def test_load_config_require_file_validation(tmp_path):
+    config_file = tmp_path / "config.yaml"
+
+    # Valid config with require_file
+    config_file.write_text(yaml.safe_dump({
+        "main_folder": "/tmp",
+        "command_to_run": "echo",
+        "require_file": "package.json"
+    }))
+    assert cmdrunner.load_config(str(config_file))["require_file"] == "package.json"
+
+    # Invalid configurations (must be a string)
+    config_file.write_text(yaml.safe_dump({
+        "main_folder": "/tmp",
+        "command_to_run": "echo",
+        "require_file": 123
+    }))
+    with pytest.raises(cmdrunner.ConfigError, match="'require_file' must be a string if provided."):
+        cmdrunner.load_config(str(config_file))
+
+
+def test_run_command_require_file_filtering(tmp_path):
+    base_dir = tmp_path / "projects"
+    base_dir.mkdir()
+
+    # Setup directories
+    p1 = base_dir / "proj_with_file"
+    p2 = base_dir / "proj_without_file"
+    p1.mkdir()
+    p2.mkdir()
+
+    # Place required file only in p1
+    (p1 / "package.json").write_text("{}")
+
+    # Command that touches a file to verify execution
+    command = "python3 -c \"from pathlib import Path; Path('touched.txt').write_text('yes')\""
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        command,
+        require_file="package.json"
+    )
+
+    # Verification: p1 should have 'touched.txt', but p2 should NOT since it was skipped
+    assert (p1 / "touched.txt").exists()
+    assert not (p2 / "touched.txt").exists()
+
+
+def test_main_cli_overrides_require_file(tmp_path, monkeypatch):
+    base_dir = tmp_path / "projects"
+    base_dir.mkdir()
+
+    p1 = base_dir / "proj1"
+    p2 = base_dir / "proj2"
+    p1.mkdir()
+    p2.mkdir()
+
+    # Place require_file "requirements.txt" in p1 and "package.json" in p2
+    (p1 / "requirements.txt").write_text("")
+    (p2 / "package.json").write_text("")
+
+    # Configuration file specifies "requirements.txt"
+    config_data = {
+        "main_folder": str(base_dir),
+        "command_to_run": "python3 -c \"from pathlib import Path; Path('run.txt').write_text('run')\"",
+        "require_file": "requirements.txt"
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    # CLI override specifies "package.json"
+    monkeypatch.setattr(sys, "argv", [
+        "cmdrunner.py",
+        str(config_file),
+        "-r", "package.json"
+    ])
+
+    cmdrunner.main()
+
+    # Since CLI overrides configuration, only p2 (which has package.json) should have been run.
+    assert not (p1 / "run.txt").exists()
+    assert (p2 / "run.txt").exists()


### PR DESCRIPTION
This PR adds a highly useful directory filtering capability to cmdrunner.py based on the presence of a specified file. With `--require-file` (or `-r` from the CLI, or `require_file` key in YAML config), folders that do not contain the target file are automatically skipped. This prevents unnecessary errors and runs commands (e.g., build or package commands) only where relevant files (like package.json, requirements.txt, etc.) are actually present. Fully documented in docs/cmdrunner.md and backed by comprehensive unit tests.

---
*PR created automatically by Jules for task [9919041009770888162](https://jules.google.com/task/9919041009770888162) started by @RainRat*