### PR TITLE
[UI/UX] Add task marker type filtering option to CLI todo mode

### DIFF
--- a/multitool.py
+++ b/multitool.py
@@ -2045,12 +2045,18 @@ def _extract_comment_items(input_file: str, quiet: bool = False) -> Iterable[str
             yield match.group(1).strip()
 
 
-def _extract_todo_items(input_file: str, quiet: bool = False) -> Iterable[str]:
+def _extract_todo_items(
+    input_file: str,
+    markers: Sequence[str] | None = None,
+    quiet: bool = False,
+) -> Iterable[str]:
     """Yields TODO and FIXME items extracted from a file."""
     lines = _read_file_lines_robust(input_file)
-    # Common TODO markers: TODO, FIXME, XXX, BUG, HACK
-    # We look for the marker followed by optional colon/whitespace and then the text.
-    todo_pattern = re.compile(r'\b(TODO|FIXME|XXX|BUG|HACK)[:\s]+(.*)', re.IGNORECASE)
+    if markers:
+        pattern_str = r'\b(' + '|'.join(re.escape(m.strip()) for m in markers if m.strip()) + r')[:\s]+(.*)'
+    else:
+        pattern_str = r'\b(TODO|FIXME|XXX|BUG|HACK)[:\s]+(.*)'
+    todo_pattern = re.compile(pattern_str, re.IGNORECASE)
 
     for line in tqdm(lines, desc=f'Processing {input_file} (todo)', unit=' lines', disable=quiet):
         match = todo_pattern.search(line)
@@ -2780,14 +2786,27 @@ def todo_mode(
     min_length: int,
     max_length: int,
     process_output: bool,
+    marker: List[str] | None = None,
     output_format: str = 'line',
     quiet: bool = False,
     clean_items: bool = True,
     limit: int | None = None,
 ) -> None:
     """Extracts TODO and FIXME items from source files."""
+    parsed_markers = None
+    if marker:
+        parsed_markers = []
+        for item in marker:
+            for m in item.split(','):
+                cleaned_m = m.strip()
+                if cleaned_m:
+                    parsed_markers.append(cleaned_m)
+
+    def extractor(f, quiet=False):
+        return _extract_todo_items(f, markers=parsed_markers, quiet=quiet)
+
     _process_items(
-        _extract_todo_items,
+        extractor,
         input_files,
         output_file,
         min_length,
@@ -7808,9 +7827,9 @@ MODE_DETAILS = {
     },
     "todo": {
         "summary": "Extracts TODO and FIXME items",
-        "description": "Finds TODO, FIXME, XXX, BUG, and HACK items in source files. It extracts the text following the marker, cleaning up common comment endings.",
-        "example": "python multitool.py todo src/ --output tasks.txt",
-        "flags": "[FILES...]",
+        "description": "Finds TODO, FIXME, XXX, BUG, and HACK items in source files. It extracts the text following the marker, cleaning up common comment endings. Use -k or --marker to filter by specific marker types (e.g. TODO, FIXME, BUG).",
+        "example": "python multitool.py todo src/ -k BUG,FIXME --output tasks.txt",
+        "flags": "[FILES...] [-k MARKER]",
     },
     "flatten": {
         "summary": "Flattens nested data structures",
@@ -8712,6 +8731,14 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawTextHelpFormatter,
         description=MODE_DETAILS['todo']['description'],
         epilog=f"{BLUE}Example:{RESET}\n  {GREEN}{MODE_DETAILS['todo']['example']}{RESET}",
+    )
+    todo_options = todo_parser.add_argument_group(f"{BLUE}TODO OPTIONS{RESET}")
+    todo_options.add_argument(
+        '-k', '--marker',
+        type=str,
+        nargs='+',
+        metavar='MARKER',
+        help="Filter items by marker type(s) (e.g. TODO, FIXME, BUG).",
     )
     _add_common_mode_arguments(todo_parser)
 
@@ -10360,6 +10387,7 @@ def main() -> None:
             todo_mode,
             {
                 **common_kwargs,
+                'marker': getattr(args, 'marker', None),
                 'output_format': output_format,
             },
         ),

--- a/tests/test_multitool_todo.py
+++ b/tests/test_multitool_todo.py
@@ -69,3 +69,50 @@ def test_todo_mode_case_insensitive(tmp_path, capsys):
 
     captured = capsys.readouterr()
     assert "lowercase todo" in captured.out
+
+def test_todo_mode_marker_filter(tmp_path, capsys):
+    import multitool
+    multitool._STDIN_CACHE = None
+
+    test_file = tmp_path / "test.py"
+    test_file.write_text("""
+# TODO: Implement this
+# FIXME: Fix this
+# BUG: Critical bug
+# HACK: Fast hack
+""", encoding="utf-8")
+
+    # Single marker via -k
+    sys.argv = ["multitool.py", "todo", str(test_file), "-k", "BUG", "--raw"]
+    main()
+
+    captured = capsys.readouterr()
+    output = captured.out.strip().split("\n")
+    assert "Critical bug" in output
+    assert "Implement this" not in output
+    assert "Fix this" not in output
+    assert "Fast hack" not in output
+
+    # Multiple comma-separated markers via --marker
+    multitool._STDIN_CACHE = None
+    sys.argv = ["multitool.py", "todo", str(test_file), "--marker", "BUG,FIXME", "--raw"]
+    main()
+
+    captured = capsys.readouterr()
+    output = captured.out.strip().split("\n")
+    assert "Critical bug" in output
+    assert "Fix this" in output
+    assert "Implement this" not in output
+    assert "Fast hack" not in output
+
+    # Multiple space-separated markers
+    multitool._STDIN_CACHE = None
+    sys.argv = ["multitool.py", "todo", str(test_file), "--marker", "TODO", "HACK", "--raw"]
+    main()
+
+    captured = capsys.readouterr()
+    output = captured.out.strip().split("\n")
+    assert "Implement this" in output
+    assert "Fast hack" in output
+    assert "Critical bug" not in output
+    assert "Fix this" not in output


### PR DESCRIPTION
**PR Title:** [UI/UX] Add task marker type filtering option to CLI todo mode

**Description:**
* **Context:** CLI (Command Line Interface)
* **Problem:** In `multitool.py todo`, the tool automatically extracts all task markers (`TODO`, `FIXME`, `XXX`, `BUG`, `HACK`). When a developer needs to inspect or extract only a specific category of tasks (such as `BUG` or `FIXME`), there was no flag to filter markers at extraction time, forcing users to pipe output to external tools or write post-processing scripts.
* **Solution:** Added a `-k` / `--marker` option to `multitool.py todo` allowing power users to filter task items by marker type directly from the command line (e.g. `python multitool.py todo src/ -k BUG,FIXME`). It supports both space-separated and comma-separated marker values while preserving backward compatibility for default extractions.

**Changes:**
Updated `multitool.py` and `tests/test_multitool_todo.py` to support and verify marker filtering in `todo` mode.

---
*PR created automatically by Jules for task [5336374827374284410](https://jules.google.com/task/5336374827374284410) started by @RainRat*