### PR TITLE
[DOCS] Simplify CLI logs and error messages to use plain English

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -578,9 +578,9 @@ def _read_stdin_text() -> str:
     stream = getattr(sys.stdin, "buffer", sys.stdin)
     data = stream.read()
     if isinstance(data, str):
-        logging.info("Successfully read input diff from standard input.")
+        logging.info("Successfully read input diff.")
         return data
-    return _decode_with_fallback(data, "input diff from standard input")
+    return _decode_with_fallback(data, "input diff")
 
 
 def _read_git_diff(git_args: Optional[str]) -> str:
@@ -1000,12 +1000,12 @@ def main():
                 is_git = False
 
             if is_git:
-                logging.info("Standard input is an interactive terminal. Automatically running 'git diff'...")
+                logging.info("No files specified. Running in a Git repository; automatically checking your recent changes (git diff)...")
                 diff_text = _read_git_diff(None)
             else:
                 logging.error(
-                    "No input files specified and standard input is an interactive terminal.\n"
-                    "Please provide input files, pipe diff data, or run inside a Git repository."
+                    "No files specified and not running inside a Git repository.\n"
+                    "Please specify one or more input files, run inside a Git repository, or pipe a diff command into this tool."
                 )
                 sys.exit(1)
         else:

--- a/gentypos.py
+++ b/gentypos.py
@@ -509,7 +509,7 @@ def load_file(file_path: Optional[str]) -> set[str]:
     try:
         words = set()
         if file_path == '-':
-            logging.info("Reading from standard input...")
+            logging.info("Reading from input data...")
             source = sys.stdin
         else:
             source = open(file_path, 'r', encoding='utf-8')

--- a/tests/test_diff2typo_coverage.py
+++ b/tests/test_diff2typo_coverage.py
@@ -65,7 +65,7 @@ def test_read_stdin_text_str(monkeypatch, caplog):
     with caplog.at_level(logging.INFO):
         text = diff2typo._read_stdin_text()
         assert text == "text input"
-        assert "Successfully read input diff from standard input" in caplog.text
+        assert "Successfully read input diff." in caplog.text
 
 def test_read_diff_sources_not_found():
     with pytest.raises(SystemExit) as excinfo:

--- a/typostats.py
+++ b/typostats.py
@@ -411,10 +411,10 @@ def _read_file_lines_robust(path: str, newline: str | None = None) -> List[str]:
 
     if path == '-':
         if _STDIN_CACHE is not None:
-            logging.info("Using cached standard input...")
+            logging.info("Using cached input data...")
             return list(_STDIN_CACHE)
 
-        logging.info("Reading from standard input...")
+        logging.info("Reading from input data...")
         stream = getattr(sys.stdin, "buffer", sys.stdin)
         data = stream.read()
         if isinstance(data, str):
@@ -1189,7 +1189,7 @@ def main() -> None:
 
     if not input_files:
         if sys.stdin.isatty():
-            logging.info("Standard input is an interactive terminal. Automatically scanning the current directory...")
+            logging.info("No input files specified. Automatically scanning the current directory for typo logs...")
             input_files = ['.']
         else:
             input_files = ['-']


### PR DESCRIPTION
Simplifies user-facing status, log, and error messages across core CLI scripts (diff2typo.py, typostats.py, gentypos.py) to use plain English and be highly accessible for an international/casual audience, keeping consistent with standard documentation guidelines. Updates the associated tests to align with the new strings.

---
*PR created automatically by Jules for task [16670749002848344473](https://jules.google.com/task/16670749002848344473) started by @RainRat*