### PR TITLE
[TEST] Add targeted unit tests for cmdrunner error and timeout log output branches

### DIFF
--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -1753,3 +1753,39 @@ def test_execution_summary_with_failed_and_timeout(tmp_path, capsys):
     summary_text = "\n".join(report_summary)
     assert "Failed runs:" in summary_text
     assert "Timed out runs:" in summary_text
+
+
+def test_run_command_timeout_with_stderr_and_stdout(tmp_path, caplog):
+    base_dir = tmp_path / "projects"
+    base_dir.mkdir()
+    (base_dir / "proj1").mkdir()
+
+    cmd_stderr = "python3 -c \"import sys, time; sys.stderr.write('err_output\\n'); sys.stderr.flush(); time.sleep(5)\""
+    with caplog.at_level(logging.ERROR):
+        cmdrunner.run_command_in_folders(str(base_dir), cmd_stderr, timeout=0.1)
+    assert any("Stderr:\nerr_output" in msg for msg in caplog.messages)
+
+    caplog.clear()
+
+    cmd_stdout = "python3 -c \"import sys, time; sys.stdout.write('out_output\\n'); sys.stdout.flush(); time.sleep(5)\""
+    with caplog.at_level(logging.ERROR):
+        cmdrunner.run_command_in_folders(str(base_dir), cmd_stdout, timeout=0.1)
+    assert any("Stdout:\nout_output" in msg for msg in caplog.messages)
+
+
+def test_run_command_failed_with_stderr_and_stdout(tmp_path, caplog):
+    base_dir = tmp_path / "projects"
+    base_dir.mkdir()
+    (base_dir / "proj1").mkdir()
+
+    cmd_stderr = "python3 -c \"import sys; sys.stderr.write('err_msg\\n'); sys.exit(1)\""
+    with caplog.at_level(logging.ERROR):
+        cmdrunner.run_command_in_folders(str(base_dir), cmd_stderr)
+    assert any("Stderr:\nerr_msg" in msg for msg in caplog.messages)
+
+    caplog.clear()
+
+    cmd_stdout = "python3 -c \"import sys; sys.stdout.write('out_msg\\n'); sys.exit(1)\""
+    with caplog.at_level(logging.ERROR):
+        cmdrunner.run_command_in_folders(str(base_dir), cmd_stdout)
+    assert any("Stdout:\nout_msg" in msg for msg in caplog.messages)


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Added unit tests `test_run_command_timeout_with_stderr_and_stdout` and `test_run_command_failed_with_stderr_and_stdout` in `tests/test_cmdrunner.py` to cover stderr and stdout formatting branches during subprocess timeout and execution failure logging in `cmdrunner.py`.
* **Why:** To eliminate remaining coverage gaps in `cmdrunner.py` and bring `cmdrunner.py` to 100% statement coverage and 100% branch coverage.

---
*PR created automatically by Jules for task [5112922637068214870](https://jules.google.com/task/5112922637068214870) started by @RainRat*