### PR TITLE
[FEAT] Concurrent Command Execution with Parallel Jobs in cmdrunner

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -116,6 +116,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if "if_not_exists" in config and not isinstance(config["if_not_exists"], str):
         errors.append("'if_not_exists' must be a string.")
 
+    if "jobs" in config and (isinstance(config["jobs"], bool) or not isinstance(config["jobs"], int) or config["jobs"] < 1):
+        errors.append("'jobs' must be an integer of 1 or more.")
+
     if errors:
         raise ConfigError(" ".join(errors))
 
@@ -133,6 +136,7 @@ def run_command_in_folders(
     output_format: Optional[str] = None,
     if_exists: Optional[str] = None,
     if_not_exists: Optional[str] = None,
+    jobs: int = 1,
 ) -> None:
     """
     Run a specified command in each folder within the main folder,
@@ -161,26 +165,22 @@ def run_command_in_folders(
             if not os.path.exists(os.path.join(main_folder, item, if_not_exists))
         ]
 
-    iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
-
     report_data = []
 
-    # Iterate through each item in the main folder
-    for item in iterator:
+    def run_single_folder(item: str) -> Dict[str, Any]:
         item_path = os.path.join(main_folder, item)
         current_command = command.replace("{}", shlex.quote(item))
 
         if dry_run:
             logging.warning(f"Dry run: would run command '{current_command}' in '{item}'")
-            report_data.append({
+            return {
                 "folder": item,
                 "command": current_command,
                 "status": "dry-run",
                 "return_code": 0,
                 "stdout": "",
                 "stderr": "",
-            })
-            continue
+            }
 
         logging.info(f"Running command in: {item}")
 
@@ -197,38 +197,73 @@ def run_command_in_folders(
                 timeout=timeout,
             )
             logging.info(f"Command output for '{item}':\n{result.stdout}")
-            report_data.append({
+            return {
                 "folder": item,
                 "command": current_command,
                 "status": "success",
                 "return_code": 0,
                 "stdout": result.stdout,
                 "stderr": result.stderr,
-            })
+            }
         except subprocess.TimeoutExpired as e:
             logging.error(f"The command in '{item}' timed out after {timeout} seconds.")
-            report_data.append({
+            return {
                 "folder": item,
                 "command": current_command,
                 "status": "timeout",
                 "return_code": -1,
                 "stdout": e.stdout.decode() if isinstance(e.stdout, bytes) else (e.stdout or ""),
                 "stderr": e.stderr.decode() if isinstance(e.stderr, bytes) else (e.stderr or ""),
-            })
-            if fail_fast:
-                sys.exit(1)
+            }
         except subprocess.CalledProcessError as e:
             logging.error(f"The command failed in '{item}':\n{e.stderr}")
-            report_data.append({
+            return {
                 "folder": item,
                 "command": current_command,
                 "status": "failed",
                 "return_code": e.returncode,
                 "stdout": e.stdout or "",
                 "stderr": e.stderr or "",
-            })
-            if fail_fast:
+            }
+
+    if jobs > 1 and not dry_run:
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as executor:
+            future_to_item = {
+                executor.submit(run_single_folder, item): item
+                for item in directories
+            }
+            # Progress bar tracking
+            for future in tqdm(
+                concurrent.futures.as_completed(future_to_item),
+                total=len(future_to_item),
+                desc="Processing folders",
+                unit="folder",
+                disable=quiet,
+            ):
+                item = future_to_item[future]
+                try:
+                    result = future.result()
+                    report_data.append(result)
+                    if fail_fast and result["status"] in ("failed", "timeout"):
+                        # Shutdown executor immediately without waiting for other jobs
+                        executor.shutdown(wait=False, cancel_futures=True)
+                        sys.exit(1)
+                except Exception as exc:
+                    logging.error(f"An unexpected error occurred in folder '{item}': {exc}")
+                    if fail_fast:
+                        executor.shutdown(wait=False, cancel_futures=True)
+                        sys.exit(1)
+    else:
+        iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
+        for item in iterator:
+            res = run_single_folder(item)
+            report_data.append(res)
+            if fail_fast and res["status"] in ("failed", "timeout"):
                 sys.exit(1)
+
+    # Sort report_data by folder name to ensure consistent deterministic output
+    report_data.sort(key=lambda x: x["folder"])
 
     if output_file:
         # Determine the format
@@ -362,6 +397,11 @@ def parse_arguments() -> argparse.Namespace:
         type=float,
         help='The maximum execution time in seconds for the command in each folder.'
     )
+    options_group.add_argument(
+        '-j', '--jobs',
+        type=int,
+        help='Run commands concurrently using this many jobs.'
+    )
 
     # Output Options Group
     output_group = parser.add_argument_group(f"{BLUE}OUTPUT OPTIONS{RESET}")
@@ -423,6 +463,7 @@ def main() -> None:
     timeout = args.timeout if args.timeout is not None else config.get('timeout', None)
     if_exists = args.if_exists or config.get('if_exists', None)
     if_not_exists = args.if_not_exists or config.get('if_not_exists', None)
+    jobs = args.jobs if args.jobs is not None else config.get('jobs', 1)
 
     # Validate that required options are present
     errors = []
@@ -448,6 +489,7 @@ def main() -> None:
         output_format=args.format,
         if_exists=if_exists,
         if_not_exists=if_not_exists,
+        jobs=jobs,
     )
 
 if __name__ == "__main__":

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -58,6 +58,9 @@ if_exists: "package.json"
 
 # (Optional) Only run the command in folders that do NOT contain this specific file or path
 if_not_exists: "initialized.log"
+
+# (Optional) Run commands concurrently using this many jobs
+jobs: 4
 ```
 
 ## Options
@@ -73,6 +76,7 @@ if_not_exists: "initialized.log"
 - `--timeout`: The maximum execution time in seconds for the command in each folder. Overrides config file if provided.
 - `--if-exists`: Only run the command in folders that contain this specific file or path (e.g., `package.json` or `requirements.txt`). Overrides config file if provided.
 - `--if-not-exists`: Only run the command in folders that do NOT contain this specific file or path (e.g., `initialized.log`). Overrides config file if provided.
+- `-j`, `--jobs`: Run commands concurrently using this many jobs. Overrides config file if provided.
 - `-o`, `--output`: Where to save the execution report. If not provided, no report is saved.
 - `-f`, `--format`: Choose the format for the output report (`json`, `csv`, `txt`). If not provided, it is automatically detected from the output file extension.
 

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -1050,3 +1050,128 @@ def test_main_with_if_not_exists_config(tmp_path, monkeypatch):
 
     assert (proj1 / 'out_conf.txt').exists()
     assert not (proj2 / 'out_conf.txt').exists()
+
+
+def test_load_config_invalid_jobs(tmp_path):
+    config_file = tmp_path / 'config_invalid_jobs.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'jobs': 'not-an-int',
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'jobs' must be an integer of 1 or more." in exc_info.value.args[0]
+
+
+def test_load_config_jobs_bool(tmp_path):
+    config_file = tmp_path / 'config_invalid_jobs_bool.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'jobs': True,
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'jobs' must be an integer of 1 or more." in exc_info.value.args[0]
+
+
+def test_load_config_jobs_less_than_1(tmp_path):
+    config_file = tmp_path / 'config_invalid_jobs_zero.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'jobs': 0,
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'jobs' must be an integer of 1 or more." in exc_info.value.args[0]
+
+
+def test_run_command_parallel_success(tmp_path):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+    (base_dir / 'proj1').mkdir()
+    (base_dir / 'proj2').mkdir()
+
+    command = "python3 -c \"open('test_parallel.txt','w').write('parallel')\""
+
+    cmdrunner.run_command_in_folders(str(base_dir), command, jobs=3)
+
+    for name in ['proj1', 'proj2']:
+        test_file = base_dir / name / 'test_parallel.txt'
+        assert test_file.exists()
+        assert test_file.read_text() == 'parallel'
+
+
+def test_run_command_parallel_fail_fast(tmp_path):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+    (base_dir / 'proj1').mkdir()
+    (base_dir / 'proj2').mkdir()
+
+    command = "python3 -c 'import sys; sys.exit(1)'"
+
+    with pytest.raises(SystemExit) as excinfo:
+        cmdrunner.run_command_in_folders(str(base_dir), command, fail_fast=True, jobs=2)
+    assert excinfo.value.code == 1
+
+
+def test_main_parallel_cli_override(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+    (base_dir / 'proj1').mkdir()
+
+    command = "python3 -c \"open('cli_parallel.txt','w').write('cli')\""
+
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['cmdrunner.py', '-m', str(base_dir), '-c', command, '-j', '2']
+    )
+
+    cmdrunner.main()
+
+    assert (base_dir / 'proj1' / 'cli_parallel.txt').exists()
+    assert (base_dir / 'proj1' / 'cli_parallel.txt').read_text() == 'cli'
+
+
+def test_main_parallel_config(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+    (base_dir / 'proj1').mkdir()
+
+    command = "python3 -c \"open('config_parallel.txt','w').write('config')\""
+
+    config_data = {
+        'main_folder': str(base_dir),
+        'command_to_run': command,
+        'jobs': 4,
+    }
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(config_file)])
+
+    cmdrunner.main()
+
+    assert (base_dir / 'proj1' / 'config_parallel.txt').exists()
+    assert (base_dir / 'proj1' / 'config_parallel.txt').read_text() == 'config'


### PR DESCRIPTION
Introduces a new -j/--jobs CLI option and configuration field to run commands concurrently in parallel using concurrent.futures.ThreadPoolExecutor, greatly speeding up multi-project task runners.

---
*PR created automatically by Jules for task [11573442301647376618](https://jules.google.com/task/11573442301647376618) started by @RainRat*