### PR TITLE
[FEAT] Add multi-source input support to gentypos.py

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -17,15 +17,21 @@ python gentypos.py hello --no-filter
 python gentypos.py apple banana orange --no-filter
 ```
 
-### 2. Process words from a file
-Use a configuration file or specify an input file directly from the command line.
+### 2. Process words from files or directories
+Use a configuration file or specify one or more input files, directories, or glob patterns directly from the command line. The tool will recursively find supported files (like `.txt`, `.csv`, `.log`), ignoring standard development folders like `.git` or `node_modules`, and load all of their words together.
 
 ```bash
 # Process words using a configuration file
 python gentypos.py --config gentypos.yaml
 
-# Process words directly from a text file
-python gentypos.py --input words.txt --output typos.txt
+# Process words from multiple text files
+python gentypos.py --input words1.txt words2.txt --output typos.txt
+
+# Process words from a directory of wordlists
+python gentypos.py --input my_wordlists/ --output typos.txt
+
+# Process words using glob patterns
+python gentypos.py --input "data/*.txt" --output typos.txt
 ```
 
 ## Options
@@ -37,7 +43,7 @@ python gentypos.py --input words.txt --output typos.txt
 | `--output`, `-o` | None | Save results to this file. Use `-` to print to the screen. |
 | `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), or `list` (typo). By default, it is automatically detected from the output file extension. |
 | `--substitutions`, `-s` | None | A file containing custom typo patterns (JSON, CSV, or YAML). Useful for loading your personal typo history from `typostats.py`. |
-| `--input`, `-i` | None | The path to an input file containing words to process (one per line). |
+| `--input`, `-i` | None | One or more input files, directories, or glob patterns containing words to process (one per line). |
 | `--dictionary`, `-d` | None | The path to a large dictionary file used to filter out real words. |
 | `--min-length`, `-m` | None | Ignore words shorter than this length. |
 | `--max-length` | None | Ignore words longer than this length. |
@@ -54,7 +60,7 @@ The tool uses a YAML file to control how typos are generated.
 
 ```yaml
 # File Paths
-input_file: "words.txt"           # Small dictionary to process
+input_file: "words.txt"           # Small dictionary to process (can also be a list of files/directories)
 dictionary_file: "dictionary.txt"  # Large dictionary (to filter out real words)
 output_file: "typos.txt"          # Where to save the results
 

--- a/gentypos.py
+++ b/gentypos.py
@@ -532,6 +532,57 @@ def load_file(file_path: Optional[str]) -> set[str]:
         sys.exit(1)
 
 
+def _resolve_input_sources(input_files: Sequence[str]) -> list[str]:
+    """
+    Recursively expand directory paths, handle glob patterns,
+    and ignore common development/environment folders.
+    """
+    import glob
+    expanded_files = []
+    ignored_dirs = {
+        '.git', 'node_modules', 'venv', '.venv', '.pytest_cache',
+        '.ruff_cache', '.vscode', '.idea', '__pycache__', 'dist', 'build'
+    }
+    supported_extensions = {'.txt', '.csv', '.json', '.yaml', '.yml', '.md', '.log', '.lst'}
+
+    for path in input_files:
+        if path == '-':
+            expanded_files.append('-')
+            continue
+
+        # Handle glob expansion
+        matches = glob.glob(path)
+        if not matches:
+            matches = [path]
+
+        for match in sorted(matches):
+            if os.path.isdir(match):
+                for root, dirs, files in os.walk(match):
+                    # Prune ignored directories in-place to avoid walking into them
+                    dirs[:] = [d for d in dirs if d not in ignored_dirs]
+                    for file in sorted(files):
+                        ext = os.path.splitext(file)[1].lower()
+                        if ext in supported_extensions:
+                            expanded_files.append(os.path.join(root, file))
+            else:
+                expanded_files.append(match)
+
+    # Deduplicate while preserving order
+    return list(dict.fromkeys(expanded_files))
+
+
+def load_words_from_sources(input_files: Sequence[str]) -> set[str]:
+    """
+    Load words from all resolved input files and combine them.
+    """
+    all_words = set()
+    resolved_paths = _resolve_input_sources(input_files)
+    for path in resolved_paths:
+        words = load_file(path)
+        all_words.update(words)
+    return all_words
+
+
 def parse_yaml_config(config_path: str) -> dict[str, Any]:
     """
     Parse the YAML configuration file.
@@ -615,7 +666,14 @@ def format_typos(
 def _extract_config_settings(config: MutableMapping[str, Any], quiet: bool = False) -> SimpleNamespace:
     """Extract validated configuration values into a structured namespace."""
 
-    input_file = config.get('input_file')
+    input_file_val = config.get('input_file')
+    if input_file_val is None:
+        input_files = []
+    elif isinstance(input_file_val, list):
+        input_files = input_file_val
+    else:
+        input_files = [input_file_val]
+
     dictionary_file = config.get('dictionary_file')
     output_file = config.get('output_file')
     output_format = config.get('output_format', 'arrow').lower()
@@ -658,7 +716,7 @@ def _extract_config_settings(config: MutableMapping[str, Any], quiet: bool = Fal
     max_length = word_length.get('max_length', None)
 
     settings = SimpleNamespace(
-        input_file=input_file,
+        input_files=input_files,
         dictionary_file=dictionary_file,
         output_file=output_file,
         output_format=output_format,
@@ -879,14 +937,14 @@ def main() -> None:
     io_group.add_argument(
         '-i', '--input',
         dest='input_file',
-        type=str,
-        help="The path to an input file containing words to process (one per line).",
+        nargs='+',
+        help="One or more input files, directories, or glob patterns containing words to process (one per line).",
     )
     # Hidden alias
     parser.add_argument(
         '--input-file',
         dest='input_file',
-        type=str,
+        nargs='+',
         help=argparse.SUPPRESS,
     )
     io_group.add_argument(
@@ -1053,12 +1111,16 @@ def main() -> None:
         logging.info(f"Processing {len(word_list)} words from CLI arguments.")
     else:
         logging.info("Loading wordlist (small dictionary)...")
-        word_set = load_file(settings.input_file)
+        word_set = load_words_from_sources(settings.input_files)
         word_list = list(word_set)
+        if len(settings.input_files) == 1:
+            source_desc = f"'{settings.input_files[0]}'"
+        else:
+            source_desc = f"{len(settings.input_files)} source(s)"
         logging.info(
-            "Loaded %d words from the small dictionary ('%s').",
+            "Loaded %d words from the small dictionary (%s).",
             len(word_list),
-            settings.input_file,
+            source_desc,
         )
 
     # Load dictionary if needed

--- a/tests/test_gentypos_multisource.py
+++ b/tests/test_gentypos_multisource.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import types
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import gentypos
+
+def test_resolve_input_sources_files_and_globs(tmp_path):
+    f1 = tmp_path / "words1.txt"
+    f1.write_text("hello\n")
+    f2 = tmp_path / "words2.csv"
+    f2.write_text("world\n")
+
+    inputs = [str(f1), str(tmp_path / "*.csv")]
+    resolved = gentypos._resolve_input_sources(inputs)
+
+    assert str(f1) in resolved
+    assert str(f2) in resolved
+    assert len(resolved) == 2
+
+def test_resolve_input_sources_recursive_dir(tmp_path):
+    sub_dir = tmp_path / "nested"
+    sub_dir.mkdir()
+
+    f1 = sub_dir / "words.txt"
+    f1.write_text("apple\n")
+
+    ignored_dir = tmp_path / "node_modules"
+    ignored_dir.mkdir()
+    f2 = ignored_dir / "ignored.txt"
+    f2.write_text("banana\n")
+
+    f3 = sub_dir / "words.exe"
+    f3.write_text("cherry\n")
+
+    resolved = gentypos._resolve_input_sources([str(tmp_path)])
+
+    assert str(f1) in resolved
+    assert str(f2) not in resolved
+    assert str(f3) not in resolved
+
+def test_load_words_from_sources(tmp_path):
+    f1 = tmp_path / "words1.txt"
+    f1.write_text("apple\n")
+    f2 = tmp_path / "words2.txt"
+    f2.write_text("banana\n")
+
+    words = gentypos.load_words_from_sources([str(f1), str(f2)])
+    assert words == {"apple", "banana"}
+
+def test_extract_config_settings_single_vs_list():
+    config1 = {"input_file": "words.txt"}
+    settings1 = gentypos._extract_config_settings(config1)
+    assert settings1.input_files == ["words.txt"]
+
+    config2 = {"input_file": ["words1.txt", "words2.txt"]}
+    settings2 = gentypos._extract_config_settings(config2)
+    assert settings2.input_files == ["words1.txt", "words2.txt"]
+
+    config3 = {}
+    settings3 = gentypos._extract_config_settings(config3)
+    assert settings3.input_files == []


### PR DESCRIPTION
This PR adds multi-source input capability to `gentypos.py`. It enables batch processing of words from multiple files, directories, and glob patterns, making it consistent with other tools in the suite (like `typostats.py` and `multitool.py`). 

Key improvements:
- Enhanced `-i`/`--input` and `--input-file` arguments to accept `nargs='+'` in `argparse`.
- Added recursive scanning of directories for supported text formats (`.txt`, `.csv`, `.log`, `.lst`, `.md`), automatically ignoring standard noise folders like `.git`, `node_modules`, `venv`, etc.
- Added support for glob patterns (e.g. `*.txt`) using Python's built-in `glob` module.
- Retained full backward compatibility with single-string inputs in configuration files (e.g., `gentypos.yaml`).
- Updated the user documentation in `docs/gentypos.md` with clear examples.
- Added comprehensive unit tests in `tests/test_gentypos_multisource.py` covering directory recursion, globbing, exclusions, and configuration format variations.

---
*PR created automatically by Jules for task [9516495844608225172](https://jules.google.com/task/9516495844608225172) started by @RainRat*