### PR TITLE
[UI/UX] Add -i / --input flag option to typostats.py

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -49,7 +49,8 @@ The tool automatically recognizes several common ways of listing typos:
 - `-t`, `--transposition`: Find swapped letters (like `teh` instead of `the`).
 - `-k`, `--keyboard`: Find typos caused by hitting keys next to each other on the keyboard.
 
-### Output Options
+### Input & Output Options
+- `-i`, `--input`: One or more input files or patterns containing typo corrections.
 - `-f`, `--format`: Choose the output format:
   - `arrow` (Default): Easy to read.
   - `csv`: Standard comma-separated values.

--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -332,6 +332,18 @@ def test_read_file_lines_robust_encoding_failures():
             assert typostats._read_file_lines_robust("dummy_none.txt") == ["latin-1_fallback"]
 
 
+def test_main_cli_input_flag(tmp_path):
+    f1 = tmp_path / "typos1.txt"
+    f1.write_text("teh -> the\n")
+    f2 = tmp_path / "typos2.txt"
+    f2.write_text("recived -> received\n")
+
+    with patch('sys.argv', ['typostats.py', '-i', str(f1), str(f2), '-q']), \
+         patch('typostats.generate_report') as mock_report:
+        typostats.main()
+        assert mock_report.call_args[1]['total_pairs'] == 2
+
+
 def test_main_cli_functionality():
     with patch('sys.argv', ['typostats.py', '--help']):
         with pytest.raises(SystemExit):

--- a/typostats.py
+++ b/typostats.py
@@ -1103,6 +1103,14 @@ def main() -> None:
         nargs='*',
         help="One or more files containing typo corrections (txt, csv, json, yaml, md). If empty, it reads from standard input.",
     )
+    io_group.add_argument(
+        '-i', '--input',
+        dest='input_files_flag',
+        nargs='+',
+        metavar='FILE',
+        default=None,
+        help="One or more input files or patterns containing typo corrections.",
+    )
     io_group.add_argument('-o', '--output', help="Save the report to this file instead of printing it.")
     io_group.add_argument(
         '-e', '--exclude',
@@ -1198,7 +1206,9 @@ def main() -> None:
     handler.setFormatter(MinimalFormatter('%(levelname)s: %(message)s'))
     logging.basicConfig(level=log_level, handlers=[handler])
 
-    input_files = args.input_files
+    pos_inputs = getattr(args, 'input_files', []) or []
+    flag_inputs = getattr(args, 'input_files_flag', []) or []
+    input_files = pos_inputs + flag_inputs
     output_file = args.output
     min_occurrences = args.min
     sort_by = args.sort


### PR DESCRIPTION
Add -i / --input option to typostats.py to reduce friction and align CLI conventions with diff2typo.py and gentypos.py.

---
*PR created automatically by Jules for task [4532268373127707883](https://jules.google.com/task/4532268373127707883) started by @RainRat*