### PR TITLE
[FEAT] JSON and YAML output formats for gentypos.py

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -48,7 +48,7 @@ python gentypos.py --input "data/*.txt" --output typos.txt
 | `--deletion` | Off | Generate deletions (skipping a letter, e.g., 'word' becomes 'wrd'). |
 | `--dictionary`, `-d` | None | The path to a large dictionary file used to filter out real words. |
 | `--duplication` | Off | Generate duplications (typing a letter twice, e.g., 'word' becomes 'woord'). |
-| `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), or `list` (typo). By default, it is automatically detected from the output file extension. |
+| `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), `list` (typo), `json`, or `yaml`. By default, it is automatically detected from the output file extension. |
 | `--input`, `-i` | None | One or more input files, directories, or glob patterns containing words to process (one per line). |
 | `--keyboard`, `--replacement`, `-k` | Off | Generate replacements (hitting a nearby key or custom substitution, e.g., 'word' becomes 'wprd'). |
 | `--max-length` | None | Ignore words longer than this length. |
@@ -73,7 +73,7 @@ input_file: "words.txt"           # Small dictionary to process (can also be a l
 dictionary_file: "dictionary.txt"  # Large dictionary (to filter out real words)
 output_file: "typos.txt"          # Where to save the results
 
-# Output Format: arrow (a -> b), csv (a,b), table (a = "b"), or list (a)
+# Output Format: arrow (a -> b), csv (a,b), table (a = "b"), list (a), json, or yaml
 output_format: "arrow"
 
 # How many times to repeat the process (makes more complex typos)

--- a/gentypos.py
+++ b/gentypos.py
@@ -148,6 +148,9 @@ def _detect_format_from_extension(path: str, allowed: Sequence[str], default: st
         'toml': 'table',
         'list': 'list',
         'arrow': 'arrow',
+        'json': 'json',
+        'yaml': 'yaml',
+        'yml': 'yaml',
     }
 
     detected = mapping.get(ext)
@@ -741,12 +744,24 @@ def format_typos(
 
     Args:
         typo_to_correct_word (dict): Mapping from typo to correct word.
-        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list').
+        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list', 'json', 'yaml').
 
     Returns:
         list: Formatted list of typo strings.
     """
     formatted = []
+    if output_format == 'json':
+        import json
+        return [json.dumps(typo_to_correct_word, indent=2)]
+    elif output_format == 'yaml':
+        if _YAML_AVAILABLE:
+            import yaml
+            return [yaml.safe_dump(dict(typo_to_correct_word), default_flow_style=False)]
+        else:
+            logging.warning("PyYAML not installed. Falling back to JSON for YAML output format.")
+            import json
+            return [json.dumps(typo_to_correct_word, indent=2)]
+
     for typo, correct_word in typo_to_correct_word.items():
         if output_format == 'arrow':
             formatted.append(f"{typo} -> {correct_word}")
@@ -776,7 +791,7 @@ def _extract_config_settings(config: MutableMapping[str, Any], quiet: bool = Fal
     output_format = config.get('output_format', 'arrow').lower()
     output_header = config.get('output_header')
 
-    valid_formats = {'arrow', 'csv', 'table', 'list'}
+    valid_formats = {'arrow', 'csv', 'table', 'list', 'json', 'yaml'}
     if output_format not in valid_formats:
         logging.warning(
             f"Unknown output format '{output_format}'. Defaulting to 'arrow'."
@@ -1045,7 +1060,7 @@ def main() -> None:
     )
     io_group.add_argument(
         '-f', '--format',
-        choices=['arrow', 'csv', 'table', 'list'],
+        choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml'],
         metavar='FMT',
         default=None,
         help="Choose an output format. If not provided, it is automatically detected from the output file extension. (default: arrow).",
@@ -1237,7 +1252,7 @@ def main() -> None:
     if args.format:
         config['output_format'] = args.format
     elif config.get('output_format') is None:
-        allowed_formats = ['arrow', 'csv', 'table', 'list']
+        allowed_formats = ['arrow', 'csv', 'table', 'list', 'json', 'yaml']
         config['output_format'] = _detect_format_from_extension(config.get('output_file'), allowed_formats, 'arrow')
     if args.substitutions:
         config['substitutions_file'] = args.substitutions

--- a/tests/test_gentypos_json_yaml_formats.py
+++ b/tests/test_gentypos_json_yaml_formats.py
@@ -1,0 +1,129 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import gentypos
+
+@pytest.fixture
+def empty_config_file(tmp_path):
+    config = tmp_path / "test_config.yaml"
+    config.write_text("{}", encoding="utf-8")
+    return str(config)
+
+def test_gentypos_json_format_stdout(capsys, empty_config_file):
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--no-filter",
+        "-f", "json"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    captured = capsys.readouterr()
+    stdout_text = captured.out
+
+    # Parse and verify the JSON
+    parsed = json.loads(stdout_text)
+    assert isinstance(parsed, dict)
+    assert len(parsed) > 0
+    # Every key is a generated typo, and its value should be 'hello'
+    for typo, correction in parsed.items():
+        assert correction == "hello"
+
+def test_gentypos_yaml_format_stdout(capsys, empty_config_file):
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--no-filter",
+        "-f", "yaml"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    captured = capsys.readouterr()
+    stdout_text = captured.out
+
+    if gentypos._YAML_AVAILABLE:
+        import yaml
+        parsed = yaml.safe_load(stdout_text)
+        assert isinstance(parsed, dict)
+        assert len(parsed) > 0
+        for typo, correction in parsed.items():
+            assert correction == "hello"
+    else:
+        # Fallback to JSON
+        parsed = json.loads(stdout_text)
+        assert isinstance(parsed, dict)
+        assert len(parsed) > 0
+
+def test_gentypos_auto_detect_json_extension(tmp_path, empty_config_file):
+    output_json = tmp_path / "typos.json"
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--no-filter",
+        "-o", str(output_json)
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    assert output_json.exists()
+    content = output_json.read_text(encoding="utf-8")
+    parsed = json.loads(content)
+    assert isinstance(parsed, dict)
+    assert len(parsed) > 0
+    for typo, correction in parsed.items():
+        assert correction == "hello"
+
+def test_gentypos_auto_detect_yaml_extension(tmp_path, empty_config_file):
+    output_yaml = tmp_path / "typos.yaml"
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--no-filter",
+        "-o", str(output_yaml)
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    assert output_yaml.exists()
+    content = output_yaml.read_text(encoding="utf-8")
+
+    if gentypos._YAML_AVAILABLE:
+        import yaml
+        parsed = yaml.safe_load(content)
+        assert isinstance(parsed, dict)
+        assert len(parsed) > 0
+        for typo, correction in parsed.items():
+            assert correction == "hello"
+    else:
+        parsed = json.loads(content)
+        assert isinstance(parsed, dict)
+
+def test_gentypos_yaml_fallback_when_yaml_unavailable(capsys):
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "--no-filter",
+        "-f", "yaml"
+    ]
+    # Patch parse_yaml_config to avoid loading YAML config, and _YAML_AVAILABLE to False to trigger fallback
+    with patch("gentypos.parse_yaml_config", return_value={}), \
+         patch("gentypos._YAML_AVAILABLE", False):
+        with patch.object(sys, 'argv', test_args):
+            gentypos.main()
+
+    captured = capsys.readouterr()
+    stdout_text = captured.out
+    # Falling back to JSON
+    parsed = json.loads(stdout_text)
+    assert isinstance(parsed, dict)
+    assert len(parsed) > 0


### PR DESCRIPTION
### What
The gentypos.py tool was enhanced to support generating typos in `json` and `yaml` formats, which can be selected via `-f`/`--format` or auto-detected from output file extensions (`.json`, `.yaml`, `.yml`). If `PyYAML` is not installed, YAML formatting gracefully falls back to JSON with a warning message. 

### Why
This feature adds significant value for interoperability, allowing the output of `gentypos.py` to be piped or imported directly into JSON/YAML parsers, configuration systems, or other mapping tools (like `multitool.py`). 

### Changes
- **gentypos.py**:
  - Added `'json'` and `'yaml'` to the valid formats list and format-detection mapping.
  - Implemented dictionary serialization in `format_typos` for JSON (using `json.dumps`) and YAML (using `yaml.safe_dump`).
  - Added `'json'` and `'yaml'` to format CLI parameter choices.
- **docs/gentypos.md**:
  - Documented `json` and `yaml` formats in options and configuration examples.
- **tests/test_gentypos_json_yaml_formats.py**:
  - Added comprehensive test suite verifying JSON/YAML formatting, extension-based auto-detection, and PyYAML missing fallback. All tests pass successfully.

---
*PR created automatically by Jules for task [17822640999805682948](https://jules.google.com/task/17822640999805682948) started by @RainRat*