### PR TITLE
[DOCS] Document diff2typo automatic Git fallback behavior

### DIFF
--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -12,6 +12,12 @@ python diff2typo.py my_changes.diff [OPTIONS]
 git diff | python diff2typo.py [OPTIONS]
 ```
 
+### Automatic Git Fallback
+
+If you do not specify any input files or pipe data from another command, the tool will automatically check if you are inside a Git repository:
+- **Inside a Git repository:** It automatically runs `git diff` to find typos in your current unstaged changes.
+- **Outside a Git repository:** It exits with a helpful message instead of waiting indefinitely.
+
 ## Core Features
 
 1. **Find typos in diffs:** Reads Git diff files or data sent directly from other commands to find words you have corrected. This includes finding typos corrected by renaming or copying files.


### PR DESCRIPTION
I have documented the "Automatic Git Fallback" behavior in `docs/diff2typo.md`. This details how the `diff2typo.py` tool automatically checks if it is run inside or outside a Git repository when no input files are specified or piped, and either runs `git diff` or exits gracefully with a helpful message. This provides a better developer and casual user experience and avoids standard input hanging confusion.

---
*PR created automatically by Jules for task [5634783432590107764](https://jules.google.com/task/5634783432590107764) started by @RainRat*