### PR TITLE
[FEAT] Add Include Pattern Filtering to diff2typo

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -413,11 +413,23 @@ def _is_file_excluded(filepath: str, patterns: Optional[List[str]]) -> bool:
     return False
 
 
+def _is_file_included(filepath: str, patterns: Optional[List[str]]) -> bool:
+    if not patterns:
+        return True
+    if not filepath:
+        return False
+    for pattern in patterns:
+        if fnmatch.fnmatch(filepath, pattern) or fnmatch.fnmatch(os.path.basename(filepath), pattern):
+            return True
+    return False
+
+
 def find_typos(
     diff_text: str,
     min_length: int = 2,
     max_dist: Optional[int] = None,
     exclude_patterns: Optional[List[str]] = None,
+    include_patterns: Optional[List[str]] = None,
 ) -> List[str]:
     """
     Parses the diff text to find typo corrections.
@@ -459,8 +471,9 @@ def find_typos(
                     current_file = p
                 if current_file.startswith('"') and current_file.endswith('"'):
                     current_file = current_file[1:-1]
-            if current_file and _is_file_excluded(current_file, exclude_patterns):
-                skip_current_file = True
+            if current_file:
+                if _is_file_excluded(current_file, exclude_patterns) or not _is_file_included(current_file, include_patterns):
+                    skip_current_file = True
             continue
 
         # Handle file renames and copies
@@ -475,7 +488,7 @@ def find_typos(
             if path.startswith('"') and path.endswith('"'):
                 path = path[1:-1]
             additions.append(path)
-            if not (skip_current_file or _is_file_excluded(path, exclude_patterns)):
+            if not (skip_current_file or _is_file_excluded(path, exclude_patterns) or not _is_file_included(path, include_patterns)):
                 typos.extend(process_diff_block(removals, additions, min_length, max_dist))
             removals = []
             additions = []
@@ -492,7 +505,7 @@ def find_typos(
                     typos.extend(process_diff_block(removals, additions, min_length, max_dist))
                 removals = []
                 additions = []
-                skip_current_file = _is_file_excluded(current_file, exclude_patterns)
+                skip_current_file = _is_file_excluded(current_file, exclude_patterns) or not _is_file_included(current_file, include_patterns)
             continue
 
         if skip_current_file:
@@ -861,6 +874,12 @@ def main():
         help="One or more file patterns (e.g., '*.json', 'tests/*') to exclude from typo scanning.",
     )
     analysis_group.add_argument(
+        '-I', '--include',
+        nargs='+',
+        default=None,
+        help="One or more file patterns (e.g., '*.md', 'src/*') to include in typo scanning (all files are scanned by default).",
+    )
+    analysis_group.add_argument(
         '-M', '--mode',
         type=str,
         choices=['typos', 'corrections', 'both', 'audit'],
@@ -1033,6 +1052,7 @@ def main():
         min_length=args.min_length,
         max_dist=args.max_dist,
         exclude_patterns=args.exclude,
+        include_patterns=args.include,
     )
     counts = Counter(candidates_raw)
 

--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -29,6 +29,7 @@ git diff | python diff2typo.py [OPTIONS]
 | `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), or `list` (typo only). |
 | `--mode`, `-M` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
 | `--exclude`, `-e` | None | One or more file patterns (e.g., `*.json`, `tests/*`) to exclude from typo scanning. |
+| `--include`, `-I` | None | One or more file patterns (e.g., `*.md`, `src/*`) to include in typo scanning (all files are scanned by default). |
 | `--min-length`, `-m` | `2` | Ignore words shorter than this length. |
 | `--max-dist`, `-D` | None | Only include typos with a number of character changes up to this value. Useful for filtering out intentional word changes. |
 | `--min-count`, `-c` | `1` | Minimum occurrences of a typo in the diff to include it in the output. |

--- a/tests/test_diff2typo_include.py
+++ b/tests/test_diff2typo_include.py
@@ -1,0 +1,115 @@
+import pytest
+from diff2typo import _is_file_included, find_typos, main
+from unittest.mock import patch
+
+def test_is_file_included():
+    assert _is_file_included("tests/test_math.py", ["*.py"])
+    assert _is_file_included("config.json", ["*.json"])
+    assert _is_file_included("src/lib.py", ["src/*"])
+    assert _is_file_included("package-lock.json", ["package-lock.json"])
+    assert not _is_file_included("src/lib.py", ["*.json"])
+    assert _is_file_included("src/lib.py", None)
+    assert not _is_file_included("", ["*.py"])
+
+
+def test_find_typos_inclusion():
+    diff_text = """diff --git a/src/main.py b/src/main.py
+--- a/src/main.py
++++ b/src/main.py
+@@ -1,2 +1,2 @@
+-def hello():
+-    print("hllo")
++def hello():
++    print("hello")
+diff --git a/config.json b/config.json
+--- a/config.json
++++ b/config.json
+@@ -1,2 +1,2 @@
+- "vrsion": "1.0.0"
++ "version": "1.0.0"
+"""
+    # Include only src/*
+    results = find_typos(diff_text, include_patterns=["src/*"])
+    assert "hllo -> hello" in results
+    assert "vrsion -> version" not in results
+
+    # Include only config.json
+    results = find_typos(diff_text, include_patterns=["*.json"])
+    assert "hllo -> hello" not in results
+    assert "vrsion -> version" in results
+
+    # No inclusion patterns (defaults to all)
+    results = find_typos(diff_text)
+    assert "hllo -> hello" in results
+    assert "vrsion -> version" in results
+
+
+def test_find_typos_inclusion_rename():
+    diff_rename_with_content = """diff --git a/old_dir/registre.py b/new_dir/register.py
+similarity index 85%
+rename from old_dir/registre.py
+rename to new_dir/register.py
+--- a/old_dir/registre.py
++++ b/new_dir/register.py
+@@ -1,2 +1,2 @@
+-class Registre:
++class Register:
+"""
+    # Include only old_dir/* (should match rename destination or skip_current_file context)
+    results = find_typos(diff_rename_with_content, include_patterns=["new_dir/*"])
+    assert "registre -> register" in results
+
+    results_none = find_typos(diff_rename_with_content, include_patterns=["other_dir/*"])
+    assert "registre -> register" not in results_none
+
+
+def test_find_typos_inclusion_unified_header():
+    diff_text = """--- a/src/math.py
++++ b/src/math.py
+@@ -1,2 +1,2 @@
+-x = y + 1 # formulaa
++x = y + 1 # formula
+"""
+    # Include other files
+    results = find_typos(diff_text, include_patterns=["config.json"])
+    assert "formulaa -> formula" not in results
+
+    # Include math.py
+    results = find_typos(diff_text, include_patterns=["math.py"])
+    assert "formulaa -> formula" in results
+
+
+def test_find_typos_inclusion_and_exclusion():
+    diff_text = """diff --git a/src/main.py b/src/main.py
+--- a/src/main.py
++++ b/src/main.py
+@@ -1,2 +1,2 @@
+-def hello():
+-    print("hllo")
++def hello():
++    print("hello")
+diff --git a/src/test.py b/src/test.py
+--- a/src/test.py
++++ b/src/test.py
+@@ -1,2 +1,2 @@
+-def test_val(): # formulaa
++def test_val(): # formula
+"""
+    # Include src/* but exclude test.py
+    results = find_typos(diff_text, exclude_patterns=["*test.py"], include_patterns=["src/*"])
+    assert "hllo -> hello" in results
+    assert "formulaa -> formula" not in results
+
+
+def test_cli_include():
+    # Verify command line argument parsing with mock
+    with patch("sys.argv", ["diff2typo.py", "some.diff", "--include", "*.py", "src/*", "-o", "-"]), \
+         patch("diff2typo._read_diff_sources", return_value=""), \
+         patch("diff2typo.find_typos", return_value=[]) as mock_find:
+        try:
+            main()
+        except SystemExit:
+            pass
+        mock_find.assert_called_once()
+        args, kwargs = mock_find.call_args
+        assert kwargs["include_patterns"] == ["*.py", "src/*"]


### PR DESCRIPTION
* What: Adds `--include` / `-I` flag to `diff2typo.py` to filter paths in Git diff parsing using glob matching patterns.
* Why: Provides a symmetric feature to `--exclude` that allows developers to run typo scanning on a targeted subset of changed files (e.g. only markdown files or specific subdirectories) without needing to list all other extensions to ignore.

---
*PR created automatically by Jules for task [16953617329541106201](https://jules.google.com/task/16953617329541106201) started by @RainRat*