### PR TITLE
[UI/UX] Implement typo-tolerant subcommand suggestions in multitool.py

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -8347,11 +8347,33 @@ class ModeHelpAction(argparse.Action):
         show_mode_help(values, parser)
 
 
+class TypoTolerantArgumentParser(argparse.ArgumentParser):
+    """Custom ArgumentParser subclass to suggest valid subcommands on typos."""
+
+    def error(self, message: str) -> None:
+        # Check if the error is an invalid choice for the subcommand 'mode'
+        # e.g., "argument mode: invalid choice: 'srub' (choose from help, arrow, ...)"
+        match = re.search(r"argument mode: invalid choice: '([^']+)'", message)
+
+        if match:
+            invalid_choice = match.group(1)
+            candidates = list(MODE_DETAILS.keys()) + ['help']
+            suggestion = _get_best_suggestion(invalid_choice, candidates, max_dist=2)
+            if suggestion:
+                sys.stderr.write(f"multitool.py: error: invalid mode: '{invalid_choice}'. Did you mean '{suggestion}'?\n")
+                sys.exit(2)
+            else:
+                sys.stderr.write(f"multitool.py: error: invalid mode: '{invalid_choice}'. Use 'multitool.py help' to see all available modes.\n")
+                sys.exit(2)
+
+        super().error(message)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     # Build a grouped mode summary for the epilog
     mode_summary = get_mode_summary_text()
 
-    parser = argparse.ArgumentParser(
+    parser = TypoTolerantArgumentParser(
         prog="multitool.py",
         description="A multipurpose tool for cleaning, getting, and analyzing text files.",
         epilog=dedent(

--- a/tests/test_multitool_help.py
+++ b/tests/test_multitool_help.py
@@ -106,3 +106,33 @@ def test_search_standard_help(monkeypatch, capsys):
     assert "A typo-aware search tool." in output
     assert "Example:" in output
     assert "python multitool.py search 'teh' report.txt" in output
+
+
+def test_invalid_subcommand_suggestion_close(monkeypatch, capsys):
+    """Test that misspelling a mode suggests the closest match (e.g. srub -> scrub)."""
+    monkeypatch.setattr(sys, 'argv', ['multitool.py', 'srub'])
+
+    with pytest.raises(SystemExit) as excinfo:
+        multitool.main()
+
+    assert excinfo.value.code == 2
+
+    captured = capsys.readouterr()
+    output = captured.err + captured.out
+    assert "invalid mode: 'srub'" in output
+    assert "Did you mean 'scrub'?" in output
+
+
+def test_invalid_subcommand_suggestion_no_close(monkeypatch, capsys):
+    """Test that a completely unrecognizable mode suggests help."""
+    monkeypatch.setattr(sys, 'argv', ['multitool.py', 'non_existent_gibberish'])
+
+    with pytest.raises(SystemExit) as excinfo:
+        multitool.main()
+
+    assert excinfo.value.code == 2
+
+    captured = capsys.readouterr()
+    output = captured.err + captured.out
+    assert "invalid mode: 'non_existent_gibberish'" in output
+    assert "Use 'multitool.py help' to see all available modes." in output


### PR DESCRIPTION
This PR improves CLI usability in multitool.py by introducing typo-tolerant subcommand parsing.
- Implemented `TypoTolerantArgumentParser` to override argparse error reporting.
- Intercepts invalid choice errors for the 'mode' argument and suggests the closest valid subcommand (Levenshtein distance <= 2).
- Added comprehensive unit tests in tests/test_multitool_help.py to verify suggestions for both close-matches and completely unrecognizable inputs.

---
*PR created automatically by Jules for task [15861072493439564599](https://jules.google.com/task/15861072493439564599) started by @RainRat*