### PR TITLE
[UI/UX] Improve contrast of default typostats frequency bars

### DIFF
--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -788,3 +788,13 @@ def test_main_stdin_path_explicit(capsys):
         typostats.main()
         out = capsys.readouterr().out
         assert "Total word pairs analyzed:" in out
+
+
+def test_generate_report_neutral_bar_color(capsys):
+    import os
+    counts = {("a", "b"): 1}
+    with patch('sys.stdout.isatty', return_value=True), \
+         patch.dict(os.environ, {}, clear=True):
+        typostats.generate_report(counts, output_format='arrow', quiet=False)
+        out = capsys.readouterr().out
+        assert "\033[1;36m" in out

--- a/typostats.py
+++ b/typostats.py
@@ -937,8 +937,7 @@ def generate_report(
                     marker_text = "[2:1]"
 
             if marker_text == "     ":
-                # If no specific classification, use neutral blue for the bar
-                marker_color_for_bar = c_blue
+                marker_color_for_bar = c_cyan
             else:
                 marker_color_for_bar = marker_color
 


### PR DESCRIPTION
Enhances visual readability of `typostats.py`'s report by changing fallback frequency bars color from dark blue to cyan, resolving the contrast issue with blue table structural lines.

---
*PR created automatically by Jules for task [2927129492090736614](https://jules.google.com/task/2927129492090736614) started by @RainRat*