### PR TITLE
Inline premature abstraction helper function `_read_csv_rows` in `diff2typo.py`

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -247,26 +247,6 @@ def levenshtein_distance(s1: str, s2: str) -> int:
     return previous_row[-1]
 
 
-def _read_csv_rows(file_path, description, required=False):
-    """Return CSV rows from ``file_path`` with shared error handling."""
-
-    try:
-        with open(file_path, "r", encoding="utf-8") as file_handle:
-            return list(csv.reader(file_handle))
-    except FileNotFoundError:
-        message = f"{description} '{file_path}' not found."
-        if required:
-            logging.error(message)
-            sys.exit(1)
-        logging.warning(message + " Skipping.")
-        return []
-    except Exception as exc:  # pragma: no cover - extremely unlikely
-        logging.error(f"Error reading {description.lower()} '{file_path}': {exc}")
-        if required:
-            sys.exit(1)
-        return []
-
-
 def read_allowed_words(allowed_file: str) -> Set[str]:
     """
     Reads allowed words from a CSV file and returns a set of lowercase words.
@@ -278,7 +258,16 @@ def read_allowed_words(allowed_file: str) -> Set[str]:
     Returns:
         set: A set of allowed words in lowercase.
     """
-    rows = _read_csv_rows(allowed_file, "Allowed words file", required=False)
+    try:
+        with open(allowed_file, "r", encoding="utf-8") as file_handle:
+            rows = list(csv.reader(file_handle))
+    except FileNotFoundError:
+        logging.warning(f"Allowed words file '{allowed_file}' not found. Skipping.")
+        rows = []
+    except Exception as exc:
+        logging.error(f"Error reading allowed words file '{allowed_file}': {exc}")
+        rows = []
+
     allowed_words = {row[0].strip().lower() for row in rows if row}
     if rows:
         logging.info(f"Loaded {len(allowed_words)} allowed words from '{allowed_file}'.")
@@ -311,8 +300,23 @@ def read_words_mapping(file_path: str, required: bool = True) -> Dict[str, Set[s
     We can also accept a list of words for the large dictionary. They will
         not have any corrections.
     """
+    try:
+        with open(file_path, "r", encoding="utf-8") as file_handle:
+            rows = list(csv.reader(file_handle))
+    except FileNotFoundError:
+        message = f"Large dictionary file '{file_path}' not found."
+        if required:
+            logging.error(message)
+            sys.exit(1)
+        logging.warning(message + " Skipping.")
+        rows = []
+    except Exception as exc:
+        logging.error(f"Error reading large dictionary file '{file_path}': {exc}")
+        if required:
+            sys.exit(1)
+        rows = []
+
     mapping: Dict[str, Set[str]] = {}
-    rows = _read_csv_rows(file_path, "Large dictionary file", required=required)
     for row in rows:
         if row:
             incorrect = row[0].strip().lower()

--- a/tests/test_diff2typo_coverage.py
+++ b/tests/test_diff2typo_coverage.py
@@ -35,11 +35,15 @@ def test_minimal_formatter_error_tty():
         assert "\033[1;31mERROR\033[0m" in formatted
         assert "Error message" in formatted
 
-def test_read_csv_rows_required_missing(tmp_path):
+def test_read_words_mapping_required_missing(tmp_path):
     missing_file = tmp_path / "missing.csv"
     with pytest.raises(SystemExit) as excinfo:
-        diff2typo._read_csv_rows(str(missing_file), "Test file", required=True)
+        diff2typo.read_words_mapping(str(missing_file), required=True)
     assert excinfo.value.code == 1
+
+def test_read_words_mapping_not_required_missing(tmp_path):
+    missing_file = tmp_path / "missing.csv"
+    assert diff2typo.read_words_mapping(str(missing_file), required=False) == {}
 
 def test_split_into_subwords_no_match():
     assert diff2typo.split_into_subwords("!!!") == ["!!!"]
@@ -201,3 +205,14 @@ def test_main_output_write_fail(tmp_path, monkeypatch):
         with pytest.raises(SystemExit) as excinfo:
             diff2typo.main()
         assert excinfo.value.code == 1
+
+def test_read_words_mapping_exception_required():
+    with patch("builtins.open", side_effect=OSError("Permission denied")):
+        with pytest.raises(SystemExit) as excinfo:
+            diff2typo.read_words_mapping("fake.csv", required=True)
+        assert excinfo.value.code == 1
+
+def test_read_words_mapping_exception_not_required():
+    with patch("builtins.open", side_effect=OSError("Permission denied")):
+        result = diff2typo.read_words_mapping("fake.csv", required=False)
+        assert result == {}

--- a/tests/test_diff2typo_main_gaps.py
+++ b/tests/test_diff2typo_main_gaps.py
@@ -280,10 +280,10 @@ class TestDiff2TypoMainGaps(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_read_words_mapping_empty_row(self):
-        # Target 176->175: empty row
-        with patch('diff2typo._read_csv_rows', return_value=[[], ["teh", "the"]]):
-            result = diff2typo.read_words_mapping("fake.csv")
-            self.assertEqual(result, {"teh": {"the"}})
+        with patch('builtins.open', return_value=io.StringIO("teh,the\n")):
+            with patch('csv.reader', return_value=[[], ["teh", "the"]]):
+                result = diff2typo.read_words_mapping("fake.csv")
+                self.assertEqual(result, {"teh": {"the"}})
 
     def test_minimal_formatter_no_color(self):
         # Target 80->83: color is None


### PR DESCRIPTION
This pull request improves code quality by resolving a premature abstraction in `diff2typo.py`. Specifically, the private helper function `_read_csv_rows` (which was only used in two nearby functions) was inlined directly into its callers `read_allowed_words` and `read_words_mapping`. Redundant mock expectations and direct tests of the private function were updated to test the public interfaces directly. The entire test suite of over 1,200 tests continues to pass successfully.

---
*PR created automatically by Jules for task [14972875873101633129](https://jules.google.com/task/14972875873101633129) started by @RainRat*