### PR TITLE
[FEAT] Add --if-not-exists to cmdrunner.py

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -113,6 +113,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if "if_exists" in config and not isinstance(config["if_exists"], str):
         errors.append("'if_exists' must be a string.")
 
+    if "if_not_exists" in config and not isinstance(config["if_not_exists"], str):
+        errors.append("'if_not_exists' must be a string.")
+
     if errors:
         raise ConfigError(" ".join(errors))
 
@@ -129,6 +132,7 @@ def run_command_in_folders(
     output_file: Optional[str] = None,
     output_format: Optional[str] = None,
     if_exists: Optional[str] = None,
+    if_not_exists: Optional[str] = None,
 ) -> None:
     """
     Run a specified command in each folder within the main folder,
@@ -149,6 +153,12 @@ def run_command_in_folders(
         directories = [
             item for item in directories
             if os.path.exists(os.path.join(main_folder, item, if_exists))
+        ]
+
+    if if_not_exists:
+        directories = [
+            item for item in directories
+            if not os.path.exists(os.path.join(main_folder, item, if_not_exists))
         ]
 
     iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
@@ -323,6 +333,11 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         help='Only run the command in folders that contain this specific file or path (e.g., package.json).'
     )
+    direct_group.add_argument(
+        '--if-not-exists',
+        type=str,
+        help='Only run the command in folders that do NOT contain this specific file or path (e.g., initialized.log).'
+    )
 
     # Execution Options Group
     options_group = parser.add_argument_group(f"{BLUE}EXECUTION OPTIONS{RESET}")
@@ -407,6 +422,7 @@ def main() -> None:
     fail_fast = args.fail_fast if args.fail_fast is not None else config.get('fail_fast', False)
     timeout = args.timeout if args.timeout is not None else config.get('timeout', None)
     if_exists = args.if_exists or config.get('if_exists', None)
+    if_not_exists = args.if_not_exists or config.get('if_not_exists', None)
 
     # Validate that required options are present
     errors = []
@@ -431,6 +447,7 @@ def main() -> None:
         output_file=args.output,
         output_format=args.format,
         if_exists=if_exists,
+        if_not_exists=if_not_exists,
     )
 
 if __name__ == "__main__":

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -55,6 +55,9 @@ timeout: 10.5
 
 # (Optional) Only run the command in folders that contain this specific file or path
 if_exists: "package.json"
+
+# (Optional) Only run the command in folders that do NOT contain this specific file or path
+if_not_exists: "initialized.log"
 ```
 
 ## Options
@@ -69,6 +72,7 @@ if_exists: "package.json"
 - `--fail-fast`: Stop execution immediately if any command fails or times out. Overrides config file if provided.
 - `--timeout`: The maximum execution time in seconds for the command in each folder. Overrides config file if provided.
 - `--if-exists`: Only run the command in folders that contain this specific file or path (e.g., `package.json` or `requirements.txt`). Overrides config file if provided.
+- `--if-not-exists`: Only run the command in folders that do NOT contain this specific file or path (e.g., `initialized.log`). Overrides config file if provided.
 - `-o`, `--output`: Where to save the execution report. If not provided, no report is saved.
 - `-f`, `--format`: Choose the format for the output report (`json`, `csv`, `txt`). If not provided, it is automatically detected from the output file extension.
 
@@ -88,7 +92,7 @@ In this example, if the tool processes a folder named `my-web-app`, it will run 
 ## How it Works
 
 1. **Find Folders:** The tool looks inside your `main_folder` and finds every sub-folder.
-2. **Filter:** It removes any folders you listed in `excluded_folders`, and filters remaining folders to only those containing the specified `--if-exists` file or path (if provided).
+2. **Filter:** It removes any folders you listed in `excluded_folders`, and filters remaining folders to only those containing the specified `--if-exists` file or path (if provided) and not containing the specified `--if-not-exists` file or path (if provided).
 3. **Execute:** It enters each remaining folder and runs your `command_to_run`.
 4. **Report:** It shows you the results of each command or any errors that occurred.
 
@@ -117,4 +121,9 @@ python cmdrunner.py config.yaml --quiet
 **Only run commands in projects containing a `package.json` file:**
 ```bash
 python cmdrunner.py --main-folder /home/user/projects --command-to-run "npm run build" --if-exists package.json
+```
+
+**Only run commands in projects that do NOT contain a `setup.log` file:**
+```bash
+python cmdrunner.py --main-folder /home/user/projects --command-to-run "bash setup.sh && touch setup.log" --if-not-exists setup.log
 ```

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -933,3 +933,154 @@ def test_main_with_if_exists_config(tmp_path, monkeypatch):
 
     assert not (proj1 / 'out_conf.txt').exists()
     assert (proj2 / 'out_conf.txt').exists()
+
+
+def test_load_config_invalid_if_not_exists(tmp_path):
+    config_file = tmp_path / 'config_invalid_if_not_exists.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'if_not_exists': 123,  # Invalid type (must be string)
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'if_not_exists' must be a string." in exc_info.value.args[0]
+
+
+def test_run_command_if_not_exists_filtering(tmp_path):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj_with_file = base_dir / 'proj_with_file'
+    proj_without_file = base_dir / 'proj_without_file'
+    proj_with_file.mkdir()
+    proj_without_file.mkdir()
+
+    # Create target file only in one folder
+    (proj_with_file / 'target.txt').write_text('exists')
+
+    command = "python3 -c \"open('test_file.txt','w').write('ran')\""
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        command,
+        if_not_exists='target.txt'
+    )
+
+    # Should NOT run in proj_with_file because it contains target.txt
+    assert not (proj_with_file / 'test_file.txt').exists()
+
+    # Should run in proj_without_file because it does NOT contain target.txt
+    assert (proj_without_file / 'test_file.txt').exists()
+    assert (proj_without_file / 'test_file.txt').read_text() == 'ran'
+
+
+def test_main_with_if_not_exists_cli_override(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    (proj1 / 'special.json').write_text('{}')
+
+    command = "python3 -c \"open('out.txt','w').write('ok')\""
+
+    # CLI override --if-not-exists
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['cmdrunner.py', '-m', str(base_dir), '-c', command, '--if-not-exists', 'special.json']
+    )
+
+    cmdrunner.main()
+
+    # proj1 contains special.json, so it should be skipped
+    assert not (proj1 / 'out.txt').exists()
+    # proj2 does NOT contain special.json, so it should run
+    assert (proj2 / 'out.txt').exists()
+
+
+def test_main_with_if_not_exists_config(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    (proj2 / 'config.ini').write_text('')
+
+    command = "python3 -c \"open('out_conf.txt','w').write('ok')\""
+
+    config_data = {
+        'main_folder': str(base_dir),
+        'command_to_run': command,
+        'if_not_exists': 'config.ini',
+    }
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(config_file)])
+
+    cmdrunner.main()
+
+    # proj1 does NOT contain config.ini, so it should run
+    assert (proj1 / 'out_conf.txt').exists()
+    # proj2 contains config.ini, so it should be skipped
+    assert not (proj2 / 'out_conf.txt').exists()
+
+
+def test_main_with_both_if_exists_and_if_not_exists(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    # Four projects representing all combinations:
+    # 1. contains both A and B
+    # 2. contains A but not B (matches criteria!)
+    # 3. contains B but not A
+    # 4. contains neither A nor B
+    proj1 = base_dir / 'both'
+    proj2 = base_dir / 'only_a'
+    proj3 = base_dir / 'only_b'
+    proj4 = base_dir / 'neither'
+
+    for p in [proj1, proj2, proj3, proj4]:
+        p.mkdir()
+
+    (proj1 / 'fileA.txt').write_text('')
+    (proj1 / 'fileB.txt').write_text('')
+
+    (proj2 / 'fileA.txt').write_text('')
+
+    (proj3 / 'fileB.txt').write_text('')
+
+    command = "python3 -c \"open('out_combo.txt','w').write('ok')\""
+
+    config_data = {
+        'main_folder': str(base_dir),
+        'command_to_run': command,
+        'if_exists': 'fileA.txt',
+        'if_not_exists': 'fileB.txt',
+    }
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(config_file)])
+
+    cmdrunner.main()
+
+    # Should only run in only_a
+    assert not (proj1 / 'out_combo.txt').exists()
+    assert (proj2 / 'out_combo.txt').exists()
+    assert not (proj3 / 'out_combo.txt').exists()
+    assert not (proj4 / 'out_combo.txt').exists()


### PR DESCRIPTION
### Description

* **What:** Added `--if-not-exists` command-line option and `if_not_exists` YAML configuration option to `cmdrunner.py`. This filters command execution to subdirectories under `main_folder` that do NOT contain a designated marker file or path.
* **Why:** The codebase already possesses an `--if-exists` option to filter directory runs to only those containing a designated path (e.g. `package.json`). Adding `--if-not-exists` provides a perfectly symmetric and incredibly useful option, allowing users to run setup, copying, template initialization, or fallback generation tasks only on directories where such a sentinel file or log is currently missing.

### Changes

#### 1. Core Implementation in `cmdrunner.py`
- Updated YAML validator inside `load_config()` to explicitly validate that `if_not_exists` is a string if defined.
- Added `if_not_exists` parameter to `run_command_in_folders()` signature and directory filtering logic using `not os.path.exists()`.
- Exposed `--if-not-exists` inside the argparse structure under the CLI overrides/direct options group.
- Resolved and passed CLI overrides or YAML configuration value for `if_not_exists` inside the `main()` function entry point.

#### 2. Documentation in `docs/cmdrunner.md`
- Documented `if_not_exists` under YAML configurations, CLI options table, and "How it Works" filtering logic, along with multiple execution examples.

#### 3. Test Coverage in `tests/test_cmdrunner.py`
- Added comprehensive unit tests for string validation, filtering logic, CLI override, and configuration file usage, ensuring all combinations (including concurrent use of both `if_exists` and `if_not_exists` together) are thoroughly covered and that `cmdrunner.py` maintains exactly 100% statement coverage.

---
*PR created automatically by Jules for task [18063405914176578883](https://jules.google.com/task/18063405914176578883) started by @RainRat*