### PR TITLE
[DOCS] Add Bidirectional Links Between Multitool and Paths Mode Documentation

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -122,7 +122,7 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py xml data.xml -k './/item/name'`
 
 - **`paths`**
-  - Extracts path components (basename, dirname, extension) from file and directory paths. It also supports smart splitting to find words within filenames.
+  - Extracts path components (basename, dirname, extension) from file and directory paths. It also supports smart splitting to find words within filenames. For more details and examples, see the dedicated [Paths Mode Guide](paths.md).
   - **Options:** Use `--basename`, `--dirname`, or `--extension` to pick specific parts. Use `--smart` to split components into words.
   - **Example:** `python multitool.py paths src/ --basename --smart`
 

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -4,7 +4,7 @@ Extract components from file and directory paths.
 
 ## Summary
 
-The `paths` mode helps you analyze your project structure. It extracts specific parts of file and folder paths. You can use it to get the filename, the folder path, or the file extension.
+The `paths` mode is a feature of the [Multitool](multitool.md) utility. It helps you analyze your project structure by extracting specific parts of file and folder paths. You can use it to get the filename, the folder path, or the file extension.
 
 ## Usage
 


### PR DESCRIPTION
This change establishes clear, cohesive, bidirectional navigation links between the main Multitool documentation (`docs/multitool.md`) and the dedicated `paths` mode sub-documentation (`docs/paths.md`). This resolves discoverability issues and provides a seamless reading experience for users navigating the multitool documentation and details about extracting and processing file or folder path components.

---
*PR created automatically by Jules for task [7198472973470572291](https://jules.google.com/task/7198472973470572291) started by @RainRat*