### PR TITLE
[DOCS] Fix redundant basename flag in paths.md example

### DIFF
--- a/docs/paths.md
+++ b/docs/paths.md
@@ -39,5 +39,5 @@ python multitool.py paths src/ --basename --smart --process-output
 
 ### Get unique folder names in a project
 ```bash
-python multitool.py paths . --dirname --basename --process-output --raw
+python multitool.py paths . --dirname --process-output --raw
 ```


### PR DESCRIPTION
Corrected an incorrect command example in `docs/paths.md` that was using a redundant `--basename` flag when retrieving unique folder names in a project.

---
*PR created automatically by Jules for task [7727357503156665127](https://jules.google.com/task/7727357503156665127) started by @RainRat*