### PR TITLE
Extract duplicate pattern matching into _match_pattern

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -409,13 +409,17 @@ def process_diff_block(
     return _compare_word_lists(before_words, after_words, min_length, max_dist)
 
 
-def _is_file_excluded(filepath: str, patterns: Optional[List[str]]) -> bool:
-    if not patterns or not filepath:
-        return False
+def _match_pattern(filepath: str, patterns: List[str]) -> bool:
     for pattern in patterns:
         if fnmatch.fnmatch(filepath, pattern) or fnmatch.fnmatch(os.path.basename(filepath), pattern):
             return True
     return False
+
+
+def _is_file_excluded(filepath: str, patterns: Optional[List[str]]) -> bool:
+    if not patterns or not filepath:
+        return False
+    return _match_pattern(filepath, patterns)
 
 
 def _is_file_included(filepath: str, patterns: Optional[List[str]]) -> bool:
@@ -423,10 +427,7 @@ def _is_file_included(filepath: str, patterns: Optional[List[str]]) -> bool:
         return True
     if not filepath:
         return False
-    for pattern in patterns:
-        if fnmatch.fnmatch(filepath, pattern) or fnmatch.fnmatch(os.path.basename(filepath), pattern):
-            return True
-    return False
+    return _match_pattern(filepath, patterns)
 
 
 def find_typos(


### PR DESCRIPTION
This change extracts the identical loop for pattern matching via `fnmatch` from `_is_file_excluded` and `_is_file_included` inside `diff2typo.py` into a single private helper `_match_pattern`. This removes code duplication in a fully backward-compatible, clean, and self-documenting way, backed up by complete test coverage.

---
*PR created automatically by Jules for task [5019824217136092249](https://jules.google.com/task/5019824217136092249) started by @RainRat*