### PR TITLE
[FEAT] Add --if-exists directory filtering in cmdrunner.py

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -115,6 +115,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if "timeout" in config and (isinstance(config["timeout"], bool) or not isinstance(config["timeout"], (int, float))):
         errors.append("'timeout' must be a number.")
 
+    if "if_exists" in config and not isinstance(config["if_exists"], str):
+        errors.append("'if_exists' must be a string.")
+
     if errors:
         raise ConfigError(" ".join(errors))
 
@@ -130,6 +133,7 @@ def run_command_in_folders(
     timeout: Optional[float] = None,
     output_file: Optional[str] = None,
     output_format: Optional[str] = None,
+    if_exists: Optional[str] = None,
 ) -> None:
     """
     Run a specified command in each folder within the main folder,
@@ -145,6 +149,12 @@ def run_command_in_folders(
         item for item in os.listdir(main_folder)
         if os.path.isdir(os.path.join(main_folder, item)) and item not in excluded_folders
     ])
+
+    if if_exists:
+        directories = [
+            item for item in directories
+            if os.path.exists(os.path.join(main_folder, item, if_exists))
+        ]
 
     iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
 
@@ -313,6 +323,11 @@ def parse_arguments() -> argparse.Namespace:
         nargs='+',
         help='Folders you want the tool to skip. Overrides config file if provided.'
     )
+    direct_group.add_argument(
+        '--if-exists',
+        type=str,
+        help='Only run the command in folders that contain this specific file or path (e.g., package.json).'
+    )
 
     # Execution Options Group
     options_group = parser.add_argument_group(f"{BLUE}EXECUTION OPTIONS{RESET}")
@@ -396,6 +411,7 @@ def main() -> None:
     # Prioritize CLI values over config file values
     fail_fast = args.fail_fast if args.fail_fast is not None else config.get('fail_fast', False)
     timeout = args.timeout if args.timeout is not None else config.get('timeout', None)
+    if_exists = args.if_exists or config.get('if_exists', None)
 
     # Validate that required options are present
     errors = []
@@ -419,6 +435,7 @@ def main() -> None:
         timeout=timeout,
         output_file=args.output,
         output_format=args.format,
+        if_exists=if_exists,
     )
 
 if __name__ == "__main__":

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -48,6 +48,9 @@ fail_fast: false
 
 # (Optional) The maximum execution time in seconds for the command in each folder
 timeout: 10.5
+
+# (Optional) Only run the command in folders that contain this specific file or path
+if_exists: "package.json"
 ```
 
 ## Options
@@ -61,6 +64,7 @@ timeout: 10.5
 - `--quiet`: Hides status messages and progress bars.
 - `--fail-fast`: Stop execution immediately if any command fails or times out. Overrides config file if provided.
 - `--timeout`: The maximum execution time in seconds for the command in each folder. Overrides config file if provided.
+- `--if-exists`: Only run the command in folders that contain this specific file or path (e.g., `package.json` or `requirements.txt`). Overrides config file if provided.
 - `-o`, `--output`: Where to save the execution report. If not provided, no report is saved.
 - `-f`, `--format`: Choose the format for the output report (`json`, `csv`, `txt`). If not provided, it is automatically detected from the output file extension.
 
@@ -80,7 +84,7 @@ In this example, if the tool processes a folder named `my-web-app`, it will run 
 ## How it Works
 
 1. **Find Folders:** The tool looks inside your `main_folder` and finds every sub-folder.
-2. **Filter:** It removes any folders you listed in `excluded_folders`.
+2. **Filter:** It removes any folders you listed in `excluded_folders`, and filters remaining folders to only those containing the specified `--if-exists` file or path (if provided).
 3. **Execute:** It enters each remaining folder and runs your `command_to_run`.
 4. **Report:** It shows you the results of each command or any errors that occurred.
 
@@ -104,4 +108,9 @@ python cmdrunner.py my_setup.yaml --dry-run
 **Run a command across your projects quietly:**
 ```bash
 python cmdrunner.py config.yaml --quiet
+```
+
+**Only run commands in projects containing a `package.json` file:**
+```bash
+python cmdrunner.py --main-folder /home/user/projects --command-to-run "npm run build" --if-exists package.json
 ```

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -832,3 +832,104 @@ def test_main_no_fallback_when_direct_options_provided(tmp_path, monkeypatch):
     # Verify that the direct option was run instead of the bad config file path
     assert (base_dir / 'proj1' / 'direct_test.txt').exists()
     assert (base_dir / 'proj1' / 'direct_test.txt').read_text() == 'direct_ok'
+
+
+def test_load_config_invalid_if_exists(tmp_path):
+    config_file = tmp_path / 'config_invalid_if_exists.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'if_exists': 123,  # Invalid type (must be string)
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'if_exists' must be a string." in exc_info.value.args[0]
+
+
+def test_run_command_if_exists_filtering(tmp_path):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj_with_file = base_dir / 'proj_with_file'
+    proj_without_file = base_dir / 'proj_without_file'
+    proj_with_file.mkdir()
+    proj_without_file.mkdir()
+
+    # Create target file only in one folder
+    (proj_with_file / 'target.txt').write_text('exists')
+
+    command = "python3 -c \"open('test_file.txt','w').write('ran')\""
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        command,
+        if_exists='target.txt'
+    )
+
+    # Should run in proj_with_file because it contains target.txt
+    assert (proj_with_file / 'test_file.txt').exists()
+    assert (proj_with_file / 'test_file.txt').read_text() == 'ran'
+
+    # Should NOT run in proj_without_file
+    assert not (proj_without_file / 'test_file.txt').exists()
+
+
+def test_main_with_if_exists_cli_override(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    (proj1 / 'special.json').write_text('{}')
+
+    command = "python3 -c \"open('out.txt','w').write('ok')\""
+
+    # CLI override --if-exists
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['cmdrunner.py', '-m', str(base_dir), '-c', command, '--if-exists', 'special.json']
+    )
+
+    cmdrunner.main()
+
+    assert (proj1 / 'out.txt').exists()
+    assert not (proj2 / 'out.txt').exists()
+
+
+def test_main_with_if_exists_config(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    (proj2 / 'config.ini').write_text('')
+
+    command = "python3 -c \"open('out_conf.txt','w').write('ok')\""
+
+    config_data = {
+        'main_folder': str(base_dir),
+        'command_to_run': command,
+        'if_exists': 'config.ini',
+    }
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(config_file)])
+
+    cmdrunner.main()
+
+    assert not (proj1 / 'out_conf.txt').exists()
+    assert (proj2 / 'out_conf.txt').exists()


### PR DESCRIPTION
Implement a new --if-exists parameter for cmdrunner.py that filters directory processing to only target directories containing a specific file or path. This includes full configuration validation, execution logic filtering, CLI options, updated markdown documentation, and comprehensive unit tests.

---
*PR created automatically by Jules for task [4387127890082674553](https://jules.google.com/task/4387127890082674553) started by @RainRat*