### PR TITLE
[DOCS] Add missing typo generation CLI options to gentypos documentation

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -39,18 +39,23 @@ python gentypos.py --input "data/*.txt" --output typos.txt
 | Argument | Default | Description |
 | :--- | :--- | :--- |
 | `WORDS` | None | One or more words to generate typos for. If provided, the tool ignores the input file in your configuration. |
+| `--add`, `-a` | None | Extra substitution pairs (for example `ph:f` or `th:teh`) to use during typo generation. |
 | `--config`, `-c` | `gentypos.yaml` | The path to your YAML configuration file. |
-| `--output`, `-o` | None | Save results to this file. Use `-` to print to the screen. |
-| `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), or `list` (typo). By default, it is automatically detected from the output file extension. |
-| `--substitutions`, `-s` | None | A file containing custom typo patterns (JSON, CSV, or YAML). Useful for loading your personal typo history from `typostats.py`. |
-| `--input`, `-i` | None | One or more input files, directories, or glob patterns containing words to process (one per line). |
+| `--deletion` | Off | Generate deletions (skipping a letter, e.g., 'word' becomes 'wrd'). |
 | `--dictionary`, `-d` | None | The path to a large dictionary file used to filter out real words. |
-| `--min-length`, `-m` | None | Ignore words shorter than this length. |
+| `--duplication` | Off | Generate duplications (typing a letter twice, e.g., 'word' becomes 'woord'). |
+| `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), or `list` (typo). By default, it is automatically detected from the output file extension. |
+| `--input`, `-i` | None | One or more input files, directories, or glob patterns containing words to process (one per line). |
+| `--keyboard`, `--replacement`, `-k` | Off | Generate replacements (hitting a nearby key or custom substitution, e.g., 'word' becomes 'wprd'). |
 | `--max-length` | None | Ignore words longer than this length. |
-| `--repeat`, `-r` | `1` | Number of times to repeat typo generation, stacking modifications. |
+| `--min-length`, `-m` | None | Ignore words shorter than this length. |
 | `--no-filter` | Off | Do not check typos against the large dictionary (makes generation faster). |
-| `--verbose`, `-v` | Off | Show more detailed log messages. |
+| `--output`, `-o` | None | Save results to this file. Use `-` to print to the screen. |
 | `--quiet`, `-q` | Off | Hide progress bars and status messages. |
+| `--repeat`, `-r` | `1` | Number of times to repeat typo generation, stacking modifications. |
+| `--substitutions`, `-s` | None | A file containing custom typo patterns (JSON, CSV, or YAML). Useful for loading your personal typo history from `typostats.py`. |
+| `--transposition`, `-t` | Off | Generate transpositions (swapping adjacent letters, e.g., 'word' becomes 'wrod'). |
+| `--verbose`, `-v` | Off | Show more detailed log messages. |
 
 ## Configuration (`gentypos.yaml`)
 


### PR DESCRIPTION
This pull request updates the `docs/gentypos.md` documentation to add the missing CLI options for `gentypos.py` under the Options table, sorting all arguments alphabetically. It clarifies previously undocumented key typo generation modes such as deletions, duplications, transpositions, adjacent-key replacements, and ad-hoc custom additions.

---
*PR created automatically by Jules for task [10442558977391778402](https://jules.google.com/task/10442558977391778402) started by @RainRat*