### PR TITLE
[FEAT] Parallel execution support for cmdrunner

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -11,6 +11,7 @@ except ImportError:  # pragma: no cover - optional dependency
 import sys
 import argparse
 import logging
+import concurrent.futures
 from typing import List, Dict, Any, Optional
 
 try:
@@ -116,6 +117,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if "if_not_exists" in config and not isinstance(config["if_not_exists"], str):
         errors.append("'if_not_exists' must be a string.")
 
+    if "jobs" in config and (isinstance(config["jobs"], bool) or not isinstance(config["jobs"], int) or config["jobs"] < 1):
+        errors.append("'jobs' must be an integer greater than or equal to 1.")
+
     if errors:
         raise ConfigError(" ".join(errors))
 
@@ -133,6 +137,7 @@ def run_command_in_folders(
     output_format: Optional[str] = None,
     if_exists: Optional[str] = None,
     if_not_exists: Optional[str] = None,
+    jobs: int = 1,
 ) -> None:
     """
     Run a specified command in each folder within the main folder,
@@ -161,30 +166,25 @@ def run_command_in_folders(
             if not os.path.exists(os.path.join(main_folder, item, if_not_exists))
         ]
 
-    iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
-
     report_data = []
 
-    # Iterate through each item in the main folder
-    for item in iterator:
+    def run_single(item: str) -> Dict[str, Any]:
         item_path = os.path.join(main_folder, item)
         current_command = command.replace("{}", shlex.quote(item))
 
         if dry_run:
             logging.warning(f"Dry run: would run command '{current_command}' in '{item}'")
-            report_data.append({
+            return {
                 "folder": item,
                 "command": current_command,
                 "status": "dry-run",
                 "return_code": 0,
                 "stdout": "",
                 "stderr": "",
-            })
-            continue
+            }
 
         logging.info(f"Running command in: {item}")
 
-        # Run the command in the directory
         try:
             result = subprocess.run(
                 current_command,
@@ -197,37 +197,91 @@ def run_command_in_folders(
                 timeout=timeout,
             )
             logging.info(f"Command output for '{item}':\n{result.stdout}")
-            report_data.append({
+            return {
                 "folder": item,
                 "command": current_command,
                 "status": "success",
                 "return_code": 0,
                 "stdout": result.stdout,
                 "stderr": result.stderr,
-            })
+            }
         except subprocess.TimeoutExpired as e:
             logging.error(f"The command in '{item}' timed out after {timeout} seconds.")
-            report_data.append({
+            return {
                 "folder": item,
                 "command": current_command,
                 "status": "timeout",
                 "return_code": -1,
                 "stdout": e.stdout.decode() if isinstance(e.stdout, bytes) else (e.stdout or ""),
                 "stderr": e.stderr.decode() if isinstance(e.stderr, bytes) else (e.stderr or ""),
-            })
-            if fail_fast:
-                sys.exit(1)
+            }
         except subprocess.CalledProcessError as e:
             logging.error(f"The command failed in '{item}':\n{e.stderr}")
-            report_data.append({
+            return {
                 "folder": item,
                 "command": current_command,
                 "status": "failed",
                 "return_code": e.returncode,
                 "stdout": e.stdout or "",
                 "stderr": e.stderr or "",
-            })
-            if fail_fast:
+            }
+
+    if jobs > 1 and len(directories) > 1:
+        failed = False
+        futures_map = {}
+        results_by_folder = {}
+
+        iterator = tqdm(total=len(directories), desc="Processing folders", unit="folder", disable=dry_run or quiet)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
+            for item in directories:
+                if fail_fast and failed:
+                    break
+                future = executor.submit(run_single, item)
+                futures_map[future] = item
+
+            for future in concurrent.futures.as_completed(futures_map):
+                item = futures_map[future]
+                try:
+                    res = future.result()
+                    results_by_folder[item] = res
+                    if fail_fast and res["status"] in ("failed", "timeout"):
+                        failed = True
+                        for f in futures_map:
+                            f.cancel()
+                except Exception as exc:
+                    logging.error(f"Task generated an exception in '{item}': {exc}")
+                    results_by_folder[item] = {
+                        "folder": item,
+                        "command": command.replace("{}", shlex.quote(item)),
+                        "status": "failed",
+                        "return_code": -1,
+                        "stdout": "",
+                        "stderr": str(exc),
+                    }
+                    if fail_fast:
+                        failed = True
+                        for f in futures_map:
+                            f.cancel()
+
+                iterator.update(1)
+
+        iterator.close()
+
+        # Reconstruct report_data in the exact sorted directory order
+        for item in directories:
+            if item in results_by_folder:
+                report_data.append(results_by_folder[item])
+
+        if fail_fast and failed:
+            sys.exit(1)
+
+    else:
+        iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
+        for item in iterator:
+            res = run_single(item)
+            report_data.append(res)
+            if fail_fast and res["status"] in ("failed", "timeout"):
                 sys.exit(1)
 
     if output_file:
@@ -342,6 +396,11 @@ def parse_arguments() -> argparse.Namespace:
     # Execution Options Group
     options_group = parser.add_argument_group(f"{BLUE}EXECUTION OPTIONS{RESET}")
     options_group.add_argument(
+        '-j', '--jobs',
+        type=int,
+        help='The number of concurrent jobs to run in parallel (default: 1).'
+    )
+    options_group.add_argument(
         '--dry-run',
         action='store_true',
         help='Show which folders would be checked without executing the command.'
@@ -423,6 +482,7 @@ def main() -> None:
     timeout = args.timeout if args.timeout is not None else config.get('timeout', None)
     if_exists = args.if_exists or config.get('if_exists', None)
     if_not_exists = args.if_not_exists or config.get('if_not_exists', None)
+    jobs = args.jobs if args.jobs is not None else config.get('jobs', 1)
 
     # Validate that required options are present
     errors = []
@@ -448,6 +508,7 @@ def main() -> None:
         output_format=args.format,
         if_exists=if_exists,
         if_not_exists=if_not_exists,
+        jobs=jobs,
     )
 
 if __name__ == "__main__":

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -58,6 +58,9 @@ if_exists: "package.json"
 
 # (Optional) Only run the command in folders that do NOT contain this specific file or path
 if_not_exists: "initialized.log"
+
+# (Optional) The number of concurrent jobs to run in parallel
+jobs: 4
 ```
 
 ## Options
@@ -73,6 +76,7 @@ if_not_exists: "initialized.log"
 - `--timeout`: The maximum execution time in seconds for the command in each folder. Overrides config file if provided.
 - `--if-exists`: Only run the command in folders that contain this specific file or path (e.g., `package.json` or `requirements.txt`). Overrides config file if provided.
 - `--if-not-exists`: Only run the command in folders that do NOT contain this specific file or path (e.g., `initialized.log`). Overrides config file if provided.
+- `-j`, `--jobs`: The number of concurrent jobs to run in parallel. Overrides config file if provided (default: 1).
 - `-o`, `--output`: Where to save the execution report. If not provided, no report is saved.
 - `-f`, `--format`: Choose the format for the output report (`json`, `csv`, `txt`). If not provided, it is automatically detected from the output file extension.
 

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -1050,3 +1050,140 @@ def test_main_with_if_not_exists_config(tmp_path, monkeypatch):
 
     assert (proj1 / 'out_conf.txt').exists()
     assert not (proj2 / 'out_conf.txt').exists()
+
+
+def test_load_config_invalid_jobs(tmp_path):
+    config_file = tmp_path / 'config_invalid_jobs.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'jobs': 'not-an-int',
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'jobs' must be an integer greater than or equal to 1." in exc_info.value.args[0]
+
+
+def test_load_config_jobs_less_than_one(tmp_path):
+    config_file = tmp_path / 'config_invalid_jobs_val.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'jobs': 0,
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'jobs' must be an integer greater than or equal to 1." in exc_info.value.args[0]
+
+
+def test_run_command_parallel_success(tmp_path):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    command = "python3 -c \"open('parallel_out.txt','w').write('ok')\""
+
+    # Execute with 2 parallel jobs
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        command,
+        jobs=2
+    )
+
+    assert (proj1 / 'parallel_out.txt').exists()
+    assert (proj1 / 'parallel_out.txt').read_text() == 'ok'
+    assert (proj2 / 'parallel_out.txt').exists()
+    assert (proj2 / 'parallel_out.txt').read_text() == 'ok'
+
+
+def test_main_parallel_cli_override(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    command = "python3 -c \"open('cli_parallel_out.txt','w').write('ok')\""
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['cmdrunner.py', '-m', str(base_dir), '-c', command, '--jobs', '3']
+    )
+
+    cmdrunner.main()
+
+    assert (proj1 / 'cli_parallel_out.txt').exists()
+    assert (proj2 / 'cli_parallel_out.txt').exists()
+
+
+def test_parallel_fail_fast(tmp_path):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    # command that fails (exit 1)
+    command = "python3 -c \"import sys; sys.exit(1)\""
+
+    with pytest.raises(SystemExit) as exc_info:
+        cmdrunner.run_command_in_folders(
+            str(base_dir),
+            command,
+            jobs=2,
+            fail_fast=True
+        )
+
+    assert exc_info.value.code == 1
+
+
+def test_parallel_exceptions_handled(tmp_path, caplog):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj1.mkdir()
+
+    # Force run_single inside ThreadPoolExecutor to raise an Exception or timeout
+    # Let's use an extremely low timeout value so it raises subprocess.TimeoutExpired
+    command = "python3 -c \"import time; time.sleep(2)\""
+
+    output_file = tmp_path / 'report.json'
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        command,
+        jobs=2,
+        timeout=0.01,
+        output_file=str(output_file),
+        output_format='json'
+    )
+
+    assert output_file.exists()
+    with open(output_file, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    assert len(data) == 1
+    assert data[0]['folder'] == 'proj1'
+    assert data[0]['status'] == 'timeout'


### PR DESCRIPTION
This pull request adds parallel command execution support to the `cmdrunner` tool. It implements concurrent command execution across multiple folders in parallel using a thread pool executor, with support for CLI overrides and configuration file settings. All existing and new tests pass perfectly, and full documentation is provided.

---
*PR created automatically by Jules for task [9103093380111801962](https://jules.google.com/task/9103093380111801962) started by @RainRat*