### PR TITLE
[DOCS] Correct paths mode directory-only example in paths.md

### DIFF
--- a/docs/paths.md
+++ b/docs/paths.md
@@ -39,5 +39,5 @@ python multitool.py paths src/ --basename --smart --process-output
 
 ### Get unique folder names in a project
 ```bash
-python multitool.py paths . --dirname --basename --process-output --raw
+python multitool.py paths . --dirname --process-output --raw
 ```


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Corrected the command example "Get unique folder names in a project" inside `docs/paths.md` by removing the redundant `--basename` flag.
* **Why:** Previously, the example included `--basename`, which incorrectly extracted the final component (filename) of files, making it output individual file names instead of only directory names. Correcting the command ensures it performs exactly what the heading claims—getting unique directory names only.

---
*PR created automatically by Jules for task [17363656205689707276](https://jules.google.com/task/17363656205689707276) started by @RainRat*