### PR TITLE
[DOCS] Clarify todo mode description in docs/multitool.md

### DIFF
--- a/docs/multitool.md
+++ b/docs/multitool.md
@@ -102,7 +102,7 @@ Use these modes to pull specific data from a file.
   - **Example:** `python multitool.py comments src/ --output comments.txt`
 
 - **`todo`**
-  - Extracts TODO, FIXME, XXX, BUG, and HACK items from source files. It identifies the text following these markers and cleans up common comment endings.
+  - Extracts action items marked by `TODO`, `FIXME`, `XXX`, `BUG`, or `HACK` from source files. It cleans up comment symbols and isolates the task text following each marker.
   - **Example:** `python multitool.py todo src/ --output tasks.txt`
 
 - **`json`**


### PR DESCRIPTION
Clarifies the description of `todo` mode in `docs/multitool.md` to highlight task markers (`TODO`, `FIXME`, `XXX`, `BUG`, `HACK`) in code blocks and simplify the explanation in plain English.

---
*PR created automatically by Jules for task [9302298762354154946](https://jules.google.com/task/9302298762354154946) started by @RainRat*