### PR TITLE
Refactor: Inline _detect_format_from_extension in diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -225,33 +225,6 @@ def filter_to_letters(text: str) -> str:
     return re.sub("[^a-z]", "", text.lower())
 
 
-def _detect_format_from_extension(path: str, allowed: Sequence[str], default: str) -> str:
-    """
-    Detect the output format based on the file extension.
-    Returns the default if no match is found or no extension is present.
-    """
-    if not path or path == '-':
-        return default
-
-    ext = os.path.splitext(path)[1].lower().lstrip('.')
-    if not ext:
-        return default
-
-    # Map common extensions to tool-supported formats
-    mapping = {
-        'txt': 'arrow',
-        'csv': 'csv',
-        'table': 'table',
-        'toml': 'table',
-        'list': 'list',
-        'arrow': 'arrow',
-    }
-
-    detected = mapping.get(ext)
-    if detected in allowed:
-        return detected
-
-    return default
 
 
 def levenshtein_distance(s1: str, s2: str) -> int:
@@ -912,8 +885,22 @@ def main():
 
     # Resolve output format if not provided
     if args.output_format is None:
+        default_fmt = 'arrow'
         allowed_formats = ['arrow', 'csv', 'table', 'list']
-        args.output_format = _detect_format_from_extension(args.output_file, allowed_formats, 'arrow')
+        if args.output_file and args.output_file != '-':
+            ext = os.path.splitext(args.output_file)[1].lower().lstrip('.')
+            mapping = {
+                'txt': 'arrow',
+                'csv': 'csv',
+                'table': 'table',
+                'toml': 'table',
+                'list': 'list',
+                'arrow': 'arrow',
+            }
+            detected = mapping.get(ext)
+            args.output_format = detected if detected in allowed_formats else default_fmt
+        else:
+            args.output_format = default_fmt
 
     log_level = logging.WARNING if args.quiet else logging.INFO
     # Use a custom handler and formatter to keep output clean

--- a/tests/test_diff2typo_summary_coverage.py
+++ b/tests/test_diff2typo_summary_coverage.py
@@ -53,9 +53,6 @@ def test_format_analysis_summary_unhashable():
     summary_text = "\n".join(summary_lines)
     assert "Unique typos:                       2" in summary_text
 
-def test_detect_format_from_extension_edges():
-    assert diff2typo._detect_format_from_extension("file", ["arrow"], "arrow") == "arrow"
-    assert diff2typo._detect_format_from_extension("file.unknown", ["arrow"], "arrow") == "arrow"
 
 def test_main_summary_labels_audit_mode(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
This pull request resolves an instance of Premature Abstraction by inlining the private helper function `_detect_format_from_extension` inside `diff2typo.py` directly into its only call site in the `main()` function.

### Technical Explanation
- **What:** Inlined `_detect_format_from_extension` into `main()` in `diff2typo.py` and deleted the original function definition. Also removed the corresponding `test_detect_format_from_extension_edges` test in `tests/test_diff2typo_summary_coverage.py`.
- **Why:** The helper function was only used once inside `main()`, making it a premature abstraction that added unnecessary complexity. Inlining it simplifies the module-level API, reduces code footprint, and makes the file easier to maintain.
- **Verification:** Ran all 1152 unit tests and verified that they pass with 100% success and no behavioral regressions.

---
*PR created automatically by Jules for task [16576869034901985475](https://jules.google.com/task/16576869034901985475) started by @RainRat*