### PR TITLE
[UI/UX] Add short-flag aliases to diff2typo.py for enhanced efficiency

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -777,7 +777,7 @@ def main():
         help="One or more input Git diff files or patterns. Use '-' to read from standard input.",
     )
     io_group.add_argument(
-        '--git',
+        '-g', '--git',
         nargs='?',
         const='',
         help="Fetch diff directly from Git. Optional arguments are passed to 'git diff'.",
@@ -820,7 +820,7 @@ def main():
     # Analysis Options
     analysis_group = parser.add_argument_group(f"{BLUE}ANALYSIS OPTIONS{RESET}")
     analysis_group.add_argument(
-        '--mode',
+        '-M', '--mode',
         type=str,
         choices=['typos', 'corrections', 'both', 'audit'],
         default='typos',
@@ -844,14 +844,14 @@ def main():
     parser.add_argument('--min_length', type=int, help=argparse.SUPPRESS, default=argparse.SUPPRESS)
 
     analysis_group.add_argument(
-        '--max-dist',
+        '-D', '--max-dist',
         type=int,
         default=None,
         help='Only include typos with a number of character changes up to this value (default: no limit).',
     )
 
     analysis_group.add_argument(
-        '--min-count',
+        '-c', '--min-count',
         type=int,
         default=1,
         help='Minimum occurrences of a typo in the diff to include it in the output (default: 1).',

--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -24,13 +24,13 @@ git diff | python diff2typo.py [OPTIONS]
 | Argument | Default | Description |
 | :--- | :--- | :--- |
 | `FILE` | standard input | One or more input Git diff files. Use `-` to read from standard input. |
-| `--git` | None | Fetch diff directly from Git. Optional arguments are passed to `git diff` (for example, `--git "HEAD~3"`). |
+| `--git`, `-g` | None | Fetch diff directly from Git. Optional arguments are passed to `git diff` (for example, `-g "HEAD~3"`). |
 | `--output`, `-o` | the screen | Path to the output file. Use `-` to print to the screen. |
 | `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), or `list` (typo only). |
-| `--mode` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
+| `--mode`, `-M` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
 | `--min-length`, `-m` | `2` | Ignore words shorter than this length. |
-| `--max-dist` | None | Only include typos with a number of character changes up to this value. Useful for filtering out intentional word changes. |
-| `--min-count` | `1` | Minimum occurrences of a typo in the diff to include it in the output. |
+| `--max-dist`, `-D` | None | Only include typos with a number of character changes up to this value. Useful for filtering out intentional word changes. |
+| `--min-count`, `-c` | `1` | Minimum occurrences of a typo in the diff to include it in the output. |
 | `--sort` | `alpha` | How to sort the results: `count` (most frequent first) or `alpha` (alphabetical). |
 | `--limit`, `-L` | None | Limit the number of typos in the output. |
 | `--dictionary`, `-d` | `words.csv` | A file containing the large dictionary of correct words. The tool uses this to make sure the "fix" is a real word. |

--- a/tests/test_diff2typo_short_flags.py
+++ b/tests/test_diff2typo_short_flags.py
@@ -1,0 +1,50 @@
+import sys
+import argparse
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import diff2typo
+
+def test_short_flags_parsing(monkeypatch):
+    """Verify that short flags -g, -M, -D, -c parse identically to long flags."""
+
+    import argparse
+    original_parse = argparse.ArgumentParser.parse_args
+    captured_args = []
+    def mock_parse(self, *args, **kwargs):
+        res = original_parse(self, *args, **kwargs)
+        captured_args.append(res)
+        return res
+
+    monkeypatch.setattr(argparse.ArgumentParser, 'parse_args', mock_parse)
+    monkeypatch.setattr(diff2typo, '_read_diff_sources', lambda _: "--- a/f\n+++ b/f\n-teh\n+the")
+    monkeypatch.setattr(diff2typo, 'read_words_mapping', lambda *a, **kw: {})
+    monkeypatch.setattr(diff2typo, 'read_allowed_words', lambda *a, **kw: set())
+
+    # Test short flags: -g, -M, -D, -c
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        [
+            'diff2typo.py',
+            '-g', 'HEAD~1',
+            '-M', 'both',
+            '-D', '3',
+            '-c', '2',
+            '--quiet'
+        ]
+    )
+
+    try:
+        diff2typo.main()
+    except SystemExit:
+        pass
+
+    assert len(captured_args) > 0
+    args = captured_args[-1]
+    assert args.git == 'HEAD~1'
+    assert args.mode == 'both'
+    assert args.max_dist == 3
+    assert args.min_count == 2


### PR DESCRIPTION
Add short-flag aliases for commonly used parameters in `diff2typo.py` to reduce friction, improve command efficiency, and minimize keystrokes for common tasks: `-g` for `--git`, `-M` for `--mode`, `-D` for `--max-dist`, and `-c` for `--min-count`. This change is non-destructive, fully documented in `docs/diff2typo.md`, and thoroughly tested in `tests/test_diff2typo_short_flags.py`.

---
*PR created automatically by Jules for task [7785100799929145824](https://jules.google.com/task/7785100799929145824) started by @RainRat*