### PR TITLE
[DOCS] Document pairs option for multitool todo mode

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -103,7 +103,8 @@ Use these modes to pull specific data from a file.
 
 - **`todo`**
   - Extracts TODO, FIXME, XXX, BUG, and HACK items from source files. It identifies the text following these markers and cleans up common comment endings.
-  - **Example:** `python multitool.py todo src/ --output tasks.txt`
+  - **Options:** Use the `--pairs` (or `-p`) flag to generate structured paired output showing the file location (`filename:line`), extracted message, and marker category (e.g., TODO, FIXME, BUG) with color highlighting.
+  - **Example:** `python multitool.py todo src/ --pairs --output tasks.txt`
 
 - **`json`**
   - Extracts values from a JSON file by key. Use dot notation for nested keys (for example, `user.name`). If you do not provide a key, it extracts items from the top level. It automatically handles lists and objects.


### PR DESCRIPTION
This PR updates `docs/multitool.md` to document the `-p`/`--pairs` CLI flag for `multitool.py` in `todo` mode.

### Changes
- Updated the `todo` mode documentation in `docs/multitool.md`.
- Added explanation for the `-p` / `--pairs` flag (outputs location, extracted message, and marker type with ANSI color highlighting).
- Updated the command example to show `--pairs` usage.

---
*PR created automatically by Jules for task [9849594124074254765](https://jules.google.com/task/9849594124074254765) started by @RainRat*