### PR TITLE
[DOCS] Link paths mode documentation and correct directory extraction example

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -122,7 +122,7 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py xml data.xml -k './/item/name'`
 
 - **`paths`**
-  - Extracts path components (basename, dirname, extension) from file and directory paths. It also supports smart splitting to find words within filenames.
+  - Extracts path components (basename, dirname, extension) from file and directory paths. It also supports smart splitting to find words within filenames. For more details, see the [dedicated paths documentation](paths.md).
   - **Options:** Use `--basename`, `--dirname`, or `--extension` to pick specific parts. Use `--smart` to split components into words.
   - **Example:** `python multitool.py paths src/ --basename --smart`
 

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -39,5 +39,5 @@ python multitool.py paths src/ --basename --smart --process-output
 
 ### Get unique folder names in a project
 ```bash
-python multitool.py paths . --dirname --basename --process-output --raw
+python multitool.py paths . --dirname --process-output --raw
 ```


### PR DESCRIPTION
This pull request improves the multitool and paths mode documentation. It establishes a clear cross-reference from the main multitool.md overview to the dedicated paths.md documentation file for the 'paths' mode. Additionally, it corrects the 'Get unique folder names' command example in paths.md by removing the redundant and conflicting --basename flag.

---
*PR created automatically by Jules for task [15003251106519386158](https://jules.google.com/task/15003251106519386158) started by @RainRat*