### PR TITLE
[FEAT] Add if-not-exists filtering to cmdrunner

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -113,6 +113,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if "if_exists" in config and not isinstance(config["if_exists"], str):
         errors.append("'if_exists' must be a string.")
 
+    if "if_not_exists" in config and not isinstance(config["if_not_exists"], str):
+        errors.append("'if_not_exists' must be a string.")
+
     if errors:
         raise ConfigError(" ".join(errors))
 
@@ -129,6 +132,7 @@ def run_command_in_folders(
     output_file: Optional[str] = None,
     output_format: Optional[str] = None,
     if_exists: Optional[str] = None,
+    if_not_exists: Optional[str] = None,
 ) -> None:
     """
     Run a specified command in each folder within the main folder,
@@ -149,6 +153,12 @@ def run_command_in_folders(
         directories = [
             item for item in directories
             if os.path.exists(os.path.join(main_folder, item, if_exists))
+        ]
+
+    if if_not_exists:
+        directories = [
+            item for item in directories
+            if not os.path.exists(os.path.join(main_folder, item, if_not_exists))
         ]
 
     iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
@@ -323,6 +333,11 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         help='Only run the command in folders that contain this specific file or path (e.g., package.json).'
     )
+    direct_group.add_argument(
+        '--if-not-exists',
+        type=str,
+        help='Only run the command in folders that do not contain this specific file or path (e.g., package.json).'
+    )
 
     # Execution Options Group
     options_group = parser.add_argument_group(f"{BLUE}EXECUTION OPTIONS{RESET}")
@@ -407,6 +422,7 @@ def main() -> None:
     fail_fast = args.fail_fast if args.fail_fast is not None else config.get('fail_fast', False)
     timeout = args.timeout if args.timeout is not None else config.get('timeout', None)
     if_exists = args.if_exists or config.get('if_exists', None)
+    if_not_exists = args.if_not_exists or config.get('if_not_exists', None)
 
     # Validate that required options are present
     errors = []
@@ -431,6 +447,7 @@ def main() -> None:
         output_file=args.output,
         output_format=args.format,
         if_exists=if_exists,
+        if_not_exists=if_not_exists,
     )
 
 if __name__ == "__main__":

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -55,6 +55,9 @@ timeout: 10.5
 
 # (Optional) Only run the command in folders that contain this specific file or path
 if_exists: "package.json"
+
+# (Optional) Only run the command in folders that do not contain this specific file or path
+if_not_exists: "node_modules"
 ```
 
 ## Options
@@ -69,6 +72,7 @@ if_exists: "package.json"
 - `--fail-fast`: Stop execution immediately if any command fails or times out. Overrides config file if provided.
 - `--timeout`: The maximum execution time in seconds for the command in each folder. Overrides config file if provided.
 - `--if-exists`: Only run the command in folders that contain this specific file or path (e.g., `package.json` or `requirements.txt`). Overrides config file if provided.
+- `--if-not-exists`: Only run the command in folders that do not contain this specific file or path (e.g., `node_modules`). Overrides config file if provided.
 - `-o`, `--output`: Where to save the execution report. If not provided, no report is saved.
 - `-f`, `--format`: Choose the format for the output report (`json`, `csv`, `txt`). If not provided, it is automatically detected from the output file extension.
 
@@ -88,7 +92,7 @@ In this example, if the tool processes a folder named `my-web-app`, it will run 
 ## How it Works
 
 1. **Find Folders:** The tool looks inside your `main_folder` and finds every sub-folder.
-2. **Filter:** It removes any folders you listed in `excluded_folders`, and filters remaining folders to only those containing the specified `--if-exists` file or path (if provided).
+2. **Filter:** It removes any folders you listed in `excluded_folders`, filters remaining folders to only those containing the specified `--if-exists` file or path (if provided), and filters out folders containing the `--if-not-exists` file or path (if provided).
 3. **Execute:** It enters each remaining folder and runs your `command_to_run`.
 4. **Report:** It shows you the results of each command or any errors that occurred.
 
@@ -117,4 +121,9 @@ python cmdrunner.py config.yaml --quiet
 **Only run commands in projects containing a `package.json` file:**
 ```bash
 python cmdrunner.py --main-folder /home/user/projects --command-to-run "npm run build" --if-exists package.json
+```
+
+**Only run commands in projects containing a `package.json` but missing `node_modules`:**
+```bash
+python cmdrunner.py --main-folder /home/user/projects --command-to-run "npm install" --if-exists package.json --if-not-exists node_modules
 ```

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -933,3 +933,129 @@ def test_main_with_if_exists_config(tmp_path, monkeypatch):
 
     assert not (proj1 / 'out_conf.txt').exists()
     assert (proj2 / 'out_conf.txt').exists()
+
+
+def test_load_config_invalid_if_not_exists(tmp_path):
+    config_file = tmp_path / 'config_invalid_if_not_exists.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'if_not_exists': 123,
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'if_not_exists' must be a string." in exc_info.value.args[0]
+
+
+def test_run_command_if_not_exists_filtering(tmp_path):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj_with_file = base_dir / 'proj_with_file'
+    proj_without_file = base_dir / 'proj_without_file'
+    proj_with_file.mkdir()
+    proj_without_file.mkdir()
+
+    (proj_with_file / 'target.txt').write_text('exists')
+
+    command = "python3 -c \"open('test_file.txt','w').write('ran')\""
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        command,
+        if_not_exists='target.txt'
+    )
+
+    assert not (proj_with_file / 'test_file.txt').exists()
+    assert (proj_without_file / 'test_file.txt').exists()
+    assert (proj_without_file / 'test_file.txt').read_text() == 'ran'
+
+
+def test_main_with_if_not_exists_cli_override(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    (proj1 / 'special.json').write_text('{}')
+
+    command = "python3 -c \"open('out.txt','w').write('ok')\""
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['cmdrunner.py', '-m', str(base_dir), '-c', command, '--if-not-exists', 'special.json']
+    )
+
+    cmdrunner.main()
+
+    assert not (proj1 / 'out.txt').exists()
+    assert (proj2 / 'out.txt').exists()
+
+
+def test_main_with_if_not_exists_config(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    (proj2 / 'config.ini').write_text('')
+
+    command = "python3 -c \"open('out_conf.txt','w').write('ok')\""
+
+    config_data = {
+        'main_folder': str(base_dir),
+        'command_to_run': command,
+        'if_not_exists': 'config.ini',
+    }
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(config_file)])
+
+    cmdrunner.main()
+
+    assert (proj1 / 'out_conf.txt').exists()
+    assert not (proj2 / 'out_conf.txt').exists()
+
+
+def test_main_with_if_exists_and_if_not_exists_combined(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj3 = base_dir / 'proj3'
+    proj1.mkdir()
+    proj2.mkdir()
+    proj3.mkdir()
+
+    (proj1 / 'package.json').write_text('{}')
+    (proj2 / 'package.json').write_text('{}')
+    (proj2 / 'node_modules').mkdir()
+
+    command = "python3 -c \"open('out_comb.txt','w').write('ok')\""
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['cmdrunner.py', '-m', str(base_dir), '-c', command, '--if-exists', 'package.json', '--if-not-exists', 'node_modules']
+    )
+
+    cmdrunner.main()
+
+    assert (proj1 / 'out_comb.txt').exists()
+    assert not (proj2 / 'out_comb.txt').exists()
+    assert not (proj3 / 'out_comb.txt').exists()


### PR DESCRIPTION
This PR adds `--if-not-exists` (and `if_not_exists` config key) to cmdrunner.py. This serves as the logical complement of the `--if-exists` feature, enabling developers to run command only in directories where a certain file/path is absent. Includes full configuration validation, option handling, comprehensive unit tests, and documentation updates.

---
*PR created automatically by Jules for task [2177375538639464014](https://jules.google.com/task/2177375538639464014) started by @RainRat*