### PR TITLE
[FEAT] Add --dry-run option to gentypos.py

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -46,6 +46,7 @@ python gentypos.py --input "data/*.txt" --output typos.txt
 | `--all`, `-A` | Off | Generate all typo types (deletions, transpositions, replacements, and duplications). |
 | `--config`, `-c` | `gentypos.yaml` | The path to your YAML configuration file. |
 | `--deletion` | Off | Generate deletions (skipping a letter, e.g., 'word' becomes 'wrd'). |
+| `--dry-run` | Off | Show configuration details and a sample preview of typo generation without writing files. |
 | `--dictionary`, `-d` | None | The path to a large dictionary file used to filter out real words. |
 | `--duplication` | Off | Generate duplications (typing a letter twice, e.g., 'word' becomes 'woord'). |
 | `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), or `list` (typo). By default, it is automatically detected from the output file extension. |

--- a/gentypos.py
+++ b/gentypos.py
@@ -1153,6 +1153,11 @@ def main() -> None:
         help="Do not check typos against the large dictionary (this is faster).",
     )
     gen_group.add_argument(
+        '--dry-run',
+        action='store_true',
+        help="Show configuration details and a sample preview of typo generation without writing files.",
+    )
+    gen_group.add_argument(
         '-v', '--verbose',
         action='store_true',
         help="Show more detailed log messages.",
@@ -1330,6 +1335,61 @@ def main() -> None:
             )
 
     adjacent_keys, custom_subs = _setup_generation_tools(settings)
+
+    if args.dry_run:
+        logging.info(f"{BOLD}{BLUE}--- GENTYPOS DRY RUN ---{RESET}")
+        input_desc = settings.input_files if not cli_words else f"CLI Words: {cli_words}"
+        logging.info(f"Input: {input_desc}")
+        logging.info(f"Output File: {settings.output_file} (Format: {settings.output_format})")
+        logging.info(f"Min Word Length: {settings.min_length} | Max Word Length: {settings.max_length}")
+        logging.info(f"Repeat Modifications: {settings.repeat_modifications}")
+        enabled_types = [t for t, enabled in settings.typo_types.items() if enabled]
+        logging.info(f"Enabled Typo Types: {', '.join(enabled_types)}")
+        logging.info(f"Large Dictionary: {settings.dictionary_file or 'None'}")
+
+        # Sample Preview
+        logging.info(f"\n{BOLD}{BLUE}Sample Typo Generation Preview:{RESET}")
+        sample_words = word_list[:5]
+        for word in sample_words:
+            # Generate typos just for this word
+            typos_current = {word}
+            accumulated_typos = set()
+            for _ in range(settings.repeat_modifications):
+                new_typos = set()
+                for base_word in typos_current:
+                    new_typos.update(
+                        generate_all_typos(
+                            base_word,
+                            adjacent_keys,
+                            custom_subs,
+                            settings.typo_types,
+                            settings.transposition_distance,
+                            settings.enable_adjacent_substitutions,
+                            settings.enable_custom_substitutions,
+                        )
+                    )
+                accumulated_typos.update(new_typos)
+                typos_current = new_typos
+
+            # Show a preview of up to 10 accumulated typos
+            preview_typos = sorted(list(accumulated_typos))
+            kept = []
+            filtered = []
+            for t in preview_typos:
+                if all_words and t in all_words:
+                    filtered.append(t)
+                else:
+                    kept.append(t)
+
+            logging.info(f"  {BOLD}{word}{RESET}:")
+            logging.info(f"    Generated: {', '.join(preview_typos[:10])}{'...' if len(preview_typos) > 10 else ''}")
+            if all_words:
+                logging.info(f"    Kept:      {', '.join(kept[:10])}{'...' if len(kept) > 10 else ''}")
+                logging.info(f"    Filtered:  {', '.join(filtered[:10])}{'...' if len(filtered) > 10 else ''}")
+            logging.info("")
+
+        logging.info(f"{BOLD}{GREEN}Dry run complete. No files were written.{RESET}")
+        sys.exit(0)
 
     sorted_typo_dict = _run_typo_generation(
         word_list,

--- a/tests/test_gentypos_dry_run.py
+++ b/tests/test_gentypos_dry_run.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+import sys
+import logging
+from pathlib import Path
+import pytest
+import gentypos
+
+@pytest.fixture
+def empty_config_file(tmp_path):
+    config = tmp_path / "test_config.yaml"
+    config.write_text("{}", encoding="utf-8")
+    return str(config)
+
+def test_gentypos_dry_run_cli_output(caplog, empty_config_file):
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "world",
+        "-c", empty_config_file,
+        "--dry-run"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit) as exc_info:
+            with caplog.at_level(logging.INFO):
+                gentypos.main()
+
+    assert exc_info.value.code == 0
+
+    log_text = "\n".join(record.message for record in caplog.records)
+
+    assert "--- GENTYPOS DRY RUN ---" in log_text
+    assert "CLI Words: ['hello', 'world']" in log_text
+    assert "Sample Typo Generation Preview:" in log_text
+    assert "hello" in log_text
+    assert "world" in log_text
+    assert "Dry run complete. No files were written." in log_text
+
+def test_gentypos_dry_run_does_not_write_files(tmp_path, empty_config_file):
+    out_file = tmp_path / "typos.txt"
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--dry-run",
+        "-o", str(out_file)
+    ]
+    with patch.object(sys, 'argv', test_args):
+        with pytest.raises(SystemExit) as exc_info:
+            gentypos.main()
+
+    assert exc_info.value.code == 0
+    assert not out_file.exists()


### PR DESCRIPTION
This pull request implements the `--dry-run` flag in `gentypos.py`. This new option allows users to preview configuration settings, loaded wordlists, enabled typo generation modes, custom substitutions, and view a sample typo generation preview of the first 5 words of input before actually executing full generation or writing output files.

Key changes:
- Registered `--dry-run` in the argument parser of `gentypos.py`.
- Integrated Dry Run logic to display a clear summary and exit cleanly with code 0 before modifying/creating output files.
- Added comprehensive unit tests in `tests/test_gentypos_dry_run.py` to verify functionality.
- Updated documentation in `docs/gentypos.md` to cover this option.

---
*PR created automatically by Jules for task [516924122750128570](https://jules.google.com/task/516924122750128570) started by @RainRat*