### PR TITLE
[DOCS] Improve test execution documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,19 +96,21 @@ python multitool.py scrub . --mapping my_typos.txt --in-place --diff
 
 This project has a full suite of tests to make sure everything works correctly.
 
-To run all the tests in the repository, run this command:
+Always use `python -m pytest` instead of running `pytest` directly. This ensures that Python can find all project modules and avoids path errors.
+
+To run all the tests in the repository:
 ```bash
-pytest
+python -m pytest
 ```
 
 To run a specific test file, provide the path to that file:
 ```bash
-pytest tests/test_typostats.py
+python -m pytest tests/test_typostats.py
 ```
 
 To see more details about each test while it runs, use the verbose flag:
 ```bash
-pytest -v
+python -m pytest -v
 ```
 
 ## 📄 License


### PR DESCRIPTION
**PR Title:** [DOCS] Improve test execution documentation in README.md

**Description:**
* **Type:** Documentation
* **What:** The "Running Tests" section in `README.md` has been improved.
* **Why:** Running tests directly with `pytest` can fail with `ModuleNotFoundError` because the local project path is not added to Python's import search path on some development environments. Using `python -m pytest` ensures that Python prepends the current directory to `sys.path` and resolves imports correctly, offering a bulletproof, frictionless developer onboarding experience.

---
*PR created automatically by Jules for task [12490975632928097344](https://jules.google.com/task/12490975632928097344) started by @RainRat*