### PR TITLE
Refactor: Inline single-use format detection helper in typostats.py

### DIFF
--- a/tests/test_typostats_coverage_gap.py
+++ b/tests/test_typostats_coverage_gap.py
@@ -2,7 +2,6 @@ import sys
 from unittest.mock import MagicMock, patch
 from typostats import (
     _should_enable_color,
-    _detect_format_from_extension,
     is_one_letter_replacement,
     _read_file_lines_robust,
     main
@@ -27,25 +26,34 @@ def test_should_enable_color(monkeypatch):
     mock_stream.isatty.return_value = False
     assert _should_enable_color(mock_stream) is False
 
-def test_detect_format_from_extension():
-    allowed = ["json", "csv", "yaml", "arrow"]
+def test_typostats_main_format_detection_various(tmp_path):
+    input_file = tmp_path / "input.csv"
+    input_file.write_text("typo,correction\nteh,the")
 
-    assert _detect_format_from_extension("test.json", allowed, "arrow") == "json"
-    assert _detect_format_from_extension("test.csv", allowed, "arrow") == "csv"
-    assert _detect_format_from_extension("test.yaml", allowed, "arrow") == "yaml"
-    assert _detect_format_from_extension("test.yml", allowed, "arrow") == "yaml"
-    assert _detect_format_from_extension("test.arrow", allowed, "arrow") == "arrow"
-    assert _detect_format_from_extension("test.txt", allowed, "arrow") == "arrow"
+    # Mapping of output files and expected detected formats
+    cases = [
+        ("output.json", "json"),
+        ("output.csv", "csv"),
+        ("output.yaml", "yaml"),
+        ("output.yml", "yaml"),
+        ("output.arrow", "arrow"),
+        ("output.txt", "arrow"),
+        ("output.unknown", "arrow"),
+        ("outputfile", "arrow"),
+        ("-", "arrow"),
+        ("", "arrow"),
+    ]
 
-    # Unknown extension
-    assert _detect_format_from_extension("test.unknown", allowed, "default") == "default"
-
-    # No extension
-    assert _detect_format_from_extension("testfile", allowed, "default") == "default"
-
-    # Special cases
-    assert _detect_format_from_extension("-", allowed, "default") == "default"
-    assert _detect_format_from_extension("", allowed, "default") == "default"
+    for output_name, expected_format in cases:
+        out_path = str(tmp_path / output_name) if output_name and output_name != "-" else output_name
+        with patch("sys.argv", ["typostats.py", str(input_file), "-o", out_path]), \
+             patch("typostats.generate_report") as mock_report:
+            try:
+                main()
+            except SystemExit:
+                pass
+            mock_report.assert_called_once()
+            assert mock_report.call_args.kwargs["output_format"] == expected_format
 
 def test_is_one_letter_replacement_disallowed_patterns():
     # To hit line 594: (allow_1to2 or include_deletions) must be True, but allow_1to2 False.

--- a/typostats.py
+++ b/typostats.py
@@ -94,35 +94,6 @@ def _should_enable_color(stream: Any) -> bool:
     return hasattr(stream, 'isatty') and stream.isatty()
 
 
-def _detect_format_from_extension(path: str, allowed: Sequence[str], default: str) -> str:
-    """
-    Detect the output format based on the file extension.
-    Returns the default if no match is found or no extension is present.
-    """
-    if not path or path == '-':
-        return default
-
-    ext = os.path.splitext(path)[1].lower().lstrip('.')
-    if not ext:
-        return default
-
-    # Map common extensions to tool-supported formats
-    mapping = {
-        'txt': 'arrow',
-        'json': 'json',
-        'csv': 'csv',
-        'yaml': 'yaml',
-        'yml': 'yaml',
-        'arrow': 'arrow',
-    }
-
-    detected = mapping.get(ext)
-    if detected in allowed:
-        return detected
-
-    return default
-
-
 def levenshtein_distance(s1: str, s2: str) -> int:
     """Calculate the number of character changes needed to turn one string into another."""
     if len(s1) < len(s2):
@@ -1167,8 +1138,23 @@ def main() -> None:
     sort_by = args.sort
     output_format = args.format
     if output_format is None:
-        allowed_formats = ['arrow', 'yaml', 'json', 'csv']
-        output_format = _detect_format_from_extension(output_file, allowed_formats, 'arrow')
+        if not output_file or output_file == '-':
+            output_format = 'arrow'
+        else:
+            ext = os.path.splitext(output_file)[1].lower().lstrip('.')
+            if ext:
+                mapping = {
+                    'txt': 'arrow',
+                    'json': 'json',
+                    'csv': 'csv',
+                    'yaml': 'yaml',
+                    'yml': 'yaml',
+                    'arrow': 'arrow',
+                }
+                detected = mapping.get(ext)
+                output_format = detected if detected in ['arrow', 'yaml', 'json', 'csv'] else 'arrow'
+            else:
+                output_format = 'arrow'
     allow_1to2 = args.allow_1to2
     allow_2to1 = args.allow_2to1
     include_deletions = args.include_deletions


### PR DESCRIPTION
This PR improves code maintenance in typostats.py by resolving a premature abstraction:
- Inlines `_detect_format_from_extension` directly into `main()`.
- Updates `tests/test_typostats_coverage_gap.py` to test output format detection through integration test calls on `main()`.
- Ensures zero side-effect files are created in the test process.
- Maintains exactly 100% statement coverage for typostats.py.

---
*PR created automatically by Jules for task [7108336853411468579](https://jules.google.com/task/7108336853411468579) started by @RainRat*