### PR TITLE
[DOCS] Update diff2typo Git example in README Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Follow these steps to find typos you have fixed recently, see your common mistak
 The tools work best when they know which words are correct. Create a file named `words.csv` and add words you use often (like project names or technical terms), one per line. This is your "large dictionary." If you skip this, the tools will still work, but they might flag some correct words as typos.
 
 ### 2. Find Your Recent Typos
-Run `diff2typo.py` to find typos you fixed in your recent Git history. For example, to check your last 5 changes and save them to a CSV file:
+Run `diff2typo.py` to find typos you fixed in your recent Git history. For example, to check your most recent commit and save the results to a CSV file:
 ```bash
-python diff2typo.py --git "HEAD~5" --output my_typos.txt --mode typos --format csv
+python diff2typo.py --git "HEAD~1" --output my_typos.txt --mode typos --format csv
 ```
 
 ### 3. See Your Patterns


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated step 2 of the Quick Start guide in README.md.
* **Why:** Clarifies checking recent commits using `--git "HEAD~1"` instead of `--git "HEAD~5"`, preventing errors on repositories or shallow clones with fewer than five commits.

---
*PR created automatically by Jules for task [2767633910654920154](https://jules.google.com/task/2767633910654920154) started by @RainRat*