### PR TITLE
Fix CSV header parsing logic bug with leading empty lines in gentypos substitutions loading

### DIFF
--- a/gentypos.py
+++ b/gentypos.py
@@ -254,13 +254,15 @@ def _load_substitutions_file(path: str) -> dict[str, list[str]]:
                     header_keywords = typo_indicators | correct_indicators
 
                     idx_correct, idx_typo = 0, 1  # Default: correct,typo
+                    header_checked = False
 
-                    for i, row in enumerate(reader):
+                    for row in reader:
                         if not row or len(row) < 2:
                             continue
 
-                        # Skip header if first row matches keywords
-                        if i == 0:
+                        # Skip header if first non-empty row matches keywords
+                        if not header_checked:
+                            header_checked = True
                             val1, val2 = row[0].lower(), row[1].lower()
                             if val1 in header_keywords and val2 in header_keywords:
                                 # Determine column order based on headers

--- a/tests/test_gentypos_substitutions_file.py
+++ b/tests/test_gentypos_substitutions_file.py
@@ -76,3 +76,9 @@ def test_load_substitutions_malformed_json(tmp_path):
     path.write_text("{invalid json}")
     with pytest.raises(SystemExit):
         gentypos._load_substitutions_file(str(path))
+
+def test_load_substitutions_csv_leading_empty_lines(tmp_path):
+    path = tmp_path / "subs_leading.csv"
+    path.write_text("\n\n\ntypo,correct\nteh,value\nmispell,misspell\n", encoding="utf-8")
+    result = gentypos._load_substitutions_file(str(path))
+    assert result == {"value": ["teh"], "misspell": ["mispell"]}


### PR DESCRIPTION
Fixes a logic bug where leading empty/whitespace lines in a custom substitutions CSV file would prevent the header row from being correctly skipped and columns correctly mapped, resulting in headers being treated as standard mapping rows. It replaces the position-based index check `i == 0` with a robust `header_checked` boolean state flag. Fully covered by unit tests.

---
*PR created automatically by Jules for task [8489726308923241038](https://jules.google.com/task/8489726308923241038) started by @RainRat*