### PR TITLE
[FEAT] Add Markdown export format to typostats

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -55,6 +55,7 @@ The tool automatically recognizes several common ways of listing typos:
   - `csv`: Standard comma-separated values.
   - `json`: Data for other programs.
   - `yaml`: Simple list format.
+  - `markdown` / `md`: Markdown table format (`| Typo | Correction | Count |`).
 - `-o`, `--output`: Save the report to a file instead of showing it on the screen.
 - `-e`, `--exclude`: One or more file patterns (e.g., `*.json`, `tests/*`) to exclude from scanning.
 - `-q`, `--quiet`: Hide progress bars and status messages.

--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -137,6 +137,10 @@ def test_generate_report_formats(capsys, tmp_path):
     assert "typo,correction,count" in capsys.readouterr().out
     typostats.generate_report(counts, output_format='yaml')
     assert "  s:" in capsys.readouterr().out
+    typostats.generate_report(counts, output_format='markdown')
+    out_md = capsys.readouterr().out
+    assert "| Typo | Correction | Count |" in out_md
+    assert "| z | s | 3 |" in out_md
     out_file = tmp_path / "report.txt"
     typostats.generate_report(counts, output_file=str(out_file))
     assert "ANALYSIS SUMMARY" in out_file.read_text()
@@ -818,17 +822,31 @@ def test_should_enable_color_via_env_vars(monkeypatch):
 
 
 def test_detect_format_from_extension_resolution():
-    allowed = ["json", "csv", "yaml", "arrow"]
+    allowed = ["json", "csv", "yaml", "arrow", "markdown", "md"]
     assert typostats._detect_format_from_extension("test.json", allowed, "arrow") == "json"
     assert typostats._detect_format_from_extension("test.csv", allowed, "arrow") == "csv"
     assert typostats._detect_format_from_extension("test.yaml", allowed, "arrow") == "yaml"
     assert typostats._detect_format_from_extension("test.yml", allowed, "arrow") == "yaml"
     assert typostats._detect_format_from_extension("test.arrow", allowed, "arrow") == "arrow"
     assert typostats._detect_format_from_extension("test.txt", allowed, "arrow") == "arrow"
+    assert typostats._detect_format_from_extension("test.md", allowed, "arrow") == "markdown"
+    assert typostats._detect_format_from_extension("test.markdown", allowed, "arrow") == "markdown"
     assert typostats._detect_format_from_extension("test.unknown", allowed, "default") == "default"
     assert typostats._detect_format_from_extension("testfile", allowed, "default") == "default"
     assert typostats._detect_format_from_extension("-", allowed, "default") == "default"
     assert typostats._detect_format_from_extension("", allowed, "default") == "default"
+
+
+def test_markdown_export_cli_integration(tmp_path):
+    input_file = tmp_path / "typos.txt"
+    input_file.write_text("teh -> the\n")
+    output_md = tmp_path / "report.md"
+    with patch("sys.argv", ["typostats.py", str(input_file), "-f", "md", "-o", str(output_md)]):
+        typostats.main()
+    assert output_md.exists()
+    content = output_md.read_text()
+    assert "| Typo | Correction | Count |" in content
+    assert "| eh | he | 1 |" in content
 
 
 def test_is_one_letter_replacement_disallowed_patterns_check():

--- a/typostats.py
+++ b/typostats.py
@@ -114,6 +114,8 @@ def _detect_format_from_extension(path: str, allowed: Sequence[str], default: st
         'yaml': 'yaml',
         'yml': 'yaml',
         'arrow': 'arrow',
+        'md': 'markdown',
+        'markdown': 'markdown',
     }
 
     detected = mapping.get(ext)
@@ -744,7 +746,7 @@ def generate_report(
         output_file: Where to save the report. If not set, it prints to the screen.
         min_occurrences: Only include patterns that happen at least this many times.
         sort_by: How to order the results ('count', 'typo', or 'correct').
-        output_format: The style of the report ('arrow', 'yaml', 'json', or 'csv').
+        output_format: The style of the report ('arrow', 'yaml', 'json', 'csv', or 'markdown').
         limit: The maximum number of results to show.
         quiet: If True, hide progress bars and status messages.
         keyboard: If True, highlight mistakes caused by hitting nearby keys.
@@ -1003,6 +1005,11 @@ def generate_report(
         for (correct_char, typo_char), count in sorted_replacements:
             writer.writerow([typo_char, correct_char, count])
         report_content = output.getvalue()
+    elif output_format in ('markdown', 'md'):
+        lines = ["| Typo | Correction | Count |", "| --- | --- | --- |"]
+        for (correct_char, typo_char), count in sorted_replacements:
+            lines.append(f"| {typo_char} | {correct_char} | {count} |")
+        report_content = "\n".join(lines)
     else:
         # YAML-like
         # Group by correct_char
@@ -1096,7 +1103,7 @@ def main() -> None:
     io_group.add_argument(
         '-f',
         '--format',
-        choices=['arrow', 'yaml', 'json', 'csv'],
+        choices=['arrow', 'yaml', 'json', 'csv', 'markdown', 'md'],
         metavar='FMT',
         default=None,
         help="The format of the report. If not provided, it is automatically detected from the output file extension. (default: arrow).",
@@ -1187,7 +1194,7 @@ def main() -> None:
     sort_by = args.sort
     output_format = args.format
     if output_format is None:
-        allowed_formats = ['arrow', 'yaml', 'json', 'csv']
+        allowed_formats = ['arrow', 'yaml', 'json', 'csv', 'markdown', 'md']
         output_format = _detect_format_from_extension(output_file, allowed_formats, 'arrow')
     allow_1to2 = args.allow_1to2
     allow_2to1 = args.allow_2to1


### PR DESCRIPTION
**PR Title:** [FEAT] Add Markdown export format to typostats

**Description:**
* **What:** Added Markdown export format support (`-f markdown` or `-f md`) to `typostats.py`. The output is formatted as a Markdown table (`| Typo | Correction | Count |`). Automatic format detection from output file extensions was also updated to recognize `.md` and `.markdown` files.
* **Why:** Following Interoperability and Symmetry heuristics, `typostats.py` supported reading typo lists from Markdown tables and exporting reports to `arrow`, `csv`, `json`, `yaml`, and `table` (TOML) formats, but lacked an option to export analysis reports directly to Markdown format for inclusion in documentation, PR summaries, or GitHub/GitLab comments.

**Changes:**
Updated `typostats.py`, `docs/typostats.md`, and `tests/test_typostats.py`.

---
*PR created automatically by Jules for task [12773141295897211695](https://jules.google.com/task/12773141295897211695) started by @RainRat*