### PR TITLE
Refactor duplicate latin-1 file reading fallbacks in typostats.py

### DIFF
--- a/typostats.py
+++ b/typostats.py
@@ -439,6 +439,7 @@ def _read_file_lines_robust(path: str, newline: str | None = None) -> List[str]:
             logging.warning(f"Input path '{path}' is a directory. Skipping.")
             return []
 
+        fallback_to_latin1 = False
         try:
             with open(path, 'r', encoding='utf-8', newline=newline) as handle:
                 lines = handle.readlines()
@@ -460,14 +461,15 @@ def _read_file_lines_robust(path: str, newline: str | None = None) -> List[str]:
                         detected_encoding,
                         path,
                     )
-                    with open(path, 'r', encoding='latin-1', newline=newline) as handle:
-                        lines = handle.readlines()
-                    used_encoding = 'latin-1'
+                    fallback_to_latin1 = True
             else:
                 logging.warning("Encoding detection failed. Fallback to latin-1 for '%s'.", path)
-                with open(path, 'r', encoding='latin-1', newline=newline) as handle:
-                    lines = handle.readlines()
-                used_encoding = 'latin-1'
+                fallback_to_latin1 = True
+
+        if fallback_to_latin1:
+            with open(path, 'r', encoding='latin-1', newline=newline) as handle:
+                lines = handle.readlines()
+            used_encoding = 'latin-1'
 
     logging.info("Loaded '%s' using %s encoding.", path, used_encoding)
     return lines


### PR DESCRIPTION
* **What:** Refactored the file reading and encoding fallback logic in `_read_file_lines_robust` inside `typostats.py` to eliminate duplicated fallback `with open(...)` blocks. Consolidated the latin-1 fallback paths under a unified boolean flag `fallback_to_latin1`.
* **Why:** This improves code quality by removing redundant and duplicated code, making the logic much more maintainable and clear, without introducing any breaking changes. Verified that all unit tests pass successfully.

---
*PR created automatically by Jules for task [7351919256702855969](https://jules.google.com/task/7351919256702855969) started by @RainRat*