### PR TITLE
[UI/UX] Add -A/--all CLI flag to gentypos.py to reduce generation options friction

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -13,6 +13,9 @@ Pass words as arguments to see what typos are generated. By default, results are
 # Generate typos for a single word
 python gentypos.py hello --no-filter
 
+# Generate typos using all typo generation methods
+python gentypos.py hello --all --no-filter
+
 # Generate typos for multiple words
 python gentypos.py apple banana orange --no-filter
 ```
@@ -45,6 +48,11 @@ python gentypos.py --input "data/*.txt" --output typos.txt
 | `--substitutions`, `-s` | None | A file containing custom typo patterns (JSON, CSV, or YAML). Useful for loading your personal typo history from `typostats.py`. |
 | `--input`, `-i` | None | One or more input files, directories, or glob patterns containing words to process (one per line). |
 | `--dictionary`, `-d` | None | The path to a large dictionary file used to filter out real words. |
+| `--all`, `-A` | Off | Generate all typo types (deletions, transpositions, replacements, and duplications). |
+| `--transposition`, `-t` | Off | Generate transpositions (swapped letters, e.g., 'word' to 'wrod'). |
+| `--deletion` | Off | Generate deletions (skipping a letter, e.g., 'word' to 'wrd'). |
+| `--duplication` | Off | Generate duplications (typing a letter twice, e.g., 'word' to 'woord'). |
+| `--keyboard`, `-k`, `--replacement` | Off | Generate replacements (hitting a nearby key or custom substitution, e.g., 'word' to 'wprd'). |
 | `--min-length`, `-m` | None | Ignore words shorter than this length. |
 | `--max-length` | None | Ignore words longer than this length. |
 | `--repeat`, `-r` | `1` | Number of times to repeat typo generation, stacking modifications. |

--- a/gentypos.py
+++ b/gentypos.py
@@ -1091,6 +1091,11 @@ def main() -> None:
     # Generation Options
     gen_group = parser.add_argument_group(f"{BLUE}GENERATION OPTIONS{RESET}")
     gen_group.add_argument(
+        '-A', '--all',
+        action='store_true',
+        help="Generate all typo types (deletions, transpositions, replacements, and duplications).",
+    )
+    gen_group.add_argument(
         '-t', '--transposition',
         action='store_true',
         help="Generate transpositions (swapped letters, e.g., 'word' to 'wrod').",
@@ -1267,6 +1272,12 @@ def main() -> None:
             sys.exit(1)
 
     validate_config(config, cli_mode=is_cli_mode or (not is_cli_mode and not sys.stdin.isatty()), config_defaults=run_defaults)
+
+    if args.all:
+        args.deletion = True
+        args.transposition = True
+        args.replacement = True
+        args.duplication = True
 
     cli_typo_types = {
         'deletion': args.deletion,

--- a/tests/test_gentypos_cli_all.py
+++ b/tests/test_gentypos_cli_all.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import gentypos
+
+@pytest.fixture
+def empty_config_file(tmp_path):
+    config = tmp_path / "test_config.yaml"
+    config.write_text("{}", encoding="utf-8")
+    return str(config)
+
+def test_gentypos_cli_all_long_flag(capsys, empty_config_file):
+    test_args = [
+        "gentypos.py",
+        "word",
+        "-c", empty_config_file,
+        "--all",
+        "--no-filter",
+        "-f", "arrow"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    captured = capsys.readouterr()
+    stdout_lines = captured.out.splitlines()
+    assert len(stdout_lines) > 0
+
+    # 1. Deletion: 'wrd', 'wod', 'ord', 'wor'
+    assert any("wrd -> word" in line or "wod -> word" in line for line in stdout_lines)
+
+    # 2. Transposition: 'wrod', 'owrd', 'wodr'
+    assert any("wrod -> word" in line for line in stdout_lines)
+
+    # 3. Replacement (keyboard / substitution): 'wprd' (o -> p), 'wsrd' (o -> s)
+    assert any("wprd -> word" in line for line in stdout_lines)
+
+    # 4. Duplication: 'woord', 'wword', 'worrd', 'wordd'
+    assert any("woord -> word" in line or "wword -> word" in line for line in stdout_lines)
+
+def test_gentypos_cli_all_short_flag(capsys, empty_config_file):
+    test_args = [
+        "gentypos.py",
+        "word",
+        "-c", empty_config_file,
+        "-A",
+        "--no-filter",
+        "-f", "arrow"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    captured = capsys.readouterr()
+    stdout_lines = captured.out.splitlines()
+    assert len(stdout_lines) > 0
+
+    # 1. Deletion
+    assert any("wrd -> word" in line or "wod -> word" in line for line in stdout_lines)
+
+    # 2. Transposition
+    assert any("wrod -> word" in line for line in stdout_lines)
+
+    # 3. Replacement
+    assert any("wprd -> word" in line for line in stdout_lines)
+
+    # 4. Duplication
+    assert any("woord -> word" in line or "wword -> word" in line for line in stdout_lines)


### PR DESCRIPTION
Introduces the `-A`/`--all` CLI flag to `gentypos.py` to enable all typo generation modes (deletion, transposition, replacement, duplication) at once. This simplifies command-line usage and improves consistency with `typostats.py`'s `-a`/`--all` option. Includes updated markdown documentation and a comprehensive new unit test suite under `tests/test_gentypos_cli_all.py`.

---
*PR created automatically by Jules for task [17492142022815799068](https://jules.google.com/task/17492142022815799068) started by @RainRat*