### PR TITLE
[FEAT] Add --include / -I flag to diff2typo.py to filter scanned files by glob patterns

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -413,11 +413,23 @@ def _is_file_excluded(filepath: str, patterns: Optional[List[str]]) -> bool:
     return False
 
 
+def _is_file_included(filepath: str, patterns: Optional[List[str]]) -> bool:
+    if not patterns:
+        return True
+    if not filepath:
+        return False
+    for pattern in patterns:
+        if fnmatch.fnmatch(filepath, pattern) or fnmatch.fnmatch(os.path.basename(filepath), pattern):
+            return True
+    return False
+
+
 def find_typos(
     diff_text: str,
     min_length: int = 2,
     max_dist: Optional[int] = None,
     exclude_patterns: Optional[List[str]] = None,
+    include_patterns: Optional[List[str]] = None,
 ) -> List[str]:
     """
     Parses the diff text to find typo corrections.
@@ -427,6 +439,7 @@ def find_typos(
         min_length (int): Minimum length of differing substrings to consider as typos.
         max_dist (int, optional): Maximum Levenshtein distance for typos.
         exclude_patterns (list, optional): List of file/path patterns to exclude.
+        include_patterns (list, optional): List of file/path patterns to include.
 
     Returns:
         list: A list of typo candidates in the format "before -> after".
@@ -459,8 +472,9 @@ def find_typos(
                     current_file = p
                 if current_file.startswith('"') and current_file.endswith('"'):
                     current_file = current_file[1:-1]
-            if current_file and _is_file_excluded(current_file, exclude_patterns):
-                skip_current_file = True
+            if current_file:
+                if not _is_file_included(current_file, include_patterns) or _is_file_excluded(current_file, exclude_patterns):
+                    skip_current_file = True
             continue
 
         # Handle file renames and copies
@@ -475,7 +489,7 @@ def find_typos(
             if path.startswith('"') and path.endswith('"'):
                 path = path[1:-1]
             additions.append(path)
-            if not (skip_current_file or _is_file_excluded(path, exclude_patterns)):
+            if not (skip_current_file or _is_file_excluded(path, exclude_patterns) or not _is_file_included(path, include_patterns)):
                 typos.extend(process_diff_block(removals, additions, min_length, max_dist))
             removals = []
             additions = []
@@ -492,7 +506,7 @@ def find_typos(
                     typos.extend(process_diff_block(removals, additions, min_length, max_dist))
                 removals = []
                 additions = []
-                skip_current_file = _is_file_excluded(current_file, exclude_patterns)
+                skip_current_file = _is_file_excluded(current_file, exclude_patterns) or not _is_file_included(current_file, include_patterns)
             continue
 
         if skip_current_file:
@@ -861,6 +875,12 @@ def main():
         help="One or more file patterns (e.g., '*.json', 'tests/*') to exclude from typo scanning.",
     )
     analysis_group.add_argument(
+        '-I', '--include',
+        nargs='+',
+        default=None,
+        help="One or more file patterns (e.g., '*.py', 'src/*') to restrict typo scanning to.",
+    )
+    analysis_group.add_argument(
         '-M', '--mode',
         type=str,
         choices=['typos', 'corrections', 'both', 'audit'],
@@ -1033,6 +1053,7 @@ def main():
         min_length=args.min_length,
         max_dist=args.max_dist,
         exclude_patterns=args.exclude,
+        include_patterns=args.include,
     )
     counts = Counter(candidates_raw)
 

--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -29,6 +29,7 @@ git diff | python diff2typo.py [OPTIONS]
 | `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), or `list` (typo only). |
 | `--mode`, `-M` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
 | `--exclude`, `-e` | None | One or more file patterns (e.g., `*.json`, `tests/*`) to exclude from typo scanning. |
+| `--include`, `-I` | None | One or more file patterns (e.g., `*.py`, `src/*`) to restrict typo scanning to. |
 | `--min-length`, `-m` | `2` | Ignore words shorter than this length. |
 | `--max-dist`, `-D` | None | Only include typos with a number of character changes up to this value. Useful for filtering out intentional word changes. |
 | `--min-count`, `-c` | `1` | Minimum occurrences of a typo in the diff to include it in the output. |

--- a/tests/test_diff2typo_include.py
+++ b/tests/test_diff2typo_include.py
@@ -1,0 +1,151 @@
+import pytest
+from diff2typo import _is_file_included, find_typos, main
+from unittest.mock import patch
+
+def test_is_file_included():
+    assert _is_file_included("tests/test_math.py", ["*.py"])
+    assert _is_file_included("config.json", ["*.json"])
+    assert _is_file_included("src/lib.py", ["src/*"])
+    assert _is_file_included("package-lock.json", ["package-lock.json"])
+    assert not _is_file_included("src/lib.py", ["*.json"])
+    assert _is_file_included("src/lib.py", None)
+    assert not _is_file_included("", ["*.py"])
+
+
+def test_find_typos_inclusion():
+    diff_text = """diff --git a/src/main.py b/src/main.py
+--- a/src/main.py
++++ b/src/main.py
+@@ -1,2 +1,2 @@
+-def hello():
+-    print("hllo")
++def hello():
++    print("hello")
+diff --git a/config.json b/config.json
+--- a/config.json
++++ b/config.json
+@@ -1,2 +1,2 @@
+- "vrsion": "1.0.0"
++ "version": "1.0.0"
+"""
+    results = find_typos(diff_text, include_patterns=["*.py"])
+    assert "hllo -> hello" in results
+    assert "vrsion -> version" not in results
+
+    results = find_typos(diff_text, include_patterns=["*.json"])
+    assert "hllo -> hello" not in results
+    assert "vrsion -> version" in results
+
+    results = find_typos(diff_text, include_patterns=["*.py", "*.json"])
+    assert "hllo -> hello" in results
+    assert "vrsion -> version" in results
+
+    results = find_typos(diff_text, include_patterns=["*.py"], exclude_patterns=["src/*"])
+    assert "hllo -> hello" not in results
+    assert "vrsion -> version" not in results
+
+
+def test_find_typos_inclusion_rename():
+    diff_rename_with_content = """diff --git a/old_dir/registre.py b/new_dir/register.py
+similarity index 85%
+rename from old_dir/registre.py
+rename to new_dir/register.py
+--- a/old_dir/registre.py
++++ b/new_dir/register.py
+@@ -1,2 +1,2 @@
+-class Registre:
++class Register:
+"""
+    results = find_typos(diff_rename_with_content, include_patterns=["new_dir/*"])
+    assert "registre -> register" in results
+
+    results = find_typos(diff_rename_with_content, include_patterns=["other/*"])
+    assert "registre -> register" not in results
+
+
+def test_find_typos_inclusion_unified_header():
+    diff_text = """--- a/src/math.py
++++ b/src/math.py
+@@ -1,2 +1,2 @@
+-x = y + 1 # formulaa
++x = y + 1 # formula
+"""
+    results = find_typos(diff_text, include_patterns=["math.py"])
+    assert "formulaa -> formula" in results
+
+    results = find_typos(diff_text, include_patterns=["other.py"])
+    assert "formulaa -> formula" not in results
+
+
+def test_find_typos_inclusion_quotes_and_spaces():
+    diff_text = """diff --git a/"my dir/spaced file.py" b/"my dir/spaced file.py"
+--- a/"my dir/spaced file.py"
++++ b/"my dir/spaced file.py"
+@@ -1,2 +1,2 @@
+-def f(): # typoo
++def f(): # typo
+"""
+    results = find_typos(diff_text, include_patterns=["my dir/*"])
+    assert "typoo -> typo" in results
+
+    results = find_typos(diff_text, include_patterns=["other dir/*"])
+    assert "typoo -> typo" not in results
+
+
+def test_cli_include():
+    with patch("sys.argv", ["diff2typo.py", "some.diff", "--include", "*.py", "src/*", "-o", "-"]), \
+         patch("diff2typo._read_diff_sources", return_value=""), \
+         patch("diff2typo.find_typos", return_value=[]) as mock_find:
+        try:
+            main()
+        except SystemExit:
+            pass
+        mock_find.assert_called_once()
+        args, kwargs = mock_find.call_args
+        assert kwargs["include_patterns"] == ["*.py", "src/*"]
+
+
+def test_find_typos_inclusion_edge_cases():
+    diff_no_prefix = """diff --git main.py main.py
+--- main.py
++++ main.py
+@@ -1,2 +1,2 @@
+-def hello():
+-    print("hllo")
++def hello():
++    print("hello")
+"""
+    results = find_typos(diff_no_prefix, include_patterns=["main.py"])
+    assert "hllo -> hello" in results
+
+    results2 = find_typos(diff_no_prefix, include_patterns=["other.py"])
+    assert "hllo -> hello" not in results2
+
+    diff_rename_quoted = """diff --git "a/old file.py" "b/new file.py"
+similarity index 100%
+rename from "old file.py"
+rename to "new file.py"
+"""
+    results_rename = find_typos(diff_rename_quoted, include_patterns=["new file.py"])
+    assert results_rename == []
+
+    diff_unmatched_quote = """diff --git a/unmatched" b/unmatched
+--- a/unmatched
++++ b/unmatched
+@@ -1,2 +1,2 @@
+-def f(): # typoo
++def f(): # typo
+"""
+    results_unmatched = find_typos(diff_unmatched_quote, include_patterns=["unmatched"])
+    assert "typoo -> typo" in results_unmatched
+
+    diff_fallback_quotes = """diff --git "file.py" "file.py"
+--- "file.py"
++++ "file.py"
+@@ -1,2 +1,2 @@
+-def f(): # typoo
++def f(): # typo
+"""
+    with patch("shlex.split", side_effect=ValueError):
+        results_fallback = find_typos(diff_fallback_quotes, include_patterns=["file.py"])
+        assert "typoo -> typo" in results_fallback


### PR DESCRIPTION
Implemented the `--include` / `-I` CLI option in `diff2typo.py` to allow restricting typo scanning to files matching specific glob patterns. Added the helper `_is_file_included`, integrated it into the parsing logic in `find_typos`, added an argument to the argparse parser, added thorough unit tests in `tests/test_diff2typo_include.py`, and documented the new feature in `docs/diff2typo.md`.

---
*PR created automatically by Jules for task [14841765543552162470](https://jules.google.com/task/14841765543552162470) started by @RainRat*