### PR TITLE
refactor(diff2typo): remove redundant wrapper _is_file_included

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -428,12 +428,6 @@ def _match_pattern(filepath: str, patterns: Optional[List[str]]) -> bool:
     return False
 
 
-def _is_file_included(filepath: str, patterns: Optional[List[str]]) -> bool:
-    if not patterns:
-        return True
-    return _match_pattern(filepath, patterns)
-
-
 def find_typos(
     diff_text: str,
     min_length: int = 2,
@@ -482,7 +476,7 @@ def find_typos(
                 if current_file.startswith('"') and current_file.endswith('"'):
                     current_file = current_file[1:-1]
             if current_file:
-                if _match_pattern(current_file, exclude_patterns) or not _is_file_included(current_file, include_patterns):
+                if _match_pattern(current_file, exclude_patterns) or (include_patterns and not _match_pattern(current_file, include_patterns)):
                     skip_current_file = True
             continue
 
@@ -498,7 +492,7 @@ def find_typos(
             if path.startswith('"') and path.endswith('"'):
                 path = path[1:-1]
             additions.append(path)
-            if not (skip_current_file or _match_pattern(path, exclude_patterns) or not _is_file_included(path, include_patterns)):
+            if not (skip_current_file or _match_pattern(path, exclude_patterns) or (include_patterns and not _match_pattern(path, include_patterns))):
                 typos.extend(process_diff_block(removals, additions, min_length, max_dist))
             removals = []
             additions = []
@@ -515,7 +509,7 @@ def find_typos(
                     typos.extend(process_diff_block(removals, additions, min_length, max_dist))
                 removals = []
                 additions = []
-                skip_current_file = _match_pattern(current_file, exclude_patterns) or not _is_file_included(current_file, include_patterns)
+                skip_current_file = _match_pattern(current_file, exclude_patterns) or (include_patterns and not _match_pattern(current_file, include_patterns))
             continue
 
         if skip_current_file:

--- a/tests/test_diff2typo_include.py
+++ b/tests/test_diff2typo_include.py
@@ -1,15 +1,15 @@
 import pytest
-from diff2typo import _is_file_included, find_typos, main
+from diff2typo import _match_pattern, find_typos, main
 from unittest.mock import patch
 
-def test_is_file_included():
-    assert _is_file_included("tests/test_math.py", ["*.py"])
-    assert _is_file_included("config.json", ["*.json"])
-    assert _is_file_included("src/lib.py", ["src/*"])
-    assert _is_file_included("package-lock.json", ["package-lock.json"])
-    assert not _is_file_included("src/lib.py", ["*.json"])
-    assert _is_file_included("src/lib.py", None)
-    assert not _is_file_included("", ["*.py"])
+def test_match_pattern_include():
+    assert _match_pattern("tests/test_math.py", ["*.py"])
+    assert _match_pattern("config.json", ["*.json"])
+    assert _match_pattern("src/lib.py", ["src/*"])
+    assert _match_pattern("package-lock.json", ["package-lock.json"])
+    assert not _match_pattern("src/lib.py", ["*.json"])
+    assert not _match_pattern("src/lib.py", None)
+    assert not _match_pattern("", ["*.py"])
 
 
 def test_find_typos_inclusion():


### PR DESCRIPTION
* **What:** Removed the redundant private wrapper function `_is_file_included` from `diff2typo.py` and updated call sites in `find_typos()` to check pattern inclusion with `_match_pattern` directly. Updated `tests/test_diff2typo_include.py` to test `_match_pattern` directly.
* **Why:** Eliminates premature abstraction and trivial function wrapper overhead while keeping module behavior identical and non-breaking.

---
*PR created automatically by Jules for task [15005688193213771556](https://jules.google.com/task/15005688193213771556) started by @RainRat*