### PR TITLE
[UI/UX] Add short flag -s alias for --sort option in diff2typo

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -1016,7 +1016,7 @@ def main():
     )
 
     analysis_group.add_argument(
-        '--sort',
+        '-s', '--sort',
         choices=['count', 'alpha'],
         default='alpha',
         help="How to sort the results: 'count' (most frequent first) or 'alpha' (alphabetical, default).",

--- a/tests/test_diff2typo_short_flags.py
+++ b/tests/test_diff2typo_short_flags.py
@@ -8,7 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import diff2typo
 
 def test_short_flags_parsing(monkeypatch):
-    """Verify that short flags -g, -M, -D, -c parse identically to long flags."""
+    """Verify that short flags -g, -M, -D, -c, -s parse identically to long flags."""
 
     import argparse
     original_parse = argparse.ArgumentParser.parse_args
@@ -23,7 +23,7 @@ def test_short_flags_parsing(monkeypatch):
     monkeypatch.setattr(diff2typo, 'read_words_mapping', lambda *a, **kw: {})
     monkeypatch.setattr(diff2typo, 'read_allowed_words', lambda *a, **kw: set())
 
-    # Test short flags: -g, -M, -D, -c
+    # Test short flags: -g, -M, -D, -c, -s
     monkeypatch.setattr(
         sys,
         'argv',
@@ -33,6 +33,7 @@ def test_short_flags_parsing(monkeypatch):
             '-M', 'both',
             '-D', '3',
             '-c', '2',
+            '-s', 'count',
             '--quiet'
         ]
     )
@@ -48,3 +49,4 @@ def test_short_flags_parsing(monkeypatch):
     assert args.mode == 'both'
     assert args.max_dist == 3
     assert args.min_count == 2
+    assert args.sort == 'count'


### PR DESCRIPTION
### PR Title: [UI/UX] Add short flag -s alias for --sort option in diff2typo

### Description:
* **Context:** CLI
* **Problem:** Users had to type out the full `--sort` flag when running `diff2typo.py`, unlike other options like `--mode` (`-M`), `--limit` (`-L`), `--max-dist` (`-D`), or `--min-count` (`-c`) which have concise short flag aliases. This created unnecessary friction and extra keystrokes for a common CLI task.
* **Solution:** Added `-s` as a short flag alias for `--sort` in `diff2typo.py`. This aligns `diff2typo.py` with CLI flag conventions (and matching tools like `typostats.py`), reducing keystrokes and simplifying common workflows.

### Changes:
```python
# diff2typo.py
<<<<<<< SEARCH
    analysis_group.add_argument(
        '--sort',
        choices=['count', 'alpha'],
        default='alpha',
        help="How to sort the results: 'count' (most frequent first) or 'alpha' (alphabetical, default).",
    )
=======
    analysis_group.add_argument(
        '-s', '--sort',
        choices=['count', 'alpha'],
        default='alpha',
        help="How to sort the results: 'count' (most frequent first) or 'alpha' (alphabetical, default).",
    )
>>>>>>> REPLACE
```

---
*PR created automatically by Jules for task [2462149330443816291](https://jules.google.com/task/2462149330443816291) started by @RainRat*