### PR TITLE
[FEAT] Add TOML table format export support to typostats.py

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -55,6 +55,7 @@ The tool automatically recognizes several common ways of listing typos:
   - `csv`: Standard comma-separated values.
   - `json`: Data for other programs.
   - `yaml`: Simple list format.
+  - `table`: TOML table format (`typo = "correction"`), compatible with the `typos` tool.
 - `-o`, `--output`: Save the report to a file instead of showing it on the screen.
 - `-e`, `--exclude`: One or more file patterns (e.g., `*.json`, `tests/*`) to exclude from scanning.
 - `-q`, `--quiet`: Hide progress bars and status messages.

--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -954,3 +954,35 @@ def test_typostats_main_run_as_script(tmp_path):
     import runpy
     with patch.object(sys, 'argv', ["typostats.py", str(f1), str(f2), "--quiet"]):
         runpy.run_path("typostats.py", run_name="__main__")
+
+
+def test_generate_report_table_format(tmp_path):
+    out_file = tmp_path / "report.toml"
+    counts = {("he", "eh"): 2, ("the", "teh"): 1, ("do not", "don't"): 1}
+    typostats.generate_report(
+        counts,
+        output_file=str(out_file),
+        output_format="table",
+    )
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert 'eh = "he"' in content
+    assert 'teh = "the"' in content
+    assert '"don\'t" = "do not"' in content
+
+
+def test_detect_format_from_extension_table_and_toml():
+    allowed = ['arrow', 'yaml', 'json', 'csv', 'table']
+    assert typostats._detect_format_from_extension("output.table", allowed, "arrow") == "table"
+    assert typostats._detect_format_from_extension("output.toml", allowed, "arrow") == "table"
+
+
+def test_typostats_cli_table_format(tmp_path):
+    typo_file = tmp_path / "typos.txt"
+    typo_file.write_text("teh -> the\n")
+    out_file = tmp_path / "typos.toml"
+    with patch("sys.argv", ["typostats.py", str(typo_file), "-o", str(out_file), "-f", "table"]):
+        typostats.main()
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert 'eh = "he"' in content

--- a/typostats.py
+++ b/typostats.py
@@ -114,6 +114,8 @@ def _detect_format_from_extension(path: str, allowed: Sequence[str], default: st
         'yaml': 'yaml',
         'yml': 'yaml',
         'arrow': 'arrow',
+        'table': 'table',
+        'toml': 'table',
     }
 
     detected = mapping.get(ext)
@@ -744,7 +746,7 @@ def generate_report(
         output_file: Where to save the report. If not set, it prints to the screen.
         min_occurrences: Only include patterns that happen at least this many times.
         sort_by: How to order the results ('count', 'typo', or 'correct').
-        output_format: The style of the report ('arrow', 'yaml', 'json', or 'csv').
+        output_format: The style of the report ('arrow', 'yaml', 'json', 'csv', or 'table').
         limit: The maximum number of results to show.
         quiet: If True, hide progress bars and status messages.
         keyboard: If True, highlight mistakes caused by hitting nearby keys.
@@ -1003,6 +1005,14 @@ def generate_report(
         for (correct_char, typo_char), count in sorted_replacements:
             writer.writerow([typo_char, correct_char, count])
         report_content = output.getvalue()
+    elif output_format == 'table':
+        report_lines = []
+        for (correct_char, typo_char), count in sorted_replacements:
+            if re.match(r'^[A-Za-z0-9_-]+$', typo_char):
+                report_lines.append(f'{typo_char} = {json.dumps(correct_char)}')
+            else:
+                report_lines.append(f'{json.dumps(typo_char)} = {json.dumps(correct_char)}')
+        report_content = "\n".join(report_lines)
     else:
         # YAML-like
         # Group by correct_char
@@ -1096,7 +1106,7 @@ def main() -> None:
     io_group.add_argument(
         '-f',
         '--format',
-        choices=['arrow', 'yaml', 'json', 'csv'],
+        choices=['arrow', 'yaml', 'json', 'csv', 'table'],
         metavar='FMT',
         default=None,
         help="The format of the report. If not provided, it is automatically detected from the output file extension. (default: arrow).",
@@ -1187,7 +1197,7 @@ def main() -> None:
     sort_by = args.sort
     output_format = args.format
     if output_format is None:
-        allowed_formats = ['arrow', 'yaml', 'json', 'csv']
+        allowed_formats = ['arrow', 'yaml', 'json', 'csv', 'table']
         output_format = _detect_format_from_extension(output_file, allowed_formats, 'arrow')
     allow_1to2 = args.allow_1to2
     allow_2to1 = args.allow_2to1


### PR DESCRIPTION
Add -f table format option and extension auto-detection (.toml/.table) to typostats.py for exporting typo replacement pairs in TOML key-value format.

---
*PR created automatically by Jules for task [4270206291353877169](https://jules.google.com/task/4270206291353877169) started by @RainRat*