### PR TITLE
[UI/UX] Improve gentypos.py interactive fallback UX

### DIFF
--- a/gentypos.py
+++ b/gentypos.py
@@ -1043,6 +1043,19 @@ def main() -> None:
         if args.max_length is not None:
             config['word_length']['max_length'] = args.max_length
 
+    if sys.stdin.isatty() and not cli_words:
+        resolved_input = config.get('input_file')
+        if not resolved_input or (resolved_input != '-' and not os.path.exists(resolved_input)):
+            logging.error(
+                "No input words or valid input file provided.\n"
+                "Please specify words as arguments, pipe them to stdin, or provide a valid input file.\n\n"
+                "Examples:\n"
+                "  python gentypos.py \"hello\" \"world\"\n"
+                "  echo \"hello\" | python gentypos.py\n"
+                "  python gentypos.py --input words.txt"
+            )
+            sys.exit(1)
+
     validate_config(config, cli_mode=is_cli_mode or (not is_cli_mode and not sys.stdin.isatty()), config_defaults=run_defaults)
 
     settings = _extract_config_settings(config, quiet=args.quiet)

--- a/tests/test_gentypos_interactive.py
+++ b/tests/test_gentypos_interactive.py
@@ -44,3 +44,21 @@ def test_gentypos_non_interactive_reads_stdin_instead_of_default_config(capsys, 
     assert len(stdout_lines) > 0
     # verify that typos like "ehllo" (transposition) or "gello" (adjacent replacement of 'h') are generated
     assert "ehllo" in stdout_lines or "gello" in stdout_lines
+
+
+def test_gentypos_interactive_missing_input_exits_gracefully(caplog, monkeypatch):
+    # Ensure config loading returns empty or references a non-existent file
+    monkeypatch.setattr(gentypos, "parse_yaml_config", lambda path: {})
+    # Mock exists to return False for configuration files or input files
+    monkeypatch.setattr(os.path, "exists", lambda path: False)
+
+    test_args = ["gentypos.py"]
+
+    with patch("sys.stdin.isatty", return_value=True), \
+         patch("sys.argv", test_args), \
+         pytest.raises(SystemExit) as excinfo:
+        gentypos.main()
+
+    assert excinfo.value.code == 1
+    # Check that our user-friendly error is in logs
+    assert any("No input words or valid input file provided" in record.message for record in caplog.records)


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** Running `gentypos.py` interactively without specifying input words or configuration files leads to a cryptic crash (either pointing to missing internal configuration fields or a missing default `wordlist_small.txt` file). This creates significant friction and confusion for users.
* **Solution:** Added a check when standard input is an interactive terminal (`sys.stdin.isatty()`) and no CLI words are specified. If the resolved input source is missing or non-existent, the tool now outputs a clean, highly helpful, and actionable error message with concrete CLI examples and exits gracefully with code 1.

**Changes:**
```python
    if sys.stdin.isatty() and not cli_words:
        resolved_input = config.get('input_file')
        if not resolved_input or (resolved_input != '-' and not os.path.exists(resolved_input)):
            logging.error(
                "No input words or valid input file provided.\n"
                "Please specify words as arguments, pipe them to stdin, or provide a valid input file.\n\n"
                "Examples:\n"
                "  python gentypos.py \"hello\" \"world\"\n"
                "  echo \"hello\" | python gentypos.py\n"
                "  python gentypos.py --input words.txt"
            )
            sys.exit(1)
```

---
*PR created automatically by Jules for task [6890440148561591273](https://jules.google.com/task/6890440148561591273) started by @RainRat*