### PR TITLE
[DOCS] Fix outdated installation reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The **diff2typo Suite** is a set of tools to help you find and fix typos in your
 
 - **Python 3.10 or newer:** The suite uses recent Python features.
 - **Git:** Required to use `diff2typo.py` with your repository history.
-- **Dependencies:** The following Python packages are required and will be installed in step 2:
+- **Dependencies:** The following Python packages are required and will be installed in step 3:
   - `PyYAML`: Handles configuration files.
   - `pyahocorasick`: Performs fast string matching.
   - `tqdm`: Displays progress bars for long tasks.


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Section "Prerequisites" under `README.md` was improved.
* **Why:** The installation section of `README.md` listed that dependencies will be installed in "step 2", but they are actually installed in "step 3". This fixes the incorrect reference to provide clear and accurate setup instructions.

---
*PR created automatically by Jules for task [2468735772305871567](https://jules.google.com/task/2468735772305871567) started by @RainRat*