### PR TITLE
[DOCS] Remove redundant --basename flag from paths.md example

### DIFF
--- a/docs/paths.md
+++ b/docs/paths.md
@@ -39,5 +39,5 @@ python multitool.py paths src/ --basename --smart --process-output
 
 ### Get unique folder names in a project
 ```bash
-python multitool.py paths . --dirname --basename --process-output --raw
+python multitool.py paths . --dirname --process-output --raw
 ```


### PR DESCRIPTION
This change corrects the command example for getting unique folder names in `docs/paths.md` by removing the redundant `--basename` flag. This ensures the documented command behavior matches the actual tool behavior.

---
*PR created automatically by Jules for task [4985524707555553777](https://jules.google.com/task/4985524707555553777) started by @RainRat*