### PR TITLE
[FEAT] Add JSON and YAML output format support to diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -28,6 +28,8 @@ Output Formats:
     - csv: typo,correction
     - table: typo = "correction"
     - list: typo
+    - json: JSON array of objects or dict
+    - yaml: YAML document
 '''
 
 import argparse
@@ -36,6 +38,7 @@ import contextlib
 import csv
 import fnmatch
 import glob
+import json
 import logging
 import os
 import re
@@ -46,6 +49,12 @@ import sys
 import tempfile
 import time
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, TextIO
+
+try:
+    import yaml
+    _YAML_AVAILABLE = True
+except ImportError:
+    _YAML_AVAILABLE = False
 
 try:
     from tqdm import tqdm
@@ -549,11 +558,28 @@ def format_typos(typos: Iterable[str], output_format: str) -> List[str]:
 
     Args:
         typos (list): List of typo strings in the format "before -> after".
-        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list').
+        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list', 'json', 'yaml').
 
     Returns:
         list: Formatted list of typo strings.
     """
+    if output_format in ('json', 'yaml'):
+        items = []
+        for typo in typos:
+            if ' -> ' in typo:
+                before, after = typo.split(' -> ')
+                items.append({"typo": before, "correction": after})
+            else:
+                items.append({"typo": typo, "correction": ""})
+
+        if output_format == 'yaml':
+            if _YAML_AVAILABLE:
+                return yaml.safe_dump(items, default_flow_style=False).rstrip().split('\n')
+            else:
+                logging.warning("PyYAML not installed. Falling back to JSON for YAML output format.")
+
+        return json.dumps(items, indent=2).split('\n')
+
     formatted: List[str] = []
     for typo in typos:
         if ' -> ' in typo:
@@ -906,12 +932,12 @@ def main():
         '-f',
         dest='output_format',
         type=str,
-        choices=['arrow', 'csv', 'table', 'list'],
+        choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml'],
         default=None,
-        help='Format of the output typos. If not provided, it is automatically detected from the output file extension. Choices are: arrow (typo -> correction), csv (typo,correction), table (typo = "correction"), list (typo). Default is arrow.',
+        help='Format of the output typos. If not provided, it is automatically detected from the output file extension. Choices are: arrow (typo -> correction), csv (typo,correction), table (typo = "correction"), list (typo), json, yaml. Default is arrow.',
     )
     # Hidden alias for backward compatibility
-    parser.add_argument('--output_format', type=str, choices=['arrow', 'csv', 'table', 'list'], help=argparse.SUPPRESS, default=argparse.SUPPRESS)
+    parser.add_argument('--output_format', type=str, choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml'], help=argparse.SUPPRESS, default=argparse.SUPPRESS)
 
     # Analysis Options
     analysis_group = parser.add_argument_group(f"{BLUE}ANALYSIS OPTIONS{RESET}")
@@ -1021,7 +1047,7 @@ def main():
     # Resolve output format if not provided
     if args.output_format is None:
         default_fmt = 'arrow'
-        allowed_formats = ['arrow', 'csv', 'table', 'list']
+        allowed_formats = ['arrow', 'csv', 'table', 'list', 'json', 'yaml']
         if args.output_file and args.output_file != '-':
             ext = os.path.splitext(args.output_file)[1].lower().lstrip('.')
             mapping = {
@@ -1031,6 +1057,9 @@ def main():
                 'toml': 'table',
                 'list': 'list',
                 'arrow': 'arrow',
+                'json': 'json',
+                'yaml': 'yaml',
+                'yml': 'yaml',
             }
             detected = mapping.get(ext)
             args.output_format = detected if detected in allowed_formats else default_fmt
@@ -1169,16 +1198,40 @@ def main():
     if args.mode == 'both':
         typos_final = sort_and_limit(typos_list)
         corrections_final = sort_and_limit(corrections_list)
+        filtered_items.extend(typos_final)
+        filtered_items.extend(corrections_final)
 
-        if typos_final:
-            final_output.append("=== Typos ===")
-            final_output.extend(format_typos(typos_final, args.output_format))
-            final_output.append("")  # Blank line for separation.
-            filtered_items.extend(typos_final)
-        if corrections_final:
-            final_output.append("=== Corrections ===")
-            final_output.extend(format_typos(corrections_final, args.output_format))
-            filtered_items.extend(corrections_final)
+        if args.output_format in ('json', 'yaml'):
+            def _to_dicts(items):
+                res = []
+                for typo in items:
+                    if ' -> ' in typo:
+                        b, a = typo.split(' -> ')
+                        res.append({"typo": b, "correction": a})
+                    else:
+                        res.append({"typo": typo, "correction": ""})
+                return res
+
+            data = {
+                "typos": _to_dicts(typos_final),
+                "corrections": _to_dicts(corrections_final),
+            }
+            if args.output_format == 'yaml':
+                if _YAML_AVAILABLE:
+                    final_output = yaml.safe_dump(data, default_flow_style=False).rstrip().split('\n')
+                else:
+                    logging.warning("PyYAML not installed. Falling back to JSON for YAML output format.")
+                    final_output = json.dumps(data, indent=2).split('\n')
+            else:
+                final_output = json.dumps(data, indent=2).split('\n')
+        else:
+            if typos_final:
+                final_output.append("=== Typos ===")
+                final_output.extend(format_typos(typos_final, args.output_format))
+                final_output.append("")  # Blank line for separation.
+            if corrections_final:
+                final_output.append("=== Corrections ===")
+                final_output.extend(format_typos(corrections_final, args.output_format))
     else:
         results_list = []
         if args.mode == 'typos':

--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -54,7 +54,7 @@ If you run the tool without specifying any input files or piping any changes, it
 | `--git`, `-g` | None | Fetch diff directly from Git. Optional arguments are passed to `git diff` (for example, `-g "HEAD~3"`). |
 | `--git-log`, `-l` | None | Fetch commit history diffs directly from Git. Optional arguments are passed to `git log` (for example, `-l "HEAD~3"`). |
 | `--output`, `-o` | the screen | Path to the output file. Use `-` to print to the screen. |
-| `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), or `list` (typo only). |
+| `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), `list` (typo only), `json`, or `yaml`. Automatically detected from file extension (`.json`, `.yaml`, `.yml`). |
 | `--mode`, `-M` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
 | `--exclude`, `-e` | None | One or more file patterns (e.g., `*.json`, `tests/*`) to exclude from typo scanning. |
 | `--include`, `-I` | None | One or more file patterns (e.g., `*.md`, `src/*`) to include in typo scanning (all files are scanned by default). |
@@ -98,6 +98,13 @@ python diff2typo.py --git "HEAD~5" --output recent_typos.txt
 
 ```bash
 python diff2typo.py --git-log "HEAD~5" --output recent_typos.txt
+```
+
+**Export typos as JSON or YAML:**
+
+```bash
+python diff2typo.py feature.diff --format json --output typos.json
+python diff2typo.py feature.diff --format yaml --output typos.yaml
 ```
 
 **Pipe directly from Git and save to a file:**

--- a/tests/test_diff2typo_json_yaml.py
+++ b/tests/test_diff2typo_json_yaml.py
@@ -1,0 +1,185 @@
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import diff2typo
+
+
+SAMPLE_DIFF = """diff --git a/file.txt b/file.txt
+index 123..456 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,2 @@
+-This is teh first line.
++This is the first line.
+-He had a recieve error.
++He had a receive error.
+"""
+
+
+def test_format_typos_json():
+    typos = ["teh -> the", "recieve -> receive", "lonelyword"]
+    res = diff2typo.format_typos(typos, "json")
+    output = "\n".join(res)
+    data = json.loads(output)
+    assert isinstance(data, list)
+    assert len(data) == 3
+    assert data[0] == {"typo": "teh", "correction": "the"}
+    assert data[1] == {"typo": "recieve", "correction": "receive"}
+    assert data[2] == {"typo": "lonelyword", "correction": ""}
+
+
+def test_format_typos_yaml():
+    typos = ["teh -> the", "recieve -> receive"]
+    res = diff2typo.format_typos(typos, "yaml")
+    output = "\n".join(res)
+    if diff2typo._YAML_AVAILABLE:
+        import yaml
+        data = yaml.safe_load(output)
+        assert isinstance(data, list)
+        assert data[0] == {"typo": "teh", "correction": "the"}
+        assert data[1] == {"typo": "recieve", "correction": "receive"}
+
+
+def test_format_typos_yaml_fallback(caplog):
+    typos = ["teh -> the"]
+    with patch("diff2typo._YAML_AVAILABLE", False):
+        res = diff2typo.format_typos(typos, "yaml")
+        output = "\n".join(res)
+        data = json.loads(output)
+        assert data[0] == {"typo": "teh", "correction": "the"}
+        assert "PyYAML not installed" in caplog.text
+
+
+def test_main_json_format_flag():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        diff_file = os.path.join(tmpdir, "test.diff")
+        out_file = os.path.join(tmpdir, "output.json")
+        with open(diff_file, "w", encoding="utf-8") as f:
+            f.write(SAMPLE_DIFF)
+
+        test_args = ["diff2typo.py", diff_file, "-o", out_file, "-f", "json", "-q", "-d", "nonexistent.csv"]
+        with patch("sys.argv", test_args):
+            diff2typo.main()
+
+        with open(out_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert isinstance(data, list)
+        typos = {item["typo"]: item["correction"] for item in data}
+        assert typos.get("teh") == "the"
+        assert typos.get("recieve") == "receive"
+
+
+def test_main_yaml_format_flag():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        diff_file = os.path.join(tmpdir, "test.diff")
+        out_file = os.path.join(tmpdir, "output.yaml")
+        with open(diff_file, "w", encoding="utf-8") as f:
+            f.write(SAMPLE_DIFF)
+
+        test_args = ["diff2typo.py", diff_file, "-o", out_file, "-f", "yaml", "-q", "-d", "nonexistent.csv"]
+        with patch("sys.argv", test_args):
+            diff2typo.main()
+
+        with open(out_file, "r", encoding="utf-8") as f:
+            content = f.read()
+        if diff2typo._YAML_AVAILABLE:
+            import yaml
+            data = yaml.safe_load(content)
+            assert isinstance(data, list)
+            typos = {item["typo"]: item["correction"] for item in data}
+            assert typos.get("teh") == "the"
+
+
+def test_main_auto_extension_detection_json_yaml():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        diff_file = os.path.join(tmpdir, "test.diff")
+        json_out = os.path.join(tmpdir, "out.json")
+        yaml_out = os.path.join(tmpdir, "out.yaml")
+        yml_out = os.path.join(tmpdir, "out.yml")
+        with open(diff_file, "w", encoding="utf-8") as f:
+            f.write(SAMPLE_DIFF)
+
+        test_args = ["diff2typo.py", diff_file, "-o", json_out, "-q", "-d", "nonexistent.csv"]
+        with patch("sys.argv", test_args):
+            diff2typo.main()
+
+        with open(json_out, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert isinstance(data, list)
+
+        test_args = ["diff2typo.py", diff_file, "-o", yml_out, "-q", "-d", "nonexistent.csv"]
+        with patch("sys.argv", test_args):
+            diff2typo.main()
+
+        with open(yml_out, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert content.strip()
+
+
+def test_main_both_mode_json_and_yaml():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        diff_file = os.path.join(tmpdir, "test.diff")
+        out_json = os.path.join(tmpdir, "both.json")
+        dict_file = os.path.join(tmpdir, "dict.csv")
+
+        # Large dictionary contains 'recieve' as a known typo mapping to 'receive'
+        with open(dict_file, "w", encoding="utf-8") as f:
+            f.write("recieve,receive\n")
+
+        with open(diff_file, "w", encoding="utf-8") as f:
+            f.write(SAMPLE_DIFF)
+
+        test_args = [
+            "diff2typo.py",
+            diff_file,
+            "-o",
+            out_json,
+            "-M",
+            "both",
+            "-f",
+            "json",
+            "-d",
+            dict_file,
+            "-q",
+        ]
+        with patch("sys.argv", test_args):
+            diff2typo.main()
+
+        with open(out_json, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert "typos" in data
+        assert "corrections" in data
+        assert isinstance(data["typos"], list)
+        assert isinstance(data["corrections"], list)
+
+
+def test_main_both_mode_yaml_fallback(caplog):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        diff_file = os.path.join(tmpdir, "test.diff")
+        out_yaml = os.path.join(tmpdir, "both.yaml")
+        with open(diff_file, "w", encoding="utf-8") as f:
+            f.write(SAMPLE_DIFF)
+
+        test_args = [
+            "diff2typo.py",
+            diff_file,
+            "-o",
+            out_yaml,
+            "-M",
+            "both",
+            "-f",
+            "yaml",
+            "-q",
+            "-d",
+            "nonexistent.csv",
+        ]
+        with patch("diff2typo._YAML_AVAILABLE", False), patch("sys.argv", test_args):
+            diff2typo.main()
+
+        with open(out_yaml, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert "typos" in data
+        assert "corrections" in data


### PR DESCRIPTION
Add JSON and YAML output format support to diff2typo.py with automatic extension detection and PyYAML fallback.

---
*PR created automatically by Jules for task [1197438642408914152](https://jules.google.com/task/1197438642408914152) started by @RainRat*