### PR TITLE
[FEAT] Add --dry-run CLI option to diff2typo.py

### DIFF
--- a/diff2typo.py
+++ b/diff2typo.py
@@ -1061,6 +1061,12 @@ def main():
     parser.add_argument('--typos_tool_path', type=str, help=argparse.SUPPRESS, default=argparse.SUPPRESS)
 
     analysis_group.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Show configuration details and a sample preview of typo extraction without writing files.',
+    )
+
+    analysis_group.add_argument(
         '--quiet', '-q',
         action='store_true',
         help='Hide progress bars and status messages.'
@@ -1108,6 +1114,7 @@ def main():
 
     git_val = getattr(args, 'git', None)
     git_log_val = getattr(args, 'git_log', None)
+    dry_run_val = getattr(args, 'dry_run', False)
 
     # Robust handling for Mock/MagicMock in unit tests
     with contextlib.suppress(ImportError):
@@ -1116,6 +1123,8 @@ def main():
             git_val = None
         if isinstance(git_log_val, unittest.mock.Mock):
             git_log_val = None
+        if isinstance(dry_run_val, unittest.mock.Mock):
+            dry_run_val = False
 
     if git_val is not None:
         diff_text = _read_git_diff(git_val)
@@ -1206,6 +1215,37 @@ def main():
     if args.mode == 'audit':
         logging.info("Checking for cases where correct words were changed into typos...")
         audit_list = process_audit_typos(candidates, args, large_dictionary, allowed_words)
+
+    if dry_run_val:
+        use_color = _should_enable_color(sys.stderr)
+        c_blue = (BOLD + _BLUE) if use_color else ""
+        c_green = (BOLD + _GREEN) if use_color else ""
+        c_reset = _RESET if use_color else ""
+
+        logging.info(f"{c_blue}--- DIFF2TYPO DRY RUN ---{c_reset}")
+        input_desc = input_files if input_files else ("Git Diff" if git_val is not None else ("Git Log" if git_log_val is not None else "stdin"))
+        logging.info(f"Input Source: {input_desc}")
+        logging.info(f"Output Target: {args.output_file} (Format: {args.output_format})")
+        logging.info(f"Mode: {args.mode} | Min Length: {args.min_length} | Max Dist: {args.max_dist if args.max_dist is not None else 'None'}")
+        logging.info(f"Min Count: {args.min_count} | Sort: {args.sort} | Limit: {args.limit if args.limit is not None else 'None'}")
+        logging.info(f"Large Dictionary: {args.dictionary_file} | Allowed File: {args.allowed_file}")
+        logging.info(f"Exclude Patterns: {args.exclude if args.exclude else 'None'} | Include Patterns: {args.include if args.include else 'None'}")
+
+        # Sample Preview
+        logging.info(f"\n{c_blue}Sample Typo Extraction Preview:{c_reset}")
+        if args.mode == 'both':
+            sample_typos = typos_list[:5]
+            sample_corrections = corrections_list[:5]
+            logging.info(f"  Typos ({len(typos_list)} total): {', '.join(sample_typos) if sample_typos else 'None'}")
+            logging.info(f"  Corrections ({len(corrections_list)} total): {', '.join(sample_corrections) if sample_corrections else 'None'}")
+        else:
+            sample_items = (typos_list if args.mode == 'typos' else (corrections_list if args.mode == 'corrections' else audit_list))
+            logging.info(f"  Found {len(sample_items)} candidate(s) in '{args.mode}' mode:")
+            for item in sample_items[:10]:
+                logging.info(f"    {item}")
+
+        logging.info(f"{c_green}Dry run complete. No files were written.{c_reset}")
+        return
 
     # Helper to sort and limit results
     def sort_and_limit(items):

--- a/docs/diff2typo.md
+++ b/docs/diff2typo.md
@@ -66,6 +66,7 @@ If you run the tool without specifying any input files or piping any changes, it
 | `--dictionary`, `-d` | `words.csv` | A file containing the large dictionary of correct words. The tool uses this to make sure the "fix" is a real word. |
 | `--allowed` | `allowed.csv` | A list of words to explicitly ignore, even if they look like typos. |
 | `--typos-path` | `typos` | The path to the external `typos` tool. |
+| `--dry-run` | Off | Show configuration details and a sample preview of typo extraction without writing files. |
 | `--quiet`, `-q` | Off | Hide progress bars and status messages. |
 
 ## Examples
@@ -112,6 +113,12 @@ python diff2typo.py feature.diff --format markdown --output typos.md
 
 ```bash
 git diff | python diff2typo.py --output found_typos.txt --mode both
+```
+
+**Preview configuration and sample typos without writing files:**
+
+```bash
+python diff2typo.py feature.diff --output typos.txt --dry-run
 ```
 
 **Find patterns with typostats:**

--- a/tests/test_diff2typo_dry_run.py
+++ b/tests/test_diff2typo_dry_run.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch
+import diff2typo
+
+
+def test_diff2typo_dry_run_basic(tmp_path, caplog):
+    """Verify that --dry-run prints execution summary and sample preview without creating the output file."""
+    diff_file = tmp_path / "sample.diff"
+    diff_file.write_text(
+        "diff --git a/file.py b/file.py\n"
+        "--- a/file.py\n"
+        "+++ b/file.py\n"
+        "-teh house\n"
+        "+the house\n"
+    )
+    output_file = tmp_path / "output_typos.txt"
+
+    test_args = [
+        "diff2typo.py",
+        str(diff_file),
+        "-o",
+        str(output_file),
+        "--dry-run",
+    ]
+
+    with patch.object(sys, "argv", test_args):
+        with caplog.at_level("INFO"):
+            diff2typo.main()
+
+    assert not output_file.exists(), "Output file must not be written in dry-run mode."
+    assert "--- DIFF2TYPO DRY RUN ---" in caplog.text
+    assert f"Output Target: {output_file}" in caplog.text
+    assert "Mode: typos" in caplog.text
+    assert "Sample Typo Extraction Preview:" in caplog.text
+    assert "teh -> the" in caplog.text
+    assert "Dry run complete. No files were written." in caplog.text
+
+
+def test_diff2typo_dry_run_both_mode(tmp_path, caplog):
+    """Verify --dry-run with --mode both displays both typos and corrections preview without writing output."""
+    diff_file = tmp_path / "sample.diff"
+    diff_file.write_text(
+        "diff --git a/file.py b/file.py\n"
+        "--- a/file.py\n"
+        "+++ b/file.py\n"
+        "-teh house\n"
+        "+the house\n"
+    )
+    output_file = tmp_path / "output_both.txt"
+
+    test_args = [
+        "diff2typo.py",
+        str(diff_file),
+        "-o",
+        str(output_file),
+        "-M",
+        "both",
+        "--dry-run",
+    ]
+
+    with patch.object(sys, "argv", test_args):
+        with caplog.at_level("INFO"):
+            diff2typo.main()
+
+    assert not output_file.exists()
+    assert "--- DIFF2TYPO DRY RUN ---" in caplog.text
+    assert "Mode: both" in caplog.text
+    assert "Sample Typo Extraction Preview:" in caplog.text
+    assert "Typos (" in caplog.text
+    assert "Corrections (" in caplog.text
+    assert "Dry run complete. No files were written." in caplog.text
+
+
+def test_diff2typo_dry_run_corrections_mode(tmp_path, caplog):
+    """Verify --dry-run with --mode corrections runs cleanly without writing output files."""
+    diff_file = tmp_path / "sample.diff"
+    diff_file.write_text(
+        "diff --git a/file.py b/file.py\n"
+        "--- a/file.py\n"
+        "+++ b/file.py\n"
+        "-teh house\n"
+        "+the house\n"
+    )
+    output_file = tmp_path / "output_corrections.txt"
+
+    test_args = [
+        "diff2typo.py",
+        str(diff_file),
+        "-o",
+        str(output_file),
+        "-M",
+        "corrections",
+        "--dry-run",
+    ]
+
+    with patch.object(sys, "argv", test_args):
+        with caplog.at_level("INFO"):
+            diff2typo.main()
+
+    assert not output_file.exists()
+    assert "--- DIFF2TYPO DRY RUN ---" in caplog.text
+    assert "Mode: corrections" in caplog.text
+    assert "Dry run complete. No files were written." in caplog.text


### PR DESCRIPTION
Adds a --dry-run CLI option to diff2typo.py to display configuration settings and a sample preview of candidate typos/corrections extracted from diffs without creating or modifying output files.

---
*PR created automatically by Jules for task [2493362930711835719](https://jules.google.com/task/2493362930711835719) started by @RainRat*