### PR TITLE
[UI/UX] Improve CLI error suggestion feedback for subcommands

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -8347,11 +8347,48 @@ class ModeHelpAction(argparse.Action):
         show_mode_help(values, parser)
 
 
+class TypoTolerantArgumentParser(argparse.ArgumentParser):
+    """Custom ArgumentParser subclass that intercepts invalid subcommand and --mode-help choice errors
+    to dynamically suggest the closest valid choice match.
+    """
+
+    def error(self, message: str) -> None:
+        match = re.search(r"argument (mode|--mode-help): invalid choice: '([^']+)'", message)
+        if match:
+            arg_type = match.group(1)
+            invalid_val = match.group(2)
+            if arg_type == "--mode-help":
+                candidates = list(MODE_DETAILS.keys()) + ["all"]
+                suggestion = _get_best_suggestion(invalid_val, candidates, max_dist=3)
+                if suggestion:
+                    self.exit(
+                        status=2,
+                        message=(
+                            f"{RED}Error:{RESET} '{invalid_val}' is not a valid mode for --mode-help.\n"
+                            f"Did you mean: {GREEN}{suggestion}{RESET}?\n\n"
+                            f"Run {GREEN}python multitool.py help{RESET} to see a list of all available commands.\n"
+                        )
+                    )
+            else:
+                candidates = list(MODE_DETAILS.keys()) + ["help"]
+                suggestion = _get_best_suggestion(invalid_val, candidates, max_dist=3)
+                if suggestion:
+                    self.exit(
+                        status=2,
+                        message=(
+                            f"{RED}Error:{RESET} 'multitool.py' has no subcommand '{invalid_val}'.\n"
+                            f"Did you mean: {GREEN}{suggestion}{RESET}?\n\n"
+                            f"Run {GREEN}python multitool.py help{RESET} to see a list of all available commands.\n"
+                        )
+                    )
+        super().error(message)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     # Build a grouped mode summary for the epilog
     mode_summary = get_mode_summary_text()
 
-    parser = argparse.ArgumentParser(
+    parser = TypoTolerantArgumentParser(
         prog="multitool.py",
         description="A multipurpose tool for cleaning, getting, and analyzing text files.",
         epilog=dedent(

--- a/tests/test_multitool_help.py
+++ b/tests/test_multitool_help.py
@@ -106,3 +106,35 @@ def test_search_standard_help(monkeypatch, capsys):
     assert "A typo-aware search tool." in output
     assert "Example:" in output
     assert "python multitool.py search 'teh' report.txt" in output
+
+def test_invalid_subcommand_suggestion(monkeypatch, capsys):
+    """Test that typing an invalid subcommand suggests the closest valid choice."""
+    monkeypatch.setattr(sys, 'argv', ['multitool.py', 'checkk'])
+
+    with pytest.raises(SystemExit) as excinfo:
+        multitool.main()
+
+    assert excinfo.value.code == 2
+
+    captured = capsys.readouterr()
+    output = captured.err + captured.out
+
+    assert "has no subcommand 'checkk'" in output
+    assert "Did you mean: check" in output
+    assert "Run python multitool.py help to see a list of all available commands." in output
+
+def test_invalid_mode_help_suggestion(monkeypatch, capsys):
+    """Test that typing an invalid --mode-help mode suggests the closest valid choice."""
+    monkeypatch.setattr(sys, 'argv', ['multitool.py', '--mode-help', 'coments'])
+
+    with pytest.raises(SystemExit) as excinfo:
+        multitool.main()
+
+    assert excinfo.value.code == 2
+
+    captured = capsys.readouterr()
+    output = captured.err + captured.out
+
+    assert "is not a valid mode for --mode-help" in output
+    assert "Did you mean: comments" in output
+    assert "Run python multitool.py help to see a list of all available commands." in output


### PR DESCRIPTION
**PR Title:** [UI/UX] Improve CLI error feedback for invalid subcommands and --mode-help choices

**Description:**
* **Context:** CLI
* **Problem:** When a user enters an invalid subcommand (e.g., `checkk` instead of `check`) or a typo-ridden `--mode-help` argument (e.g., `coments` instead of `comments`), `argparse` displays a massive, overwhelming list of over 50 choices. This is highly difficult to read and increases friction when trying to recover from simple mistakes.
* **Solution:** Intercept the subcommand and `--mode-help` invalid choice errors using a custom `TypoTolerantArgumentParser` subclass. By utilizing Levenshtein distance, the parser dynamically identifies and suggests the closest valid subcommand match with clear, high-contrast visual suggestions (e.g., `Did you mean: check?`), while maintaining compatibility and falling back gracefully for unrecognized inputs.

**Changes:**
```python
class TypoTolerantArgumentParser(argparse.ArgumentParser):
    \"\"\"Custom ArgumentParser subclass that intercepts invalid subcommand and --mode-help choice errors
    to dynamically suggest the closest valid choice match.
    \"\"\"

    def error(self, message: str) -> None:
        match = re.search(r"argument (mode|--mode-help): invalid choice: '([^']+)'", message)
        if match:
            arg_type = match.group(1)
            invalid_val = match.group(2)
            if arg_type == "--mode-help":
                candidates = list(MODE_DETAILS.keys()) + ["all"]
                suggestion = _get_best_suggestion(invalid_val, candidates, max_dist=3)
                if suggestion:
                    self.exit(
                        status=2,
                        message=(
                            f"{RED}Error:{RESET} '{invalid_val}' is not a valid mode for --mode-help.\n"
                            f"Did you mean: {GREEN}{suggestion}{RESET}?\n\n"
                            f"Run {GREEN}python multitool.py help{RESET} to see a list of all available commands.\n"
                        )
                    )
            else:
                candidates = list(MODE_DETAILS.keys()) + ["help"]
                suggestion = _get_best_suggestion(invalid_val, candidates, max_dist=3)
                if suggestion:
                    self.exit(
                        status=2,
                        message=(
                            f"{RED}Error:{RESET} 'multitool.py' has no subcommand '{invalid_val}'.\n"
                            f"Did you mean: {GREEN}{suggestion}{RESET}?\n\n"
                            f"Run {GREEN}python multitool.py help{RESET} to see a list of all available commands.\n"
                        )
                    )
        super().error(message)
```

---
*PR created automatically by Jules for task [10212877152317253742](https://jules.google.com/task/10212877152317253742) started by @RainRat*