### PR TITLE
[FEAT] Add included_folders option to cmdrunner

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -104,6 +104,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if "excluded_folders" in config and not isinstance(config["excluded_folders"], list):
         errors.append("'excluded_folders' must be a list if provided.")
 
+    if "included_folders" in config and not isinstance(config["included_folders"], list):
+        errors.append("'included_folders' must be a list if provided.")
+
     if "fail_fast" in config and not isinstance(config["fail_fast"], bool):
         errors.append("'fail_fast' must be a boolean.")
 
@@ -133,6 +136,7 @@ def run_command_in_folders(
     output_format: Optional[str] = None,
     if_exists: Optional[str] = None,
     if_not_exists: Optional[str] = None,
+    included_folders: Optional[List[str]] = None,
 ) -> None:
     """
     Run a specified command in each folder within the main folder,
@@ -148,6 +152,9 @@ def run_command_in_folders(
         item for item in os.listdir(main_folder)
         if os.path.isdir(os.path.join(main_folder, item)) and item not in excluded_folders
     ])
+
+    if included_folders:
+        directories = [item for item in directories if item in included_folders]
 
     if if_exists:
         directories = [
@@ -329,6 +336,12 @@ def parse_arguments() -> argparse.Namespace:
         help='Folders you want the tool to skip. Overrides config file if provided.'
     )
     direct_group.add_argument(
+        '-i', '--included-folders',
+        dest='included_folders',
+        nargs='+',
+        help='Specific folders you want to run the command on. Overrides config file if provided.'
+    )
+    direct_group.add_argument(
         '--if-exists',
         type=str,
         help='Only run the command in folders that contain this specific file or path (e.g., package.json).'
@@ -417,6 +430,7 @@ def main() -> None:
     main_folder = args.main_folder or args.base_directory or config.get('main_folder') or config.get('base_directory', '')
     command_to_run = args.command_to_run or config.get('command_to_run', '')
     excluded = args.excluded_folders if args.excluded_folders is not None else config.get('excluded_folders', [])
+    included = args.included_folders if args.included_folders is not None else config.get('included_folders', None)
 
     # Prioritize CLI values over config file values
     fail_fast = args.fail_fast if args.fail_fast is not None else config.get('fail_fast', False)
@@ -448,6 +462,7 @@ def main() -> None:
         output_format=args.format,
         if_exists=if_exists,
         if_not_exists=if_not_exists,
+        included_folders=included,
     )
 
 if __name__ == "__main__":

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -47,6 +47,11 @@ excluded_folders:
   - ".git"
   - "venv"
 
+# (Optional) Specific folders you want to run the command on
+included_folders:
+  - "my-app-1"
+  - "my-app-2"
+
 # (Optional) Stop execution immediately if any command fails or times out
 fail_fast: false
 
@@ -67,6 +72,7 @@ if_not_exists: "initialized.log"
 - `-b`, `--base-directory`: Legacy alias for the main folder containing your projects. Overrides config file if provided.
 - `-c`, `--command-to-run`: The command to run in each folder. Overrides config file if provided.
 - `-e`, `--excluded-folders`: A space-separated list of folders to skip. Overrides config file if provided.
+- `-i`, `--included-folders`: A space-separated list of folders to run the command on. Overrides config file if provided.
 - `--dry-run`: Shows which folders would be processed and which command would run without actually doing it. Use this to test your setup safely.
 - `--quiet`: Hides status messages and progress bars.
 - `--fail-fast`: Stop execution immediately if any command fails or times out. Overrides config file if provided.
@@ -92,7 +98,7 @@ In this example, if the tool processes a folder named `my-web-app`, it will run 
 ## How it Works
 
 1. **Find Folders:** The tool looks inside your `main_folder` and finds every sub-folder.
-2. **Filter:** It removes any folders you listed in `excluded_folders`, and filters remaining folders to only those containing the specified `--if-exists` file or path (if provided) and not containing the specified `--if-not-exists` file or path (if provided).
+2. **Filter:** It removes any folders you listed in `excluded_folders`, limits to those folders specified in `included_folders` (if provided), and filters remaining folders to only those containing the specified `--if-exists` file or path (if provided) and not containing the specified `--if-not-exists` file or path (if provided).
 3. **Execute:** It enters each remaining folder and runs your `command_to_run`.
 4. **Report:** It shows you the results of each command or any errors that occurred.
 
@@ -126,4 +132,9 @@ python cmdrunner.py --main-folder /home/user/projects --command-to-run "npm run 
 **Only run commands in projects that do NOT contain a `setup.log` file:**
 ```bash
 python cmdrunner.py --main-folder /home/user/projects --command-to-run "bash setup.sh && touch setup.log" --if-not-exists setup.log
+```
+
+**Only run commands in specific folders:**
+```bash
+python cmdrunner.py --main-folder /home/user/projects --command-to-run "npm run build" --included-folders proj1 proj2
 ```

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -973,6 +973,100 @@ def test_load_config_invalid_if_not_exists(tmp_path):
     assert "'if_not_exists' must be a string." in exc_info.value.args[0]
 
 
+def test_load_config_invalid_included_folders(tmp_path):
+    config_file = tmp_path / 'config_invalid_included_folders.yaml'
+    config_file.write_text(
+        yaml.safe_dump(
+            {
+                'main_folder': str(tmp_path),
+                'command_to_run': 'echo test',
+                'included_folders': 'not-a-list',
+            }
+        )
+    )
+
+    with pytest.raises(cmdrunner.ConfigError) as exc_info:
+        cmdrunner.load_config(str(config_file))
+
+    assert "'included_folders' must be a list if provided." in exc_info.value.args[0]
+
+
+def test_run_command_included_folders_filtering(tmp_path):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    command = "python3 -c \"open('test_file.txt','w').write('ran')\""
+
+    cmdrunner.run_command_in_folders(
+        str(base_dir),
+        command,
+        included_folders=['proj1']
+    )
+
+    # Should run in proj1
+    assert (proj1 / 'test_file.txt').exists()
+    assert (proj1 / 'test_file.txt').read_text() == 'ran'
+
+    # Should NOT run in proj2
+    assert not (proj2 / 'test_file.txt').exists()
+
+
+def test_main_with_included_folders_cli_override(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    command = "python3 -c \"open('out.txt','w').write('ok')\""
+
+    # CLI override --included-folders
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['cmdrunner.py', '-m', str(base_dir), '-c', command, '--included-folders', 'proj1']
+    )
+
+    cmdrunner.main()
+
+    assert (proj1 / 'out.txt').exists()
+    assert not (proj2 / 'out.txt').exists()
+
+
+def test_main_with_included_folders_config(tmp_path, monkeypatch):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    proj1 = base_dir / 'proj1'
+    proj2 = base_dir / 'proj2'
+    proj1.mkdir()
+    proj2.mkdir()
+
+    command = "python3 -c \"open('out_conf.txt','w').write('ok')\""
+
+    config_data = {
+        'main_folder': str(base_dir),
+        'command_to_run': command,
+        'included_folders': ['proj2'],
+    }
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(config_file)])
+
+    cmdrunner.main()
+
+    assert not (proj1 / 'out_conf.txt').exists()
+    assert (proj2 / 'out_conf.txt').exists()
+
+
 def test_run_command_if_not_exists_filtering(tmp_path):
     base_dir = tmp_path / 'projects'
     base_dir.mkdir()


### PR DESCRIPTION
This pull request adds support for the `included_folders` option to `cmdrunner.py` (accessible via the configuration file or the `-i`/`--included-folders` CLI flag). This lets users target specific subdirectories to execute commands on, complementing the existing `excluded_folders` option. Testing and documentation have been updated accordingly, and all checks pass cleanly.

---
*PR created automatically by Jules for task [17878244596313822142](https://jules.google.com/task/17878244596313822142) started by @RainRat*