### PR TITLE
[FEAT] Add if-not-exists option to cmdrunner.py

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -113,6 +113,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if "if_exists" in config and not isinstance(config["if_exists"], str):
         errors.append("'if_exists' must be a string.")
 
+    if "if_not_exists" in config and not isinstance(config["if_not_exists"], str):
+        errors.append("'if_not_exists' must be a string.")
+
     if errors:
         raise ConfigError(" ".join(errors))
 
@@ -129,6 +132,7 @@ def run_command_in_folders(
     output_file: Optional[str] = None,
     output_format: Optional[str] = None,
     if_exists: Optional[str] = None,
+    if_not_exists: Optional[str] = None,
 ) -> None:
     """
     Run a specified command in each folder within the main folder,
@@ -149,6 +153,12 @@ def run_command_in_folders(
         directories = [
             item for item in directories
             if os.path.exists(os.path.join(main_folder, item, if_exists))
+        ]
+
+    if if_not_exists:
+        directories = [
+            item for item in directories
+            if not os.path.exists(os.path.join(main_folder, item, if_not_exists))
         ]
 
     iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
@@ -323,6 +333,11 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         help='Only run the command in folders that contain this specific file or path (e.g., package.json).'
     )
+    direct_group.add_argument(
+        '--if-not-exists',
+        type=str,
+        help='Only run the command in folders that do not contain this specific file or path (e.g., package.json).'
+    )
 
     # Execution Options Group
     options_group = parser.add_argument_group(f"{BLUE}EXECUTION OPTIONS{RESET}")
@@ -407,6 +422,7 @@ def main() -> None:
     fail_fast = args.fail_fast if args.fail_fast is not None else config.get('fail_fast', False)
     timeout = args.timeout if args.timeout is not None else config.get('timeout', None)
     if_exists = args.if_exists or config.get('if_exists', None)
+    if_not_exists = args.if_not_exists or config.get('if_not_exists', None)
 
     # Validate that required options are present
     errors = []
@@ -431,6 +447,7 @@ def main() -> None:
         output_file=args.output,
         output_format=args.format,
         if_exists=if_exists,
+        if_not_exists=if_not_exists,
     )
 
 if __name__ == "__main__":

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -55,6 +55,9 @@ timeout: 10.5
 
 # (Optional) Only run the command in folders that contain this specific file or path
 if_exists: "package.json"
+
+# (Optional) Only run the command in folders that do not contain this specific file or path
+if_not_exists: "package.json"
 ```
 
 ## Options
@@ -69,6 +72,7 @@ if_exists: "package.json"
 - `--fail-fast`: Stop execution immediately if any command fails or times out. Overrides config file if provided.
 - `--timeout`: The maximum execution time in seconds for the command in each folder. Overrides config file if provided.
 - `--if-exists`: Only run the command in folders that contain this specific file or path (e.g., `package.json` or `requirements.txt`). Overrides config file if provided.
+- `--if-not-exists`: Only run the command in folders that do not contain this specific file or path (e.g., `package.json` or `requirements.txt`). Overrides config file if provided.
 - `-o`, `--output`: Where to save the execution report. If not provided, no report is saved.
 - `-f`, `--format`: Choose the format for the output report (`json`, `csv`, `txt`). If not provided, it is automatically detected from the output file extension.
 
@@ -117,4 +121,9 @@ python cmdrunner.py config.yaml --quiet
 **Only run commands in projects containing a `package.json` file:**
 ```bash
 python cmdrunner.py --main-folder /home/user/projects --command-to-run "npm run build" --if-exists package.json
+```
+
+**Only run commands in projects that do not contain a `package.json` file:**
+```bash
+python cmdrunner.py --main-folder /home/user/projects --command-to-run "echo 'non-npm project'" --if-not-exists package.json
 ```

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -933,3 +933,104 @@ def test_main_with_if_exists_config(tmp_path, monkeypatch):
 
     assert not (proj1 / 'out_conf.txt').exists()
     assert (proj2 / 'out_conf.txt').exists()
+
+
+def test_load_config_invalid_if_not_exists(tmp_path):
+    config_file = tmp_path / 'config_invalid_if_not_exists.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'if_not_exists': 123,  # Invalid type (must be string)
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'if_not_exists' must be a string." in exc_info.value.args[0]
+
+
+def test_run_command_if_not_exists_filtering(tmp_path):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj_with_file = base_dir / 'proj_with_file'
+    proj_without_file = base_dir / 'proj_without_file'
+    proj_with_file.mkdir()
+    proj_without_file.mkdir()
+
+    # Create target file only in one folder
+    (proj_with_file / 'target.txt').write_text('exists')
+
+    command = "python3 -c \"open('test_file.txt','w').write('ran')\""
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        command,
+        if_not_exists='target.txt'
+    )
+
+    # Should NOT run in proj_with_file because it contains target.txt
+    assert not (proj_with_file / 'test_file.txt').exists()
+
+    # Should run in proj_without_file because it does not contain target.txt
+    assert (proj_without_file / 'test_file.txt').exists()
+    assert (proj_without_file / 'test_file.txt').read_text() == 'ran'
+
+
+def test_main_with_if_not_exists_cli_override(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    (proj1 / 'special.json').write_text('{}')
+
+    command = "python3 -c \"open('out.txt','w').write('ok')\""
+
+    # CLI override --if-not-exists
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['cmdrunner.py', '-m', str(base_dir), '-c', command, '--if-not-exists', 'special.json']
+    )
+
+    cmdrunner.main()
+
+    assert not (proj1 / 'out.txt').exists()
+    assert (proj2 / 'out.txt').exists()
+
+
+def test_main_with_if_not_exists_config(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    (proj2 / 'config.ini').write_text('')
+
+    command = "python3 -c \"open('out_conf.txt','w').write('ok')\""
+
+    config_data = {
+        'main_folder': str(base_dir),
+        'command_to_run': command,
+        'if_not_exists': 'config.ini',
+    }
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(config_file)])
+
+    cmdrunner.main()
+
+    assert (proj1 / 'out_conf.txt').exists()
+    assert not (proj2 / 'out_conf.txt').exists()


### PR DESCRIPTION
This pull request adds an `if-not-exists` filtering feature to `cmdrunner.py`. Symmetrical to `if_exists`, it allows filtering command execution based on the *absence* of a specified file or directory path within target directories. It adds configuration file support (`if_not_exists`), a CLI flag (`--if-not-exists`), updates user-facing documentation in `docs/cmdrunner.md`, and is verified with a robust suite of unit tests.

---
*PR created automatically by Jules for task [15511745390557122458](https://jules.google.com/task/15511745390557122458) started by @RainRat*