### PR TITLE
[UI/UX] Improve cmdrunner feedback when zero folders processed

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -421,6 +421,12 @@ def run_command_in_folders(
         skipped_count = len([item for item in all_items if os.path.isdir(os.path.join(main_folder, item)) and item in excluded_folders])
         processed_count = len(directories)
 
+        if processed_count == 0:
+            if total_found == 0:
+                logging.warning(f"No subdirectories found in main folder '{main_folder}'.")
+            else:
+                logging.warning("No subdirectories matched the specified inclusion, exclusion, or existence criteria.")
+
         success_count = len([r for r in report_data if r["status"] == "success"])
         failed_count = len([r for r in report_data if r["status"] == "failed"])
         timeout_count = len([r for r in report_data if r["status"] == "timeout"])

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -1330,3 +1330,38 @@ def test_execution_summary_no_color(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "EXECUTION SUMMARY" in captured.err
     assert "\033[" not in captured.err
+
+
+def test_zero_processed_empty_directory(tmp_path, capsys, caplog):
+    base_dir = tmp_path / 'empty_projects'
+    base_dir.mkdir()
+
+    with caplog.at_level(logging.WARNING):
+        cmdrunner.run_command_in_folders(
+            main_folder=str(base_dir),
+            command="echo hello",
+            quiet=False
+        )
+
+    captured = capsys.readouterr()
+    assert any(f"No subdirectories found in main folder '{base_dir}'." in message for message in caplog.messages)
+    assert "Folders processed:                  0" in captured.err
+
+
+def test_zero_processed_filtered_out(tmp_path, capsys, caplog):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+    proj1 = base_dir / 'proj1'
+    proj1.mkdir()
+
+    with caplog.at_level(logging.WARNING):
+        cmdrunner.run_command_in_folders(
+            main_folder=str(base_dir),
+            command="echo hello",
+            if_exists="non_existent.txt",
+            quiet=False
+        )
+
+    captured = capsys.readouterr()
+    assert any("No subdirectories matched the specified inclusion, exclusion, or existence criteria." in message for message in caplog.messages)
+    assert "Folders processed:                  0" in captured.err


### PR DESCRIPTION
### Context
CLI (`cmdrunner.py`)

### Problem
When running `cmdrunner.py` with filters (`--if-exists`, `--if-not-exists`, `-i`/`--included-folders`, `-e`/`--excluded-folders`) that exclude all subdirectories, or when targeting a directory with no subdirectories, `cmdrunner.py` silently processes 0 folders without explaining why no commands were executed.

### Solution
Log a context-aware warning when zero subdirectories are processed, distinguishing between empty main directories and directories filtered out by filtering criteria. Add unit test coverage in `tests/test_cmdrunner.py`.

---
*PR created automatically by Jules for task [8864629591990033437](https://jules.google.com/task/8864629591990033437) started by @RainRat*