### PR TITLE
Document Piping and Stdin Usage for gentypos.py

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -37,6 +37,13 @@ python gentypos.py --input my_wordlists/ --output typos.txt
 python gentypos.py --input "data/*.txt" --output typos.txt
 ```
 
+### 3. Piping words (Standard Input)
+You can pipe a list of words from another tool directly into `gentypos.py`. If standard input is not a terminal and you do not provide any words or input files, the tool automatically reads from standard input and prints the results to standard output:
+
+```bash
+echo "hello" | python gentypos.py --no-filter
+```
+
 ## Options
 
 | Argument | Default | Description |


### PR DESCRIPTION
I have added a new section to the `gentypos.md` documentation explaining and demonstrating how to pipe lists of words from standard input (stdin) directly into `gentypos.py`. All tests have passed and formatting matches the Plain English style guidelines.

---
*PR created automatically by Jules for task [7210346945416145370](https://jules.google.com/task/7210346945416145370) started by @RainRat*