### PR TITLE
[FEAT] Add Markdown Export Support to gentypos.py

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -63,7 +63,7 @@ echo "banana" | python gentypos.py --all --no-filter
 | `--dry-run` | Off | Show configuration details and a sample preview of typo generation without writing files. |
 | `--dictionary`, `-d` | None | The path to a large dictionary file used to filter out real words. |
 | `--duplication` | Off | Generate duplications (typing a letter twice, e.g., 'word' becomes 'woord'). |
-| `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), `list` (typo), `json`, or `yaml`. By default, it is automatically detected from the output file extension. |
+| `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), `list` (typo), `json`, `yaml`, `markdown`, or `md`. By default, it is automatically detected from the output file extension. |
 | `--input`, `-i` | None | One or more input files, directories, or glob patterns containing words to process (one per line). |
 | `--keyboard`, `--replacement`, `-k` | Off | Generate replacements (hitting a nearby key or custom substitution, e.g., 'word' becomes 'wprd'). |
 | `--max-length` | None | Ignore words longer than this length. |
@@ -88,7 +88,7 @@ input_file: "words.txt"           # Small dictionary to process (can also be a l
 dictionary_file: "dictionary.txt"  # Large dictionary (to filter out real words)
 output_file: "typos.txt"          # Where to save the results
 
-# Output Format: arrow (a -> b), csv (a,b), table (a = "b"), list (a), json, or yaml
+# Output Format: arrow (a -> b), csv (a,b), table (a = "b"), list (a), json, yaml, markdown, or md
 output_format: "arrow"
 
 # How many times to repeat the process (makes more complex typos)

--- a/gentypos.py
+++ b/gentypos.py
@@ -255,6 +255,8 @@ def _detect_format_from_extension(path: str, allowed: Sequence[str], default: st
         'json': 'json',
         'yaml': 'yaml',
         'yml': 'yaml',
+        'md': 'markdown',
+        'markdown': 'markdown',
     }
 
     detected = mapping.get(ext)
@@ -848,7 +850,7 @@ def format_typos(
 
     Args:
         typo_to_correct_word (dict): Mapping from typo to correct word.
-        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list', 'json', 'yaml').
+        output_format (str): Desired output format ('arrow', 'csv', 'table', 'list', 'json', 'yaml', 'markdown', 'md').
 
     Returns:
         list: Formatted list of typo strings.
@@ -865,6 +867,11 @@ def format_typos(
             logging.warning("PyYAML not installed. Falling back to JSON for YAML output format.")
             import json
             return [json.dumps(typo_to_correct_word, indent=2)]
+    elif output_format in ('markdown', 'md'):
+        lines = ["| Typo | Correction |", "| :--- | :--- |"]
+        for typo, correct_word in typo_to_correct_word.items():
+            lines.append(f"| `{typo}` | `{correct_word}` |")
+        return lines
 
     for typo, correct_word in typo_to_correct_word.items():
         if output_format == 'arrow':
@@ -895,7 +902,7 @@ def _extract_config_settings(config: MutableMapping[str, Any], quiet: bool = Fal
     output_format = config.get('output_format', 'arrow').lower()
     output_header = config.get('output_header')
 
-    valid_formats = {'arrow', 'csv', 'table', 'list', 'json', 'yaml'}
+    valid_formats = {'arrow', 'csv', 'table', 'list', 'json', 'yaml', 'markdown', 'md'}
     if output_format not in valid_formats:
         logging.warning(
             f"Unknown output format '{output_format}'. Defaulting to 'arrow'."
@@ -1166,7 +1173,7 @@ def main() -> None:
     )
     io_group.add_argument(
         '-f', '--format',
-        choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml'],
+        choices=['arrow', 'csv', 'table', 'list', 'json', 'yaml', 'markdown', 'md'],
         metavar='FMT',
         default=None,
         help="Choose an output format. If not provided, it is automatically detected from the output file extension. (default: arrow).",
@@ -1364,7 +1371,7 @@ def main() -> None:
     if args.format:
         config['output_format'] = args.format
     elif config.get('output_format') is None:
-        allowed_formats = ['arrow', 'csv', 'table', 'list', 'json', 'yaml']
+        allowed_formats = ['arrow', 'csv', 'table', 'list', 'json', 'yaml', 'markdown', 'md']
         config['output_format'] = _detect_format_from_extension(config.get('output_file'), allowed_formats, 'arrow')
     if args.substitutions:
         config['substitutions_file'] = args.substitutions

--- a/tests/test_gentypos_markdown_format.py
+++ b/tests/test_gentypos_markdown_format.py
@@ -1,0 +1,110 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import gentypos
+
+
+@pytest.fixture
+def empty_config_file(tmp_path):
+    config = tmp_path / "test_config.yaml"
+    config.write_text("{}", encoding="utf-8")
+    return str(config)
+
+
+def test_gentypos_markdown_format_stdout(capsys, empty_config_file):
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--no-filter",
+        "-f", "markdown"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    captured = capsys.readouterr()
+    lines = [line.strip() for line in captured.out.strip().split('\n') if line.strip()]
+
+    assert lines[0] == "| Typo | Correction |"
+    assert lines[1] == "| :--- | :--- |"
+    assert len(lines) > 2
+    for row in lines[2:]:
+        assert row.startswith("| `")
+        assert row.endswith("` |")
+        assert "`hello`" in row
+
+
+def test_gentypos_md_format_stdout(capsys, empty_config_file):
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--no-filter",
+        "-f", "md"
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    captured = capsys.readouterr()
+    lines = [line.strip() for line in captured.out.strip().split('\n') if line.strip()]
+
+    assert lines[0] == "| Typo | Correction |"
+    assert lines[1] == "| :--- | :--- |"
+    assert len(lines) > 2
+    for row in lines[2:]:
+        assert "`hello`" in row
+
+
+def test_gentypos_auto_detect_md_extension(tmp_path, empty_config_file):
+    output_md = tmp_path / "typos.md"
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--no-filter",
+        "-o", str(output_md)
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    assert output_md.exists()
+    content = output_md.read_text(encoding="utf-8")
+    lines = [line.strip() for line in content.strip().split('\n') if line.strip()]
+
+    assert lines[0] == "| Typo | Correction |"
+    assert lines[1] == "| :--- | :--- |"
+    assert len(lines) > 2
+
+
+def test_gentypos_auto_detect_markdown_extension(tmp_path, empty_config_file):
+    output_markdown = tmp_path / "typos.markdown"
+    test_args = [
+        "gentypos.py",
+        "hello",
+        "-c", empty_config_file,
+        "--no-filter",
+        "-o", str(output_markdown)
+    ]
+    with patch.object(sys, 'argv', test_args):
+        gentypos.main()
+
+    assert output_markdown.exists()
+    content = output_markdown.read_text(encoding="utf-8")
+    lines = [line.strip() for line in content.strip().split('\n') if line.strip()]
+
+    assert lines[0] == "| Typo | Correction |"
+    assert lines[1] == "| :--- | :--- |"
+    assert len(lines) > 2
+
+
+def test_format_typos_markdown_direct():
+    mapping = {"helo": "hello", "hlelo": "hello"}
+    result = gentypos.format_typos(mapping, "markdown")
+
+    assert result[0] == "| Typo | Correction |"
+    assert result[1] == "| :--- | :--- |"
+    assert "| `helo` | `hello` |" in result
+    assert "| `hlelo` | `hello` |" in result


### PR DESCRIPTION
* **What:** Added support for Markdown (`markdown` / `md`) output formatting in `gentypos.py`. This includes formatting typo mappings into Markdown tables (`| Typo | Correction |`), handling `-f markdown` and `-f md` CLI flags, and automatically detecting the format when saving to `.md` or `.markdown` file paths.
* **Why:** In aligned tools across the suite (`diff2typo.py`, `typostats.py`, `multitool.py`), Markdown export support is already present. Adding Markdown formatting to `gentypos.py` completes output format symmetry across the suite and enables users to export typo lists directly into Markdown documentation, GitHub pull requests, and release notes.

---
*PR created automatically by Jules for task [14550919067013399578](https://jules.google.com/task/14550919067013399578) started by @RainRat*