### PR TITLE
[UI/UX] Standardize and enrich cmdrunner feedback with a polished Execution Summary

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -1,4 +1,5 @@
 import os
+import time
 import subprocess
 import shlex
 import csv
@@ -66,6 +67,32 @@ class MinimalFormatter(logging.Formatter):
                 levelname = f"{color}{levelname}{RESET}"
 
         return f"{levelname}: {record.getMessage()}"
+
+
+def _should_enable_color(stream: Any) -> bool:
+    """Check if color should be enabled for a given stream."""
+    if os.environ.get('NO_COLOR'):
+        return False
+    if os.environ.get('FORCE_COLOR'):
+        return True
+    return hasattr(stream, 'isatty') and stream.isatty()
+
+
+def _render_visual_bar(percentage: float, max_bar: int = 20) -> str:
+    """
+    Creates a high-resolution visual bar using Unicode block characters.
+    """
+    total_blocks = (percentage * max_bar) / 100
+    full_blocks = int(total_blocks)
+    fraction = total_blocks - full_blocks
+    blocks = [" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉", "█"]
+    frac_idx = int(fraction * 8)
+
+    bar = "█" * full_blocks
+    if full_blocks < max_bar:
+        bar += blocks[frac_idx]
+        bar += " " * (max_bar - full_blocks - 1)
+    return bar
 
 
 class ConfigError(Exception):
@@ -144,9 +171,14 @@ def run_command_in_folders(
         logging.error(f"The main folder '{main_folder}' does not exist or is not a folder.")
         sys.exit(1)
 
-    directories = sorted([
+    all_subdirs = [
         item for item in os.listdir(main_folder)
-        if os.path.isdir(os.path.join(main_folder, item)) and item not in excluded_folders
+        if os.path.isdir(os.path.join(main_folder, item))
+    ]
+    total_found = len(all_subdirs)
+
+    directories = sorted([
+        item for item in all_subdirs if item not in excluded_folders
     ])
 
     if if_exists:
@@ -161,9 +193,18 @@ def run_command_in_folders(
             if not os.path.exists(os.path.join(main_folder, item, if_not_exists))
         ]
 
+    processed = len(directories)
+    skipped = total_found - processed
+
     iterator = tqdm(directories, desc="Processing folders", unit="folder", disable=dry_run or quiet)
 
     report_data = []
+
+    start_time = time.perf_counter()
+    success_count = 0
+    failed_count = 0
+    timeout_count = 0
+    dry_run_count = 0
 
     # Iterate through each item in the main folder
     for item in iterator:
@@ -180,6 +221,7 @@ def run_command_in_folders(
                 "stdout": "",
                 "stderr": "",
             })
+            dry_run_count += 1
             continue
 
         logging.info(f"Running command in: {item}")
@@ -205,6 +247,7 @@ def run_command_in_folders(
                 "stdout": result.stdout,
                 "stderr": result.stderr,
             })
+            success_count += 1
         except subprocess.TimeoutExpired as e:
             logging.error(f"The command in '{item}' timed out after {timeout} seconds.")
             report_data.append({
@@ -215,6 +258,7 @@ def run_command_in_folders(
                 "stdout": e.stdout.decode() if isinstance(e.stdout, bytes) else (e.stdout or ""),
                 "stderr": e.stderr.decode() if isinstance(e.stderr, bytes) else (e.stderr or ""),
             })
+            timeout_count += 1
             if fail_fast:
                 sys.exit(1)
         except subprocess.CalledProcessError as e:
@@ -227,8 +271,70 @@ def run_command_in_folders(
                 "stdout": e.stdout or "",
                 "stderr": e.stderr or "",
             })
+            failed_count += 1
             if fail_fast:
                 sys.exit(1)
+
+    if not quiet:
+        use_color = _should_enable_color(sys.stderr)
+        c_bold = BOLD if use_color else ""
+        c_blue = BLUE if use_color else ""
+        c_green = GREEN if use_color else ""
+        c_yellow = YELLOW if use_color else ""
+        c_red = RED if use_color else ""
+        c_cyan = "\033[1;36m" if use_color else ""
+        c_reset = RESET if use_color else ""
+
+        padding = "  "
+        label_width = 35
+        report = []
+
+        report.append(f"\n{padding}{c_bold}{c_blue}EXECUTION SUMMARY{c_reset}")
+        report.append(f"{padding}{c_bold}{c_blue}───────────────────────────────────────────────────────{c_reset}")
+
+        report.append(
+            f"  {c_bold}{c_blue}{'Total folders found:':<{label_width}}{c_reset} {c_yellow}{total_found}{c_reset}"
+        )
+        report.append(
+            f"  {c_bold}{c_blue}{'Total folders skipped:':<{label_width}}{c_reset} {c_yellow}{skipped}{c_reset}"
+        )
+        report.append(
+            f"  {c_bold}{c_blue}{'Total folders processed:':<{label_width}}{c_reset} {c_green if processed > 0 else c_yellow}{processed}{c_reset}"
+        )
+        report.append("")
+        report.append(
+            f"  {c_bold}{c_blue}{'Successes:':<{label_width}}{c_reset} {c_green}{success_count}{c_reset}"
+        )
+        report.append(
+            f"  {c_bold}{c_blue}{'Failures:':<{label_width}}{c_reset} {c_red if failed_count > 0 else c_reset}{failed_count}{c_reset}"
+        )
+        report.append(
+            f"  {c_bold}{c_blue}{'Timeouts:':<{label_width}}{c_reset} {c_red if timeout_count > 0 else c_reset}{timeout_count}{c_reset}"
+        )
+
+        if dry_run_count > 0:
+            report.append(
+                f"  {c_bold}{c_blue}{'Dry run commands:':<{label_width}}{c_reset} {c_yellow}{dry_run_count}{c_reset}"
+            )
+
+        if processed > 0 and not dry_run:
+            success_rate = (success_count / processed) * 100
+            max_bar = 20
+            bar = _render_visual_bar(success_rate, max_bar)
+            c_rate = c_green if success_rate == 100 else (c_yellow if success_rate >= 50 else c_red)
+
+            report.append("")
+            report.append(
+                f"  {c_bold}{c_blue}{'Success rate:':<{label_width}}{c_reset} {c_rate}{success_rate:>5.1f}%{c_reset} {c_cyan}{bar}{c_reset}"
+            )
+
+        duration = time.perf_counter() - start_time
+        report.append(
+            f"  {c_bold}{c_blue}{'Execution time:':<{label_width}}{c_reset} {c_green}{duration:.3f}s{c_reset}"
+        )
+        report.append("")
+
+        sys.stderr.write("\n".join(report) + "\n")
 
     if output_file:
         # Determine the format

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -1050,3 +1050,94 @@ def test_main_with_if_not_exists_config(tmp_path, monkeypatch):
 
     assert (proj1 / 'out_conf.txt').exists()
     assert not (proj2 / 'out_conf.txt').exists()
+
+
+def test_should_enable_color_env_overrides():
+    with patch.dict(os.environ, {"NO_COLOR": "1"}):
+        assert not cmdrunner._should_enable_color(sys.stderr)
+    with patch.dict(os.environ, {"FORCE_COLOR": "1"}, clear=True):
+        assert cmdrunner._should_enable_color(sys.stderr)
+
+
+def test_render_visual_bar_calculations():
+    bar_100 = cmdrunner._render_visual_bar(100.0, 10)
+    assert bar_100 == "█" * 10
+    bar_0 = cmdrunner._render_visual_bar(0.0, 10)
+    assert bar_0 == " " * 10
+    bar_50 = cmdrunner._render_visual_bar(50.0, 10)
+    assert bar_50 == "█" * 5 + " " * 5
+
+
+def test_run_command_execution_summary_stdout_stderr(tmp_path, capsys):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+    (base_dir / 'proj1').mkdir()
+    (base_dir / 'proj2').mkdir()
+    (base_dir / 'proj3').mkdir()
+
+    (base_dir / 'proj1' / 'package.json').write_text('{}')
+    (base_dir / 'proj2' / 'package.json').write_text('{}')
+
+    command = "python3 -c \"import os; import sys; sys.exit(1 if 'proj2' in os.getcwd() else 0)\""
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        command,
+        if_exists='package.json'
+    )
+
+    captured = capsys.readouterr()
+    err_output = captured.err
+
+    assert "EXECUTION SUMMARY" in err_output
+    assert "Total folders found:                3" in err_output
+    assert "Total folders skipped:              1" in err_output
+    assert "Total folders processed:            2" in err_output
+    assert "Successes:                          1" in err_output
+    assert "Failures:                           1" in err_output
+    assert "Success rate:                        50.0%" in err_output
+
+
+def test_run_command_execution_summary_dry_run(tmp_path, capsys):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+    (base_dir / 'proj1').mkdir()
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        "echo 1",
+        dry_run=True
+    )
+
+    captured = capsys.readouterr()
+    err_output = captured.err
+    assert "Dry run commands:                   1" in err_output
+    assert "Success rate:" not in err_output
+
+
+def test_run_command_execution_summary_rates(tmp_path, capsys):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+    (base_dir / 'proj1').mkdir()
+
+    cmdrunner.run_command_in_folders(str(base_dir), "echo 1")
+    captured = capsys.readouterr()
+    assert "Success rate:                       100.0%" in captured.err
+
+    cmdrunner.run_command_in_folders(str(base_dir), "python3 -c 'import sys; sys.exit(1)'")
+    captured = capsys.readouterr()
+    assert "Success rate:                         0.0%" in captured.err
+
+
+def test_run_command_execution_summary_timeouts(tmp_path, capsys):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+    (base_dir / 'proj1').mkdir()
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        "python3 -c 'import time; time.sleep(5)'",
+        timeout=0.1
+    )
+    captured = capsys.readouterr()
+    assert "Timeouts:                           1" in captured.err


### PR DESCRIPTION
Add a polished EXECUTION SUMMARY block at the end of cmdrunner.py runs (when quiet is False) displaying total folders found, skipped, and processed, alongside successes, failures, timeouts, dry-runs, total execution time, and a high-resolution success rate visual bar. It brings superb UI/UX feedback and consistency matching multitool.py, diff2typo.py, and typostats.py.

---
*PR created automatically by Jules for task [11804309193490675](https://jules.google.com/task/11804309193490675) started by @RainRat*