### PR TITLE
[UI/UX] Add ad-hoc custom substitutions command line option to gentypos.py

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -37,6 +37,7 @@ python gentypos.py --input words.txt --output typos.txt
 | `--output`, `-o` | None | Save results to this file. Use `-` to print to the screen. |
 | `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), or `list` (typo). By default, it is automatically detected from the output file extension. |
 | `--substitutions`, `-s` | None | A file containing custom typo patterns (JSON, CSV, or YAML). Useful for loading your personal typo history from `typostats.py`. |
+| `--add`, `-a` | None | Extra substitution pairs (for example `ph:f` or `th:teh`) to use during typo generation directly from the command line. |
 | `--input`, `-i` | None | The path to an input file containing words to process (one per line). |
 | `--dictionary`, `-d` | None | The path to a large dictionary file used to filter out real words. |
 | `--min-length`, `-m` | None | Ignore words shorter than this length. |
@@ -97,6 +98,14 @@ custom_substitutions:
   e:
     - "a"
     - "i"
+```
+
+### Ad-hoc Custom Substitutions via CLI
+You can also specify ad-hoc custom substitutions directly from the command line using the `--add` / `-a` flag:
+
+```bash
+# Generate typos using an ad-hoc custom substitution "o:u"
+python gentypos.py hello --add "o:u" --no-filter
 ```
 
 ### Loading Substitutions from a File

--- a/gentypos.py
+++ b/gentypos.py
@@ -673,6 +673,7 @@ def _extract_config_settings(config: MutableMapping[str, Any], quiet: bool = Fal
         max_length=max_length,
         custom_substitutions_config=config.get('custom_substitutions', {}),
         substitutions_file=config.get('substitutions_file'),
+        ad_hoc=config.get('ad_hoc'),
         quiet=quiet,
     )
 
@@ -704,6 +705,27 @@ def _setup_generation_tools(
                     custom_subs_raw[k] = [existing] + v
             else:
                 custom_subs_raw[k] = v
+
+    # Merge substitutions from --add / -a if provided
+    ad_hoc_pairs = getattr(settings, 'ad_hoc', None)
+    if ad_hoc_pairs:
+        for pair in ad_hoc_pairs:
+            if ":" in pair:
+                k, v = pair.split(":", 1)
+                k = k.strip().lower()
+                v = v.strip().lower()
+                if k in custom_subs_raw:
+                    existing = custom_subs_raw[k]
+                    if existing is None:
+                        custom_subs_raw[k] = [v]
+                    elif isinstance(existing, list):
+                        if v not in [str(x).lower() for x in existing]:
+                            existing.append(v)
+                    else:
+                        if str(existing).lower() != v:
+                            custom_subs_raw[k] = [existing, v]
+                else:
+                    custom_subs_raw[k] = [v]
 
     enable_custom_substitutions = getattr(settings, 'enable_custom_substitutions', True)
     if not enable_custom_substitutions:
@@ -917,6 +939,14 @@ def main() -> None:
         help="Ignore words shorter than this length.",
     )
     gen_group.add_argument(
+        '-a', '--add',
+        dest='ad_hoc',
+        type=str,
+        nargs='+',
+        metavar='KEY:VALUE',
+        help='Extra substitution pairs (for example "ph:f" or "th:teh") to use during typo generation.',
+    )
+    gen_group.add_argument(
         '-r', '--repeat',
         dest='repeat_modifications',
         type=int,
@@ -1034,6 +1064,8 @@ def main() -> None:
         config['dictionary_file'] = args.dictionary_file
     if args.repeat_modifications is not None:
         config['repeat_modifications'] = args.repeat_modifications
+    if args.ad_hoc:
+        config['ad_hoc'] = args.ad_hoc
 
     if args.min_length is not None or args.max_length is not None:
         if 'word_length' not in config:

--- a/tests/test_gentypos_cli_overrides.py
+++ b/tests/test_gentypos_cli_overrides.py
@@ -67,6 +67,43 @@ def test_gentypos_cli_override_dictionary_file_filters_typos(capsys, empty_confi
     assert len(stdout_lines) > 0
     assert not any("spple -> apple" in line for line in stdout_lines)
 
+def test_gentypos_cli_override_add_custom_substitutions(capsys, empty_config_file):
+    # Testing that passing --add "e:a" maps hello -> hallo (replacement of 'e' with 'a')
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--add", "e:a",
+        "--no-filter",
+        "-f", "arrow"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    captured = capsys.readouterr()
+    stdout_lines = captured.out.splitlines()
+    assert len(stdout_lines) > 0
+    # Hello has 'e' which should be replaced with 'a' to produce 'hallo'
+    assert any("hallo -> hello" in line for line in stdout_lines)
+
+def test_gentypos_cli_override_add_multi_char_substitutions(capsys, empty_config_file):
+    # Testing that passing --add "ph:f" maps phone -> fone
+    test_args = [
+        "gentypos.py",
+        "phone",
+        "-c", empty_config_file,
+        "--add", "ph:f",
+        "--no-filter",
+        "-f", "arrow"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    captured = capsys.readouterr()
+    stdout_lines = captured.out.splitlines()
+    assert len(stdout_lines) > 0
+    assert any("fone -> phone" in line for line in stdout_lines)
+
 def test_gentypos_cli_override_repeat_modifications_generates_nested_typos(capsys, empty_config_file, tmp_path):
     words_file = tmp_path / "words.txt"
     words_file.write_text("cat\n", encoding="utf-8")


### PR DESCRIPTION
This PR reduces friction for the `gentypos.py` tool by adding a new command-line option, `-a`/`--add` (dest='ad_hoc'). 

Previously, if a user wanted to specify custom substitution rules (e.g. `ph:f` or `e:a`), they were forced to either edit the config file or create an external substitutions file. This created extra steps and friction for quick, one-off tasks.

With this PR, users can now specify multiple ad-hoc substitution rules directly from the command line, which are merged seamlessly into the generation configuration.

### Changes:
- Added the `-a`/`--add` (dest='ad_hoc') option to `gentypos.py` under the 'Generation Options' argparse section.
- Added logic to merge ad-hoc substitutions into `custom_subs_raw` within `_setup_generation_tools`.
- Updated `docs/gentypos.md` to document the new `--add`/`-a` option.
- Added comprehensive unit tests in `tests/test_gentypos_cli_overrides.py` to verify both single-char and multi-char ad-hoc substitutions.

---
*PR created automatically by Jules for task [7378671130805530064](https://jules.google.com/task/7378671130805530064) started by @RainRat*