### PR TITLE
[UI/UX] Add -q short flag alias to --quiet option in cmdrunner.py

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -523,7 +523,7 @@ def parse_arguments() -> argparse.Namespace:
         help='Show which folders the tool will check without running any command.'
     )
     options_group.add_argument(
-        '--quiet',
+        '-q', '--quiet',
         action='store_true',
         help='Hide status messages and progress bars.'
     )

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -77,7 +77,7 @@ jobs: 4
 - `-e`, `--excluded-folders`: A list of folders you want the tool to skip. This overrides the configuration file.
 - `-i`, `--included-folders`: A list of folders you want to run the command on. This overrides the configuration file.
 - `--dry-run`: Show which folders the tool will check without running any commands. Use this to test your setup safely.
-- `--quiet`: Hide status messages and progress bars.
+- `-q`, `--quiet`: Hide status messages and progress bars.
 - `--fail-fast`: Stop running commands immediately if any command fails. This overrides the configuration file.
 - `--timeout`: Set the maximum time in seconds for the command to run in each folder. This overrides the configuration file.
 - `--if-exists`: Only run the command in folders that contain this file or path (for example, `package.json`). This overrides the configuration file.

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -291,6 +291,36 @@ def test_main_quiet_mode_suppresses_output(tmp_path, monkeypatch, capsys):
         assert result_file.read_text() == 'silent'
 
 
+def test_main_quiet_mode_short_flag(tmp_path, monkeypatch, capsys):
+    base_dir = tmp_path / 'projects'
+    base_dir.mkdir()
+
+    for name in ['proj1', 'proj2']:
+        (base_dir / name).mkdir()
+
+    command = "python3 -c \"open('integration_quiet_short.txt','w').write('silent')\""
+    config = {
+        'base_directory': str(base_dir),
+        'command_to_run': command,
+    }
+
+    config_file = tmp_path / 'config_quiet_short.yaml'
+    config_file.write_text(yaml.safe_dump(config))
+
+    monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(config_file), '-q'])
+
+    cmdrunner.main()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+    for name in ['proj1', 'proj2']:
+        result_file = base_dir / name / 'integration_quiet_short.txt'
+        assert result_file.exists()
+        assert result_file.read_text() == 'silent'
+
+
 def test_main_missing_config(monkeypatch, tmp_path):
     missing_config = tmp_path / 'missing.yaml'
     monkeypatch.setattr(sys, 'argv', ['cmdrunner.py', str(missing_config)])


### PR DESCRIPTION
**Context:** CLI
**Problem:** Users running `cmdrunner.py` had to type the full `--quiet` flag to silence progress bars and status output, whereas all other CLI tools in the repository (`diff2typo.py`, `gentypos.py`, `typostats.py`, `multitool.py`) support the standard `-q` short flag alias.
**Solution:** Added `-q` as a short flag alias to `--quiet` in `cmdrunner.py`, updated the CLI documentation in `docs/cmdrunner.md`, and added unit test coverage in `tests/test_cmdrunner.py`.

---
*PR created automatically by Jules for task [12371937222486843750](https://jules.google.com/task/12371937222486843750) started by @RainRat*