### PR TITLE
Remove redundant private wrapper function _is_file_excluded in diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -418,10 +418,6 @@ def _match_pattern(filepath: str, patterns: Optional[List[str]]) -> bool:
     return False
 
 
-def _is_file_excluded(filepath: str, patterns: Optional[List[str]]) -> bool:
-    return _match_pattern(filepath, patterns)
-
-
 def _is_file_included(filepath: str, patterns: Optional[List[str]]) -> bool:
     if not patterns:
         return True
@@ -476,7 +472,7 @@ def find_typos(
                 if current_file.startswith('"') and current_file.endswith('"'):
                     current_file = current_file[1:-1]
             if current_file:
-                if _is_file_excluded(current_file, exclude_patterns) or not _is_file_included(current_file, include_patterns):
+                if _match_pattern(current_file, exclude_patterns) or not _is_file_included(current_file, include_patterns):
                     skip_current_file = True
             continue
 
@@ -492,7 +488,7 @@ def find_typos(
             if path.startswith('"') and path.endswith('"'):
                 path = path[1:-1]
             additions.append(path)
-            if not (skip_current_file or _is_file_excluded(path, exclude_patterns) or not _is_file_included(path, include_patterns)):
+            if not (skip_current_file or _match_pattern(path, exclude_patterns) or not _is_file_included(path, include_patterns)):
                 typos.extend(process_diff_block(removals, additions, min_length, max_dist))
             removals = []
             additions = []
@@ -509,7 +505,7 @@ def find_typos(
                     typos.extend(process_diff_block(removals, additions, min_length, max_dist))
                 removals = []
                 additions = []
-                skip_current_file = _is_file_excluded(current_file, exclude_patterns) or not _is_file_included(current_file, include_patterns)
+                skip_current_file = _match_pattern(current_file, exclude_patterns) or not _is_file_included(current_file, include_patterns)
             continue
 
         if skip_current_file:

--- a/tests/test_diff2typo_exclude.py
+++ b/tests/test_diff2typo_exclude.py
@@ -1,15 +1,15 @@
 import pytest
-from diff2typo import _is_file_excluded, find_typos, main
+from diff2typo import _match_pattern, find_typos, main
 from unittest.mock import patch, MagicMock
 
-def test_is_file_excluded():
-    assert _is_file_excluded("tests/test_math.py", ["*.py"])
-    assert _is_file_excluded("config.json", ["*.json"])
-    assert _is_file_excluded("src/lib.py", ["src/*"])
-    assert _is_file_excluded("package-lock.json", ["package-lock.json"])
-    assert not _is_file_excluded("src/lib.py", ["*.json"])
-    assert not _is_file_excluded("src/lib.py", None)
-    assert not _is_file_excluded("", ["*.py"])
+def test_match_pattern():
+    assert _match_pattern("tests/test_math.py", ["*.py"])
+    assert _match_pattern("config.json", ["*.json"])
+    assert _match_pattern("src/lib.py", ["src/*"])
+    assert _match_pattern("package-lock.json", ["package-lock.json"])
+    assert not _match_pattern("src/lib.py", ["*.json"])
+    assert not _match_pattern("src/lib.py", None)
+    assert not _match_pattern("", ["*.py"])
 
 
 def test_find_typos_exclusion():


### PR DESCRIPTION
### PR Title: Remove redundant private wrapper function `_is_file_excluded` in `diff2typo.py`

**Description:**
* **What:** The redundant private wrapper function `_is_file_excluded` has been removed from `diff2typo.py`. All internal call sites within the file have been updated to call `_match_pattern` directly. Associated unit tests in `tests/test_diff2typo_exclude.py` have been refactored to test `_match_pattern` directly instead.
* **Why:** This refactoring resolves a **Redundant Wrapper** issue (Category 1) that added unnecessary complexity to the module without serving any functional purpose. No breaking changes or external behavior modifications were introduced, and all 1,258 tests in the suite continue to pass successfully.

---
*PR created automatically by Jules for task [12345026161002339967](https://jules.google.com/task/12345026161002339967) started by @RainRat*