### PR TITLE
[UI/UX] Improve invalid subcommand suggestions in multitool.py

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -8347,11 +8347,32 @@ class ModeHelpAction(argparse.Action):
         show_mode_help(values, parser)
 
 
+class TypoTolerantArgumentParser(argparse.ArgumentParser):
+    """An ArgumentParser subclass that handles misspelled subcommands gracefully."""
+
+    def error(self, message: str) -> None:
+        if "argument mode: invalid choice:" in message:
+            match = re.search(r"invalid choice:\s*['\"]([^']+)['\"]", message)
+            if match:
+                invalid_mode = match.group(1)
+                candidates = list(MODE_DETAILS.keys())
+                suggestion = _get_best_suggestion(invalid_mode, candidates, max_dist=2)
+                if not suggestion and len(invalid_mode) > 3:
+                    suggestion = _get_best_suggestion(invalid_mode, candidates, max_dist=3)
+
+                if suggestion:
+                    sys.stderr.write(f"multitool.py: error: '{invalid_mode}' is not a valid mode. Did you mean '{suggestion}'?\n")
+                else:
+                    sys.stderr.write(f"multitool.py: error: '{invalid_mode}' is not a valid mode. See 'python multitool.py help' for a list of available modes.\n")
+                sys.exit(2)
+        super().error(message)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     # Build a grouped mode summary for the epilog
     mode_summary = get_mode_summary_text()
 
-    parser = argparse.ArgumentParser(
+    parser = TypoTolerantArgumentParser(
         prog="multitool.py",
         description="A multipurpose tool for cleaning, getting, and analyzing text files.",
         epilog=dedent(

--- a/tests/test_multitool_help.py
+++ b/tests/test_multitool_help.py
@@ -106,3 +106,30 @@ def test_search_standard_help(monkeypatch, capsys):
     assert "A typo-aware search tool." in output
     assert "Example:" in output
     assert "python multitool.py search 'teh' report.txt" in output
+
+
+def test_invalid_mode_scrb_suggestion(monkeypatch, capsys):
+    monkeypatch.setattr(sys, 'argv', ['multitool.py', 'scrb'])
+
+    with pytest.raises(SystemExit) as excinfo:
+        multitool.main()
+
+    assert excinfo.value.code == 2
+
+    captured = capsys.readouterr()
+    assert "'scrb' is not a valid mode" in captured.err
+    assert "Did you mean 'scrub'?" in captured.err
+
+
+def test_invalid_mode_completely_wrong(monkeypatch, capsys):
+    monkeypatch.setattr(sys, 'argv', ['multitool.py', 'xyzabc'])
+
+    with pytest.raises(SystemExit) as excinfo:
+        multitool.main()
+
+    assert excinfo.value.code == 2
+
+    captured = capsys.readouterr()
+    assert "'xyzabc' is not a valid mode" in captured.err
+    assert "See 'python multitool.py help' for a list of available modes." in captured.err
+    assert "choose from" not in captured.err


### PR DESCRIPTION
A Lead UI/UX improvement to intercept invalid subcommand errors in multitool.py and offer friendly, typo-tolerant suggestions (or help fallback recommendations) instead of printing standard argparse choices verbosely.

---
*PR created automatically by Jules for task [10798547130320136352](https://jules.google.com/task/10798547130320136352) started by @RainRat*