### PR TITLE
Inline format auto-detection logic in typostats to resolve premature abstraction

### DIFF
--- a/tests/test_typostats_coverage_gap.py
+++ b/tests/test_typostats_coverage_gap.py
@@ -1,8 +1,8 @@
 import sys
+import os
 from unittest.mock import MagicMock, patch
 from typostats import (
     _should_enable_color,
-    _detect_format_from_extension,
     is_one_letter_replacement,
     _read_file_lines_robust,
     main
@@ -27,25 +27,37 @@ def test_should_enable_color(monkeypatch):
     mock_stream.isatty.return_value = False
     assert _should_enable_color(mock_stream) is False
 
-def test_detect_format_from_extension():
-    allowed = ["json", "csv", "yaml", "arrow"]
+def test_detect_format_from_extension(tmp_path):
+    input_file = tmp_path / "test.txt"
+    input_file.write_text("teh -> the\n")
 
-    assert _detect_format_from_extension("test.json", allowed, "arrow") == "json"
-    assert _detect_format_from_extension("test.csv", allowed, "arrow") == "csv"
-    assert _detect_format_from_extension("test.yaml", allowed, "arrow") == "yaml"
-    assert _detect_format_from_extension("test.yml", allowed, "arrow") == "yaml"
-    assert _detect_format_from_extension("test.arrow", allowed, "arrow") == "arrow"
-    assert _detect_format_from_extension("test.txt", allowed, "arrow") == "arrow"
+    extensions_to_expected = {
+        "test.json": "json",
+        "test.csv": "csv",
+        "test.yaml": "yaml",
+        "test.yml": "yaml",
+        "test.arrow": "arrow",
+        "test.txt": "arrow",
+        "test.unknown": "arrow",
+        "testfile": "arrow",
+        "-": "arrow",
+        "": "arrow",
+    }
 
-    # Unknown extension
-    assert _detect_format_from_extension("test.unknown", allowed, "default") == "default"
+    for filename, expected_format in extensions_to_expected.items():
+        out_path = str(tmp_path / filename) if filename not in ("-", "") else filename
+        argv_args = ["typostats.py", str(input_file), "--quiet"]
+        if out_path:
+            argv_args.extend(["-o", out_path])
 
-    # No extension
-    assert _detect_format_from_extension("testfile", allowed, "default") == "default"
-
-    # Special cases
-    assert _detect_format_from_extension("-", allowed, "default") == "default"
-    assert _detect_format_from_extension("", allowed, "default") == "default"
+        with patch("sys.argv", argv_args), patch("typostats.generate_report") as mock_report:
+            try:
+                main()
+            except SystemExit:
+                pass
+            assert mock_report.called, f"generate_report not called for output {filename}"
+            kwargs = mock_report.call_args[1]
+            assert kwargs["output_format"] == expected_format, f"Expected {expected_format} for output {filename}, but got {kwargs['output_format']}"
 
 def test_is_one_letter_replacement_disallowed_patterns():
     # To hit line 594: (allow_1to2 or include_deletions) must be True, but allow_1to2 False.

--- a/typostats.py
+++ b/typostats.py
@@ -94,35 +94,6 @@ def _should_enable_color(stream: Any) -> bool:
     return hasattr(stream, 'isatty') and stream.isatty()
 
 
-def _detect_format_from_extension(path: str, allowed: Sequence[str], default: str) -> str:
-    """
-    Detect the output format based on the file extension.
-    Returns the default if no match is found or no extension is present.
-    """
-    if not path or path == '-':
-        return default
-
-    ext = os.path.splitext(path)[1].lower().lstrip('.')
-    if not ext:
-        return default
-
-    # Map common extensions to tool-supported formats
-    mapping = {
-        'txt': 'arrow',
-        'json': 'json',
-        'csv': 'csv',
-        'yaml': 'yaml',
-        'yml': 'yaml',
-        'arrow': 'arrow',
-    }
-
-    detected = mapping.get(ext)
-    if detected in allowed:
-        return detected
-
-    return default
-
-
 def levenshtein_distance(s1: str, s2: str) -> int:
     """Calculate the number of character changes needed to turn one string into another."""
     if len(s1) < len(s2):
@@ -1167,8 +1138,25 @@ def main() -> None:
     sort_by = args.sort
     output_format = args.format
     if output_format is None:
+        default_fmt = 'arrow'
         allowed_formats = ['arrow', 'yaml', 'json', 'csv']
-        output_format = _detect_format_from_extension(output_file, allowed_formats, 'arrow')
+        if output_file and output_file != '-':
+            ext = os.path.splitext(output_file)[1].lower().lstrip('.')
+            if ext:
+                mapping = {
+                    'txt': 'arrow',
+                    'json': 'json',
+                    'csv': 'csv',
+                    'yaml': 'yaml',
+                    'yml': 'yaml',
+                    'arrow': 'arrow',
+                }
+                detected = mapping.get(ext)
+                output_format = detected if detected in allowed_formats else default_fmt
+            else:
+                output_format = default_fmt
+        else:
+            output_format = default_fmt
     allow_1to2 = args.allow_1to2
     allow_2to1 = args.allow_2to1
     include_deletions = args.include_deletions


### PR DESCRIPTION
Inline format auto-detection logic in typostats to resolve premature abstraction

Removed the private helper _detect_format_from_extension in typostats.py since it was only called once, inlining it directly into main().
Updated tests/test_typostats_coverage_gap.py to test the auto-detection behavior by executing main() with different extensions instead of using direct imports, preserving exactly 100% statement coverage.

---
*PR created automatically by Jules for task [13120658553892846680](https://jules.google.com/task/13120658553892846680) started by @RainRat*