### PR TITLE
ui/ux: add contextual empty-diff suggestions and tips to diff2typo

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -1092,6 +1092,15 @@ def main():
         else:
             diff_text = _read_diff_sources(input_files)
 
+    if not diff_text.strip():
+        logging.warning("The input diff is empty (no changes detected).")
+        if git_log_val is not None:
+            logging.info("Tip: Try checking a different commit range, e.g. '-l HEAD~5'.")
+        elif git_val is not None or (not input_files and sys.stdin.isatty()):
+            logging.info("Tip: If you have no unstaged changes, try checking staged changes with '-g --cached', or previous commits with '-l HEAD~5'.")
+        else:
+            logging.info("Tip: Ensure the specified input files or piped input contain a valid Git diff or patch.")
+
     # Load the large dictionary (words mapping) once.
     # If the file is missing, we don't exit. Instead we just warn and continue without filtering.
     large_dictionary_mapping = read_words_mapping(args.dictionary_file, required=False)

--- a/tests/test_diff2typo_empty_diff_tips.py
+++ b/tests/test_diff2typo_empty_diff_tips.py
@@ -1,0 +1,98 @@
+import sys
+import logging
+from unittest.mock import MagicMock, patch
+import pytest
+import diff2typo
+
+def test_empty_diff_with_git_flag(caplog):
+    """Test that empty diff with explicit -g/--git logs unstaged/staged tips."""
+    args = MagicMock()
+    args.git = ""
+    args.git_log = None
+    args.input_files = []
+    args.input_files_flag = []
+    args.dictionary_file = "words.csv"
+    args.allowed_file = "allowed.csv"
+    args.output_file = "-"
+    args.output_format = "arrow"
+    args.quiet = False
+    args.mode = "typos"
+    args.min_length = 2
+    args.max_dist = None
+    args.min_count = 1
+    args.limit = None
+    args.sort = "alpha"
+
+    with patch("argparse.ArgumentParser.parse_args", return_value=args), \
+         patch("sys.stdin.isatty", return_value=True), \
+         patch("diff2typo._read_git_diff", return_value=""), \
+         patch("diff2typo.smart_open_output"), \
+         caplog.at_level(logging.INFO):
+
+        diff2typo.main()
+
+    log_texts = [record.message for record in caplog.records]
+    assert any("The input diff is empty (no changes detected)." in msg for msg in log_texts)
+    assert any("staged changes with '-g --cached', or previous commits with '-l HEAD~5'" in msg for msg in log_texts)
+
+def test_empty_diff_with_git_log_flag(caplog):
+    """Test that empty diff with explicit -l/--git-log logs commit range tips."""
+    args = MagicMock()
+    args.git = None
+    args.git_log = "HEAD~5"
+    args.input_files = []
+    args.input_files_flag = []
+    args.dictionary_file = "words.csv"
+    args.allowed_file = "allowed.csv"
+    args.output_file = "-"
+    args.output_format = "arrow"
+    args.quiet = False
+    args.mode = "typos"
+    args.min_length = 2
+    args.max_dist = None
+    args.min_count = 1
+    args.limit = None
+    args.sort = "alpha"
+
+    with patch("argparse.ArgumentParser.parse_args", return_value=args), \
+         patch("sys.stdin.isatty", return_value=True), \
+         patch("diff2typo._read_git_log", return_value=""), \
+         patch("diff2typo.smart_open_output"), \
+         caplog.at_level(logging.INFO):
+
+        diff2typo.main()
+
+    log_texts = [record.message for record in caplog.records]
+    assert any("The input diff is empty (no changes detected)." in msg for msg in log_texts)
+    assert any("Try checking a different commit range, e.g. '-l HEAD~5'" in msg for msg in log_texts)
+
+def test_empty_diff_with_direct_files(caplog):
+    """Test that empty diff with files logs valid diff tips."""
+    args = MagicMock()
+    args.git = None
+    args.git_log = None
+    args.input_files = ["some_empty_file.diff"]
+    args.input_files_flag = []
+    args.dictionary_file = "words.csv"
+    args.allowed_file = "allowed.csv"
+    args.output_file = "-"
+    args.output_format = "arrow"
+    args.quiet = False
+    args.mode = "typos"
+    args.min_length = 2
+    args.max_dist = None
+    args.min_count = 1
+    args.limit = None
+    args.sort = "alpha"
+
+    with patch("argparse.ArgumentParser.parse_args", return_value=args), \
+         patch("sys.stdin.isatty", return_value=True), \
+         patch("diff2typo._read_diff_sources", return_value=""), \
+         patch("diff2typo.smart_open_output"), \
+         caplog.at_level(logging.INFO):
+
+        diff2typo.main()
+
+    log_texts = [record.message for record in caplog.records]
+    assert any("The input diff is empty (no changes detected)." in msg for msg in log_texts)
+    assert any("Ensure the specified input files or piped input contain a valid Git diff or patch" in msg for msg in log_texts)


### PR DESCRIPTION
Add user-friendly warning messages and context-tailored tips to `diff2typo.py` when an empty diff is encountered to eliminate user confusion and reduce CLI friction. Added unit tests for 100% statement and branch coverage on the new path.

---
*PR created automatically by Jules for task [6670284122835689036](https://jules.google.com/task/6670284122835689036) started by @RainRat*