### PR TITLE
[FEAT] Add JSON and YAML output formats to diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -28,6 +28,8 @@ Output Formats:
     - csv: typo,correction
     - table: typo = "correction"
     - list: typo
+    - json: JSON object
+    - yaml: YAML object
 '''
 
 import argparse
@@ -36,6 +38,7 @@ import contextlib
 import csv
 import fnmatch
 import glob
+import json
 import logging
 import os
 import re
@@ -46,6 +49,12 @@ import sys
 import tempfile
 import time
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, TextIO
+
+try:
+    import yaml
+    _YAML_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dependency
+    _YAML_AVAILABLE = False
 
 try:
     from tqdm import tqdm
@@ -549,15 +558,38 @@ def format_typos(typos: Iterable[str], output_format: str) -> List[str]:
 
     Args:
         typos (list): List of typo strings in the format "before -> after".
-        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list').
+        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list', 'json', 'yaml').
 
     Returns:
         list: Formatted list of typo strings.
     """
+    if output_format == 'json':
+        mapping = {}
+        for typo in typos:
+            if ' -> ' in typo:
+                before, after = typo.split(' -> ', 1)
+                mapping[before] = after
+            else:
+                mapping[filter_to_letters(typo)] = ""
+        return [json.dumps(mapping, indent=2)]
+    elif output_format == 'yaml':
+        mapping = {}
+        for typo in typos:
+            if ' -> ' in typo:
+                before, after = typo.split(' -> ', 1)
+                mapping[before] = after
+            else:
+                mapping[filter_to_letters(typo)] = ""
+        if _YAML_AVAILABLE:
+            return [yaml.safe_dump(mapping, default_flow_style=False)]
+        else:
+            logging.warning("PyYAML not installed. Falling back to JSON for YAML output format.")
+            return [json.dumps(mapping, indent=2)]
+
     formatted: List[str] = []
     for typo in typos:
         if ' -> ' in typo:
-            before, after = typo.split(' -> ')
+            before, after = typo.split(' -> ', 1)
             if output_format == 'csv':
                 formatted.append(f"{before},{after}")
             elif output_format == 'table':
@@ -906,12 +938,12 @@ def main():
         '-f',
         dest='output_format',
         type=str,
-        choices=['arrow', 'csv', 'table', 'list'],
+        choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml'],
         default=None,
-        help='Format of the output typos. If not provided, it is automatically detected from the output file extension. Choices are: arrow (typo -> correction), csv (typo,correction), table (typo = "correction"), list (typo). Default is arrow.',
+        help='Format of the output typos. If not provided, it is automatically detected from the output file extension. Choices are: arrow (typo -> correction), csv (typo,correction), table (typo = "correction"), list (typo), json, yaml. Default is arrow.',
     )
     # Hidden alias for backward compatibility
-    parser.add_argument('--output_format', type=str, choices=['arrow', 'csv', 'table', 'list'], help=argparse.SUPPRESS, default=argparse.SUPPRESS)
+    parser.add_argument('--output_format', type=str, choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml'], help=argparse.SUPPRESS, default=argparse.SUPPRESS)
 
     # Analysis Options
     analysis_group = parser.add_argument_group(f"{BLUE}ANALYSIS OPTIONS{RESET}")
@@ -1021,7 +1053,7 @@ def main():
     # Resolve output format if not provided
     if args.output_format is None:
         default_fmt = 'arrow'
-        allowed_formats = ['arrow', 'csv', 'table', 'list']
+        allowed_formats = ['arrow', 'csv', 'table', 'list', 'json', 'yaml']
         if args.output_file and args.output_file != '-':
             ext = os.path.splitext(args.output_file)[1].lower().lstrip('.')
             mapping = {
@@ -1031,6 +1063,9 @@ def main():
                 'toml': 'table',
                 'list': 'list',
                 'arrow': 'arrow',
+                'json': 'json',
+                'yaml': 'yaml',
+                'yml': 'yaml',
             }
             detected = mapping.get(ext)
             args.output_format = detected if detected in allowed_formats else default_fmt
@@ -1170,15 +1205,58 @@ def main():
         typos_final = sort_and_limit(typos_list)
         corrections_final = sort_and_limit(corrections_list)
 
-        if typos_final:
-            final_output.append("=== Typos ===")
-            final_output.extend(format_typos(typos_final, args.output_format))
-            final_output.append("")  # Blank line for separation.
+        if args.output_format == 'json':
+            typo_map = {}
+            for item in typos_final:
+                if ' -> ' in item:
+                    b, a = item.split(' -> ', 1)
+                    typo_map[b] = a
+                else:
+                    typo_map[filter_to_letters(item)] = ""
+            corr_map = {}
+            for item in corrections_final:
+                if ' -> ' in item:
+                    b, a = item.split(' -> ', 1)
+                    corr_map[b] = a
+                else:
+                    corr_map[filter_to_letters(item)] = ""
+            data = {"typos": typo_map, "corrections": corr_map}
+            final_output = [json.dumps(data, indent=2)]
             filtered_items.extend(typos_final)
-        if corrections_final:
-            final_output.append("=== Corrections ===")
-            final_output.extend(format_typos(corrections_final, args.output_format))
             filtered_items.extend(corrections_final)
+        elif args.output_format == 'yaml':
+            typo_map = {}
+            for item in typos_final:
+                if ' -> ' in item:
+                    b, a = item.split(' -> ', 1)
+                    typo_map[b] = a
+                else:
+                    typo_map[filter_to_letters(item)] = ""
+            corr_map = {}
+            for item in corrections_final:
+                if ' -> ' in item:
+                    b, a = item.split(' -> ', 1)
+                    corr_map[b] = a
+                else:
+                    corr_map[filter_to_letters(item)] = ""
+            data = {"typos": typo_map, "corrections": corr_map}
+            if _YAML_AVAILABLE:
+                final_output = [yaml.safe_dump(data, default_flow_style=False)]
+            else:
+                logging.warning("PyYAML not installed. Falling back to JSON for YAML output format.")
+                final_output = [json.dumps(data, indent=2)]
+            filtered_items.extend(typos_final)
+            filtered_items.extend(corrections_final)
+        else:
+            if typos_final:
+                final_output.append("=== Typos ===")
+                final_output.extend(format_typos(typos_final, args.output_format))
+                final_output.append("")  # Blank line for separation.
+                filtered_items.extend(typos_final)
+            if corrections_final:
+                final_output.append("=== Corrections ===")
+                final_output.extend(format_typos(corrections_final, args.output_format))
+                filtered_items.extend(corrections_final)
     else:
         results_list = []
         if args.mode == 'typos':

--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -54,7 +54,7 @@ If you run the tool without specifying any input files or piping any changes, it
 | `--git`, `-g` | None | Fetch diff directly from Git. Optional arguments are passed to `git diff` (for example, `-g "HEAD~3"`). |
 | `--git-log`, `-l` | None | Fetch commit history diffs directly from Git. Optional arguments are passed to `git log` (for example, `-l "HEAD~3"`). |
 | `--output`, `-o` | the screen | Path to the output file. Use `-` to print to the screen. |
-| `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), or `list` (typo only). |
+| `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), `list` (typo only), `json`, or `yaml`. Auto-detected from `.json`, `.yaml`, or `.yml` file extensions. |
 | `--mode`, `-M` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
 | `--exclude`, `-e` | None | One or more file patterns (e.g., `*.json`, `tests/*`) to exclude from typo scanning. |
 | `--include`, `-I` | None | One or more file patterns (e.g., `*.md`, `src/*`) to include in typo scanning (all files are scanned by default). |

--- a/tests/test_diff2typo_json_yaml.py
+++ b/tests/test_diff2typo_json_yaml.py
@@ -1,0 +1,173 @@
+import json
+import pytest
+import diff2typo
+
+
+def test_format_typos_json():
+    typos = ["teh -> the", "wrod -> word"]
+    res = diff2typo.format_typos(typos, "json")
+    parsed = json.loads(res[0])
+    assert parsed == {"teh": "the", "wrod": "word"}
+
+
+def test_format_typos_yaml():
+    typos = ["teh -> the", "wrod -> word"]
+    res = diff2typo.format_typos(typos, "yaml")
+    if diff2typo._YAML_AVAILABLE:
+        import yaml
+        parsed = yaml.safe_load(res[0])
+        assert parsed == {"teh": "the", "wrod": "word"}
+    else:
+        parsed = json.loads(res[0])
+        assert parsed == {"teh": "the", "wrod": "word"}
+
+
+def test_format_typos_json_single_word():
+    typos = ["typoonly"]
+    res = diff2typo.format_typos(typos, "json")
+    parsed = json.loads(res[0])
+    assert parsed == {"typoonly": ""}
+
+
+def test_format_typos_yaml_no_pyyaml(monkeypatch):
+    monkeypatch.setattr(diff2typo, "_YAML_AVAILABLE", False)
+    typos = ["teh -> the"]
+    res = diff2typo.format_typos(typos, "yaml")
+    parsed = json.loads(res[0])
+    assert parsed == {"teh": "the"}
+
+
+def test_main_json_and_yaml_modes(tmp_path, monkeypatch):
+    diff_content = (
+        "diff --git a/file.txt b/file.txt\n"
+        "--- a/file.txt\n"
+        "+++ b/file.txt\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-teh house\n"
+        "+the house\n"
+    )
+    diff_file = tmp_path / "test.diff"
+    diff_file.write_text(diff_content, encoding="utf-8")
+
+    json_out = tmp_path / "out.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "diff2typo.py",
+            str(diff_file),
+            "--output",
+            str(json_out),
+            "--mode",
+            "typos",
+            "-q",
+        ],
+    )
+    diff2typo.main()
+
+    data = json.loads(json_out.read_text(encoding="utf-8"))
+    assert data == {"teh": "the"}
+
+
+def test_main_both_mode_json(tmp_path, monkeypatch):
+    diff_content = (
+        "diff --git a/file.txt b/file.txt\n"
+        "--- a/file.txt\n"
+        "+++ b/file.txt\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-teh house\n"
+        "+the house\n"
+    )
+    diff_file = tmp_path / "test.diff"
+    diff_file.write_text(diff_content, encoding="utf-8")
+
+    json_out = tmp_path / "both.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "diff2typo.py",
+            str(diff_file),
+            "--output",
+            str(json_out),
+            "--mode",
+            "both",
+            "-q",
+        ],
+    )
+    diff2typo.main()
+
+    data = json.loads(json_out.read_text(encoding="utf-8"))
+    assert "typos" in data
+    assert "corrections" in data
+    assert data["typos"] == {"teh": "the"}
+
+
+def test_main_both_mode_yaml(tmp_path, monkeypatch):
+    diff_content = (
+        "diff --git a/file.txt b/file.txt\n"
+        "--- a/file.txt\n"
+        "+++ b/file.txt\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-teh house\n"
+        "+the house\n"
+    )
+    diff_file = tmp_path / "test.diff"
+    diff_file.write_text(diff_content, encoding="utf-8")
+
+    yaml_out = tmp_path / "both.yaml"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "diff2typo.py",
+            str(diff_file),
+            "--output",
+            str(yaml_out),
+            "--mode",
+            "both",
+            "-q",
+        ],
+    )
+    diff2typo.main()
+
+    if diff2typo._YAML_AVAILABLE:
+        import yaml
+        data = yaml.safe_load(yaml_out.read_text(encoding="utf-8"))
+    else:
+        data = json.loads(yaml_out.read_text(encoding="utf-8"))
+
+    assert "typos" in data
+    assert "corrections" in data
+    assert data["typos"] == {"teh": "the"}
+
+
+def test_main_both_mode_yaml_no_pyyaml(tmp_path, monkeypatch):
+    monkeypatch.setattr(diff2typo, "_YAML_AVAILABLE", False)
+    diff_content = (
+        "diff --git a/file.txt b/file.txt\n"
+        "--- a/file.txt\n"
+        "+++ b/file.txt\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-teh house\n"
+        "+the house\n"
+    )
+    diff_file = tmp_path / "test.diff"
+    diff_file.write_text(diff_content, encoding="utf-8")
+
+    yaml_out = tmp_path / "both.yml"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "diff2typo.py",
+            str(diff_file),
+            "--output",
+            str(yaml_out),
+            "--mode",
+            "both",
+            "-q",
+        ],
+    )
+    diff2typo.main()
+
+    data = json.loads(yaml_out.read_text(encoding="utf-8"))
+    assert "typos" in data
+    assert "corrections" in data
+    assert data["typos"] == {"teh": "the"}


### PR DESCRIPTION
This change adds JSON (`-f json`) and YAML (`-f yaml`) export capabilities to `diff2typo.py`, making its output pipe-friendly and interoperable with structured data workflows and other tools in the suite (such as `gentypos.py` and `multitool.py`). Output format auto-detection is updated for `.json`, `.yaml`, and `.yml` file extensions, and `--mode both` structures the output into separate `typos` and `corrections` mapping keys. If PyYAML is missing, YAML output gracefully falls back to JSON formatting with a warning. Documentation in `docs/diff2typo.md` and CLI help text are updated, and comprehensive unit tests are added in `tests/test_diff2typo_json_yaml.py`.

---
*PR created automatically by Jules for task [9942719884520849196](https://jules.google.com/task/9942719884520849196) started by @RainRat*