### PR TITLE
[DOCS] Document Automatic Git Fallback in diff2typo.md

### DIFF
--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -12,6 +12,18 @@ python diff2typo.py my_changes.diff [OPTIONS]
 git diff | python diff2typo.py [OPTIONS]
 ```
 
+## Automatic Git Fallback
+
+If you run `diff2typo.py` without any input files, and you do not pipe any data to it, the tool automatically checks if you are inside a Git project:
+- **Inside a Git project:** It automatically runs `git diff` to analyze your current changes.
+- **Outside a Git project:** It stops and shows a helpful message telling you to provide input files or pipe diff data.
+
+This means you can simply run:
+```bash
+python diff2typo.py
+```
+This will scan your current working changes for typos without needing any extra files or flags.
+
 ## Core Features
 
 1. **Find typos in diffs:** Reads Git diff files or data sent directly from other commands to find words you have corrected. This includes finding typos corrected by renaming or copying files.


### PR DESCRIPTION
Documented the previously undocumented "Automatic Git Fallback" behavior in `diff2typo.py`. This feature runs `git diff` on behalf of the user when no input files are specified inside a Git worktree. The addition is written in clear, plain, active-voice English conforming to our style guidelines.

---
*PR created automatically by Jules for task [15917497438284446754](https://jules.google.com/task/15917497438284446754) started by @RainRat*