### PR TITLE
[FEAT] Add Markdown Export Format to diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -30,6 +30,7 @@ Output Formats:
     - list: typo
     - json: JSON array of objects or dict
     - yaml: YAML document
+    - markdown: Markdown table or list
 '''
 
 import argparse
@@ -554,7 +555,7 @@ def format_typos(typos: Iterable[str], output_format: str) -> List[str]:
 
     Args:
         typos (list): List of typo strings in the format "before -> after".
-        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list', 'json', 'yaml').
+        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list', 'json', 'yaml', 'markdown', 'md').
 
     Returns:
         list: Formatted list of typo strings.
@@ -575,6 +576,33 @@ def format_typos(typos: Iterable[str], output_format: str) -> List[str]:
                 logging.warning("PyYAML not installed. Falling back to JSON for YAML output format.")
 
         return json.dumps(items, indent=2).split('\n')
+
+    if output_format in ('markdown', 'md'):
+        formatted: List[str] = []
+        typo_pairs = []
+        single_items = []
+
+        for typo in typos:
+            if ' -> ' in typo:
+                before, after = typo.split(' -> ')
+                typo_pairs.append((before, after))
+            else:
+                single_items.append(typo)
+
+        if typo_pairs:
+            formatted.append("| Typo | Correction |")
+            formatted.append("| :--- | :--- |")
+            for before, after in typo_pairs:
+                formatted.append(f"| `{before}` | `{after}` |")
+
+        if single_items:
+            if typo_pairs:
+                formatted.append("")
+            for item in single_items:
+                clean_item = filter_to_letters(item)
+                formatted.append(f"- `{clean_item}`")
+
+        return formatted
 
     formatted: List[str] = []
     for typo in typos:
@@ -928,12 +956,12 @@ def main():
         '-f',
         dest='output_format',
         type=str,
-        choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml'],
+        choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml', 'markdown', 'md'],
         default=None,
-        help='Format of the output typos. If not provided, it is automatically detected from the output file extension. Choices are: arrow (typo -> correction), csv (typo,correction), table (typo = "correction"), list (typo), json, yaml. Default is arrow.',
+        help='Format of the output typos. If not provided, it is automatically detected from the output file extension. Choices are: arrow (typo -> correction), csv (typo,correction), table (typo = "correction"), list (typo), json, yaml, markdown, md. Default is arrow.',
     )
     # Hidden alias for backward compatibility
-    parser.add_argument('--output_format', type=str, choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml'], help=argparse.SUPPRESS, default=argparse.SUPPRESS)
+    parser.add_argument('--output_format', type=str, choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml', 'markdown', 'md'], help=argparse.SUPPRESS, default=argparse.SUPPRESS)
 
     # Analysis Options
     analysis_group = parser.add_argument_group(f"{BLUE}ANALYSIS OPTIONS{RESET}")
@@ -1043,7 +1071,7 @@ def main():
     # Resolve output format if not provided
     if args.output_format is None:
         default_fmt = 'arrow'
-        allowed_formats = ['arrow', 'csv', 'table', 'list', 'json', 'yaml']
+        allowed_formats = ['arrow', 'csv', 'table', 'list', 'json', 'yaml', 'markdown', 'md']
         if args.output_file and args.output_file != '-':
             ext = os.path.splitext(args.output_file)[1].lower().lstrip('.')
             mapping = {
@@ -1056,6 +1084,8 @@ def main():
                 'json': 'json',
                 'yaml': 'yaml',
                 'yml': 'yaml',
+                'md': 'markdown',
+                'markdown': 'markdown',
             }
             detected = mapping.get(ext)
             args.output_format = detected if detected in allowed_formats else default_fmt
@@ -1221,13 +1251,22 @@ def main():
             else:
                 final_output = json.dumps(data, indent=2).split('\n')
         else:
-            if typos_final:
-                final_output.append("=== Typos ===")
-                final_output.extend(format_typos(typos_final, args.output_format))
-                final_output.append("")  # Blank line for separation.
-            if corrections_final:
-                final_output.append("=== Corrections ===")
-                final_output.extend(format_typos(corrections_final, args.output_format))
+            if args.output_format in ('markdown', 'md'):
+                if typos_final:
+                    final_output.append("### Typos")
+                    final_output.extend(format_typos(typos_final, args.output_format))
+                    final_output.append("")  # Blank line for separation.
+                if corrections_final:
+                    final_output.append("### Corrections")
+                    final_output.extend(format_typos(corrections_final, args.output_format))
+            else:
+                if typos_final:
+                    final_output.append("=== Typos ===")
+                    final_output.extend(format_typos(typos_final, args.output_format))
+                    final_output.append("")  # Blank line for separation.
+                if corrections_final:
+                    final_output.append("=== Corrections ===")
+                    final_output.extend(format_typos(corrections_final, args.output_format))
     else:
         results_list = []
         if args.mode == 'typos':

--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -54,7 +54,7 @@ If you run the tool without specifying any input files or piping any changes, it
 | `--git`, `-g` | None | Fetch diff directly from Git. Optional arguments are passed to `git diff` (for example, `-g "HEAD~3"`). |
 | `--git-log`, `-l` | None | Fetch commit history diffs directly from Git. Optional arguments are passed to `git log` (for example, `-l "HEAD~3"`). |
 | `--output`, `-o` | the screen | Path to the output file. Use `-` to print to the screen. |
-| `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), `list` (typo only), `json`, or `yaml`. Automatically detected from file extension (`.json`, `.yaml`, `.yml`). |
+| `--format`, `-f` | `arrow` | Choose the output format: `arrow` (typo -> fix), `csv` (typo,fix), `table` (typo = "fix"), `list` (typo only), `json`, `yaml`, `markdown`, or `md`. Automatically detected from file extension (`.json`, `.yaml`, `.yml`, `.md`, `.markdown`). |
 | `--mode`, `-M` | `typos` | **`typos`**: Find typos that are not in your large dictionary (default).<br>**`corrections`**: Find corrections for typos in your large dictionary.<br>**`both`**: Run both checks and label the results.<br>**`audit`**: Find cases where a correct word was changed into a typo. |
 | `--exclude`, `-e` | None | One or more file patterns (e.g., `*.json`, `tests/*`) to exclude from typo scanning. |
 | `--include`, `-I` | None | One or more file patterns (e.g., `*.md`, `src/*`) to include in typo scanning (all files are scanned by default). |
@@ -100,11 +100,12 @@ python diff2typo.py --git "HEAD~5" --output recent_typos.txt
 python diff2typo.py --git-log "HEAD~5" --output recent_typos.txt
 ```
 
-**Export typos as JSON or YAML:**
+**Export typos as JSON, YAML, or Markdown:**
 
 ```bash
 python diff2typo.py feature.diff --format json --output typos.json
 python diff2typo.py feature.diff --format yaml --output typos.yaml
+python diff2typo.py feature.diff --format markdown --output typos.md
 ```
 
 **Pipe directly from Git and save to a file:**

--- a/tests/test_diff2typo_markdown.py
+++ b/tests/test_diff2typo_markdown.py
@@ -1,0 +1,97 @@
+import os
+import sys
+import tempfile
+import pytest
+
+from diff2typo import format_typos, main
+
+def test_format_typos_markdown_pairs():
+    typos = ["teh -> the", "fiel -> file"]
+    result = format_typos(typos, "markdown")
+    expected = [
+        "| Typo | Correction |",
+        "| :--- | :--- |",
+        "| `teh` | `the` |",
+        "| `fiel` | `file` |"
+    ]
+    assert result == expected
+
+def test_format_typos_markdown_singles():
+    typos = ["teh", "fiel"]
+    result = format_typos(typos, "md")
+    expected = [
+        "- `teh`",
+        "- `fiel`"
+    ]
+    assert result == expected
+
+def test_format_typos_markdown_mixed():
+    typos = ["teh -> the", "fiel"]
+    result = format_typos(typos, "markdown")
+    expected = [
+        "| Typo | Correction |",
+        "| :--- | :--- |",
+        "| `teh` | `the` |",
+        "",
+        "- `fiel`"
+    ]
+    assert result == expected
+
+def test_main_markdown_auto_detect_extension(monkeypatch, tmp_path):
+    diff_content = (
+        "diff --git a/test.txt b/test.txt\n"
+        "--- a/test.txt\n"
+        "+++ b/test.txt\n"
+        "@@ -1 +1 @@\n"
+        "-teh\n"
+        "+the\n"
+    )
+    diff_file = tmp_path / "sample.diff"
+    diff_file.write_text(diff_content, encoding="utf-8")
+
+    output_file = tmp_path / "output.md"
+
+    test_args = ["diff2typo.py", str(diff_file), "-o", str(output_file), "-q"]
+    monkeypatch.setattr(sys, "argv", test_args)
+
+    main()
+
+    assert output_file.exists()
+    content = output_file.read_text(encoding="utf-8")
+    assert "| Typo | Correction |" in content
+    assert "| `teh` | `the` |" in content
+
+def test_main_markdown_both_mode(monkeypatch, tmp_path):
+    diff_content = (
+        "diff --git a/test.txt b/test.txt\n"
+        "--- a/test.txt\n"
+        "+++ b/test.txt\n"
+        "@@ -1 +1 @@\n"
+        "-teh\n"
+        "+the\n"
+    )
+    diff_file = tmp_path / "sample.diff"
+    diff_file.write_text(diff_content, encoding="utf-8")
+
+    dict_file = tmp_path / "words.csv"
+    dict_file.write_text("teh,the\n", encoding="utf-8")
+
+    output_file = tmp_path / "output.txt"
+
+    test_args = [
+        "diff2typo.py",
+        str(diff_file),
+        "-o", str(output_file),
+        "-f", "markdown",
+        "-M", "both",
+        "-d", str(dict_file),
+        "-q"
+    ]
+    monkeypatch.setattr(sys, "argv", test_args)
+
+    main()
+
+    assert output_file.exists()
+    content = output_file.read_text(encoding="utf-8")
+    assert "### Typos" in content or "### Corrections" in content
+    assert "| Typo | Correction |" in content


### PR DESCRIPTION
Added Markdown export support (`-f markdown` or `-f md`) to `diff2typo.py`.

- Formats typo pairs as Markdown tables (`| Typo | Correction |`).
- Formats single typo entries as bullet lists (`- item`).
- Supports automatic format detection from `.md` and `.markdown` file extensions.
- Includes full unit test coverage in `tests/test_diff2typo_markdown.py`.
- Updated CLI documentation in `docs/diff2typo.md` and inline help strings.

---
*PR created automatically by Jules for task [3666684125657252161](https://jules.google.com/task/3666684125657252161) started by @RainRat*