### PR TITLE
[UI/UX] Change retention rate bar color to high-contrast cyan

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -161,6 +161,7 @@ def _format_analysis_summary(
     c_blue = _BLUE if use_color else ""
     c_green = _GREEN if use_color else ""
     c_yellow = _YELLOW if use_color else ""
+    c_cyan = _CYAN if use_color else ""
     c_reset = _RESET if use_color else ""
 
     padding = "  "
@@ -191,7 +192,7 @@ def _format_analysis_summary(
         bar = _render_visual_bar(retention, max_bar)
 
         report.append(
-            f"  {c_bold}{c_blue}{'Retention rate:':<{label_width}}{c_reset} {c_green}{retention:>5.1f}%{c_reset} {c_blue}{bar}{c_reset}"
+            f"  {c_bold}{c_blue}{'Retention rate:':<{label_width}}{c_reset} {c_green}{retention:>5.1f}%{c_reset} {c_cyan}{bar}{c_reset}"
         )
 
     # Unique Items

--- a/multitool.py
+++ b/multitool.py
@@ -636,6 +636,7 @@ def _format_analysis_summary(
     c_blue = BLUE if use_color else ""
     c_green = GREEN if use_color else ""
     c_yellow = YELLOW if use_color else ""
+    c_cyan = CYAN if use_color else ""
     c_reset = RESET if use_color else ""
 
     padding = "  "
@@ -661,7 +662,7 @@ def _format_analysis_summary(
         bar = _render_visual_bar(retention, max_bar)
 
         report.append(
-            f"  {c_bold}{c_blue}{'Retention rate:':<{label_width}}{c_reset} {c_green}{retention:>5.1f}%{c_reset} {c_blue}{bar}{c_reset}"
+            f"  {c_bold}{c_blue}{'Retention rate:':<{label_width}}{c_reset} {c_green}{retention:>5.1f}%{c_reset} {c_cyan}{bar}{c_reset}"
         )
 
     # Unique Items

--- a/typostats.py
+++ b/typostats.py
@@ -177,6 +177,7 @@ def _format_analysis_summary(
     c_blue = _BLUE if use_color else ""
     c_green = _GREEN if use_color else ""
     c_yellow = _YELLOW if use_color else ""
+    c_cyan = _CYAN if use_color else ""
     c_reset = _RESET if use_color else ""
 
     padding = "  "
@@ -211,7 +212,7 @@ def _format_analysis_summary(
         bar = _render_visual_bar(retention, max_bar)
 
         report.append(
-            f"  {c_bold}{c_blue}{'Retention rate:':<{label_width}}{c_reset} {c_green}{retention:>5.1f}%{c_reset} {c_blue}{bar}{c_reset}"
+            f"  {c_bold}{c_blue}{'Retention rate:':<{label_width}}{c_reset} {c_green}{retention:>5.1f}%{c_reset} {c_cyan}{bar}{c_reset}"
         )
 
     # Unique Items


### PR DESCRIPTION
Changes the 'Retention rate' visual bar color in the format analysis summary across diff2typo.py, typostats.py, and multitool.py from structural blue to high-contrast cyan. This improves visual hierarchy and contrast.

---
*PR created automatically by Jules for task [3283609210389652418](https://jules.google.com/task/3283609210389652418) started by @RainRat*