### PR TITLE
[UI/UX] Implement glob-pattern exclusions with --exclude in typostats

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -56,6 +56,7 @@ The tool automatically recognizes several common ways of listing typos:
   - `json`: Data for other programs.
   - `yaml`: Simple list format.
 - `-o`, `--output`: Save the report to a file instead of showing it on the screen.
+- `-e`, `--exclude`: One or more file patterns (e.g., `*.json`, `tests/*`) to exclude from scanning.
 - `-q`, `--quiet`: Hide progress bars and status messages.
 
 ## Understanding the Report

--- a/tests/test_typostats_exclude.py
+++ b/tests/test_typostats_exclude.py
@@ -1,0 +1,61 @@
+import sys
+import os
+import json
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import typostats
+
+
+def test_is_file_excluded_basic():
+    assert typostats._is_file_excluded("foo.json", ["*.json"]) is True
+    assert typostats._is_file_excluded("foo.txt", ["*.json"]) is False
+    assert typostats._is_file_excluded("dir/foo.json", ["*.json"]) is True
+    assert typostats._is_file_excluded("dir/foo.json", ["dir/*"]) is True
+    assert typostats._is_file_excluded("", ["*.json"]) is False
+    assert typostats._is_file_excluded("foo.json", None) is False
+    assert typostats._is_file_excluded("foo.json", []) is False
+
+
+def test_main_with_single_file_exclusion(tmp_path):
+    f1 = tmp_path / "f1.txt"
+    f1.write_text("a -> b\n", encoding="utf-8")
+    f2 = tmp_path / "f2.txt"
+    f2.write_text("c -> d\n", encoding="utf-8")
+
+    with patch('sys.argv', ['typostats.py', str(f1), str(f2), '--exclude', '*f2*']), \
+         patch('typostats.generate_report') as mock_report:
+        typostats.main()
+        assert mock_report.call_args[1]['total_pairs'] == 1
+
+
+def test_main_with_recursive_directory_exclusion(tmp_path):
+    sub1 = tmp_path / "subdir1"
+    sub1.mkdir()
+    f1 = sub1 / "file1.txt"
+    f1.write_text("a -> b\n", encoding="utf-8")
+
+    sub2 = tmp_path / "subdir2"
+    sub2.mkdir()
+    f2 = sub2 / "file2.txt"
+    f2.write_text("c -> d\n", encoding="utf-8")
+
+    with patch('sys.argv', ['typostats.py', str(tmp_path), '--exclude', '*/subdir2/*']), \
+         patch('typostats.generate_report') as mock_report:
+        typostats.main()
+        assert mock_report.call_args[1]['total_pairs'] == 1
+
+
+def test_main_with_extension_exclusion(tmp_path):
+    f1 = tmp_path / "f1.txt"
+    f1.write_text("a -> b\n", encoding="utf-8")
+    f2 = tmp_path / "f2.csv"
+    f2.write_text("c,d\n", encoding="utf-8")
+
+    with patch('sys.argv', ['typostats.py', str(f1), str(f2), '-e', '*.csv']), \
+         patch('typostats.generate_report') as mock_report:
+        typostats.main()
+        assert mock_report.call_args[1]['total_pairs'] == 1

--- a/typostats.py
+++ b/typostats.py
@@ -473,6 +473,17 @@ def _read_file_lines_robust(path: str, newline: str | None = None) -> List[str]:
     return lines
 
 
+def _is_file_excluded(filepath: str, patterns: List[str] | None) -> bool:
+    """Check if the given filepath matches any exclusion patterns."""
+    if not patterns or not filepath:
+        return False
+    import fnmatch
+    for pattern in patterns:
+        if fnmatch.fnmatch(filepath, pattern) or fnmatch.fnmatch(os.path.basename(filepath), pattern):
+            return True
+    return False
+
+
 def _get_typo_correction(item: Any) -> Tuple[str | None, str | None]:
     if isinstance(item, dict) and 'typo' in item:
         correct = item.get('correct', item.get('correction'))
@@ -1074,6 +1085,12 @@ def main() -> None:
     )
     io_group.add_argument('-o', '--output', help="Save the report to this file instead of printing it.")
     io_group.add_argument(
+        '-e', '--exclude',
+        nargs='+',
+        default=None,
+        help="One or more file patterns (e.g., '*.json', 'tests/*') to exclude from scanning.",
+    )
+    io_group.add_argument(
         '-f',
         '--format',
         choices=['arrow', 'yaml', 'json', 'csv'],
@@ -1194,6 +1211,8 @@ def main() -> None:
         else:
             input_files = ['-']
 
+    exclude_patterns = args.exclude
+
     # Expand directories recursively
     expanded_files = []
     ignored_dirs = {
@@ -1210,11 +1229,15 @@ def main() -> None:
                 # Prune ignored directories in-place to avoid walking into them
                 dirs[:] = [d for d in dirs if d not in ignored_dirs]
                 for file in files:
+                    full_path = os.path.join(root, file)
+                    if _is_file_excluded(full_path, exclude_patterns):
+                        continue
                     ext = os.path.splitext(file)[1].lower()
                     if ext in supported_extensions:
-                        expanded_files.append(os.path.join(root, file))
+                        expanded_files.append(full_path)
         else:
-            expanded_files.append(file_path)
+            if not _is_file_excluded(file_path, exclude_patterns):
+                expanded_files.append(file_path)
 
     input_files = expanded_files
 


### PR DESCRIPTION
- **Context:** CLI (Command Line Interface)
- **Problem:** When running `typostats.py` recursively over directories, users had no way to exclude specific files or subdirectories (such as test files, documentation, or temporary folders), causing irrelevant patterns to be analyzed and adding significant user friction.
- **Solution:** Added a new `--exclude` / `-e` command-line option to `typostats.py`. It allows specifying glob patterns (such as `*.csv`, `tests/*`) to skip during single-file processing and recursive directory scanning, ensuring high information density, reduced friction, and alignment with `diff2typo.py` and `cmdrunner.py`'s existing exclusion behavior.

---
*PR created automatically by Jules for task [12913228079275712527](https://jules.google.com/task/12913228079275712527) started by @RainRat*