### PR TITLE
[TEST] Add missing coverage for gentypos.py standard input fallback handling

### DIFF
--- a/tests/test_gentypos_gaps.py
+++ b/tests/test_gentypos_gaps.py
@@ -139,3 +139,15 @@ def test_main_max_length_only(tmp_path, monkeypatch):
         assert config['word_length']['max_length'] == 10
         # min_length is set to 0 by default in CLI mode if not provided
         assert config['word_length']['min_length'] == 0
+
+
+def test_stdin_no_input_file_missing_dict(tmp_path, monkeypatch, capsys):
+    import io
+    config_file = tmp_path / "config_missing_dict.yaml"
+    config_file.write_text("dictionary_file: 'non_existent_dict.txt'\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["gentypos.py", "-c", str(config_file)])
+    monkeypatch.setattr(sys, "stdin", io.StringIO("pineapple\n"))
+    gentypos.main()
+    captured = capsys.readouterr()
+    assert len(captured.out) > 0
+    assert "-> pineapple" in captured.out


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Added a new unit test `test_stdin_no_input_file_missing_dict` in `tests/test_gentypos_gaps.py`. This test exercises standard input fallback handling (`stdin` is not a terminal) when there's no input file specified and a non-existent dictionary file is provided.
* **Why:** To close the final remaining test coverage gap in `gentypos.py`, bringing its statement coverage to exactly 100%.

---
*PR created automatically by Jules for task [15477307235468161880](https://jules.google.com/task/15477307235468161880) started by @RainRat*