### PR TITLE
[DOCS] Complete and link the paths mode documentation

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -125,6 +125,7 @@ Use these modes to pull specific data from a file.
   - Extracts path components (basename, dirname, extension) from file and directory paths. It also supports smart splitting to find words within filenames.
   - **Options:** Use `--basename`, `--dirname`, or `--extension` to pick specific parts. Use `--smart` to split components into words.
   - **Example:** `python multitool.py paths src/ --basename --smart`
+  - **Detailed Guide:** See the dedicated [paths mode guide](paths.md) for more details.
 
 - **`flatten`**
   - Transforms nested JSON, YAML, or TOML structures into dot-separated `key.path = value` pairs. It supports multi-document YAML and JSON Lines (JSONL). The default output format is `arrow`.

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -11,14 +11,31 @@ python multitool.py paths [FILES...] [OPTIONS]
 ```
 
 ## Options
+
+### Path Extraction Options
 | Flag | Description |
 | :--- | :--- |
 | `--basename` | Extract the final component of the path (the filename). |
 | `--dirname` | Extract the directory part of the path. |
 | `--extension` | Extract the file extension. |
-| `-S`, `--smart` | Split path components by symbols and capital letters. |
-| `-R`, `--raw` | Keep original text (preserve casing and punctuation in paths). |
+| `-S`, `--smart` | Split path components by symbols and capital letters (e.g., "CamelCase" or "snake_case"). |
+
+### Processing & Filtering Options
+| Flag | Description |
+| :--- | :--- |
+| `-m`, `--min-length` | Skip items shorter than this length (default: 1). |
+| `-M`, `--max-length` | Skip items longer than this length (default: 1000). |
+| `-R`, `--raw` | Keep the original text. Do not change it to lowercase or remove punctuation. |
+| `-L`, `--limit` | Limit the number of items in the output. |
 | `-P`, `--process-output` | Sort the results and remove duplicates. |
+
+### Input/Output & General Options
+| Flag | Description |
+| :--- | :--- |
+| `-i`, `--input` | Path(s) to the input file(s). Supports multiple files. |
+| `-o`, `--output` | Where to save the results. Use `-` to print to the screen (default: the screen). |
+| `-f`, `--format` | Choose the format for the output. Choices: `line`, `json`, `csv`, `markdown`, `md-table`, `arrow`, `table`, `yaml`, `toml`, `xml`. |
+| `-q`, `--quiet` | Hide progress bars and status messages. |
 
 ## Examples
 


### PR DESCRIPTION
Improved the documentation for the paths mode in Multitool. Updated docs/multitool.md to include a detailed guide link pointing to docs/paths.md, and comprehensively updated docs/paths.md to document all path extraction, filtering, processing, and input/output parameters.

---
*PR created automatically by Jules for task [775470544089036036](https://jules.google.com/task/775470544089036036) started by @RainRat*