### PR TITLE
[UI/UX] Add short flag aliases -D and -u for deletion and duplication typo generation options

### DIFF
--- a/docs/gentypos.md
+++ b/docs/gentypos.md
@@ -59,10 +59,10 @@ echo "banana" | python gentypos.py --all --no-filter
 | `--add`, `-a` | None | Extra substitution pairs (for example `ph:f` or `th:teh`) to use during typo generation. |
 | `--all`, `-A` | Off | Generate all typo types (deletions, transpositions, replacements, and duplications). |
 | `--config`, `-c` | `gentypos.yaml` | The path to your YAML configuration file. |
-| `--deletion` | Off | Generate deletions (skipping a letter, e.g., 'word' becomes 'wrd'). |
+| `--deletion`, `-D` | Off | Generate deletions (skipping a letter, e.g., 'word' becomes 'wrd'). |
 | `--dry-run` | Off | Show configuration details and a sample preview of typo generation without writing files. |
 | `--dictionary`, `-d` | None | The path to a large dictionary file used to filter out real words. |
-| `--duplication` | Off | Generate duplications (typing a letter twice, e.g., 'word' becomes 'woord'). |
+| `--duplication`, `-u` | Off | Generate duplications (typing a letter twice, e.g., 'word' becomes 'woord'). |
 | `--format`, `-f` | None | Choose an output format: `arrow` (typo -> correction), `csv` (typo,correction), `table` (typo = "correction"), `list` (typo), `json`, `yaml`, `markdown`, or `md`. By default, it is automatically detected from the output file extension. |
 | `--input`, `-i` | None | One or more input files, directories, or glob patterns containing words to process (one per line). |
 | `--keyboard`, `--replacement`, `-k` | Off | Generate replacements (hitting a nearby key or custom substitution, e.g., 'word' becomes 'wprd'). |

--- a/gentypos.py
+++ b/gentypos.py
@@ -1229,12 +1229,12 @@ def main() -> None:
         help="Generate transpositions (swapped letters, e.g., 'word' to 'wrod').",
     )
     gen_group.add_argument(
-        '--deletion',
+        '-D', '--deletion',
         action='store_true',
         help="Generate deletions (skipping a letter, e.g., 'word' to 'wrd').",
     )
     gen_group.add_argument(
-        '--duplication',
+        '-u', '--duplication',
         action='store_true',
         help="Generate duplications (typing a letter twice, e.g., 'word' to 'woord').",
     )

--- a/tests/test_gentypos_short_flags.py
+++ b/tests/test_gentypos_short_flags.py
@@ -1,0 +1,30 @@
+import sys
+import pytest
+import gentypos
+
+def test_gentypos_deletion_short_flag(monkeypatch, capsys):
+    test_args = ["gentypos.py", "word", "-D", "--no-filter", "-f", "arrow", "-q"]
+    monkeypatch.setattr(sys, "argv", test_args)
+
+    gentypos.main()
+
+    captured = capsys.readouterr()
+    lines = [line.strip() for line in captured.out.strip().splitlines() if line.strip()]
+
+    # 'word' -> deletions: 'ord', 'wod', 'wrd' (note: 'wor' is skipped since trailing 'd' deletion is ignored in gentypos)
+    expected_typos = {"ord -> word", "wod -> word", "wrd -> word"}
+    assert set(lines) == expected_typos
+
+
+def test_gentypos_duplication_short_flag(monkeypatch, capsys):
+    test_args = ["gentypos.py", "test", "-u", "--no-filter", "-f", "arrow", "-q"]
+    monkeypatch.setattr(sys, "argv", test_args)
+
+    gentypos.main()
+
+    captured = capsys.readouterr()
+    lines = [line.strip() for line in captured.out.strip().splitlines() if line.strip()]
+
+    # 'test' -> duplications: 'ttest', 'teest', 'tesst', 'testt'
+    expected_typos = {"ttest -> test", "teest -> test", "tesst -> test", "testt -> test"}
+    assert set(lines) == expected_typos


### PR DESCRIPTION
**PR Title:** [UI/UX] Add short flag aliases `-D` and `-u` for deletion and duplication typo generation options

**Description:**
* **Context:** CLI
* **Problem:** In `gentypos.py`, common typo generation methods `--transposition` (`-t`), `--keyboard` (`-k`), and `--all` (`-A`) have single-character short flags, but `--deletion` and `--duplication` require typing full long options. This creates friction and inconsistency for CLI power users executing common typo generation tasks.
* **Solution:** Added `-D` as a short flag alias for `--deletion` and `-u` as a short flag alias for `--duplication` in `gentypos.py`. Updated documentation in `docs/gentypos.md` and added unit test verification in `tests/test_gentypos_short_flags.py`.

**Changes:**
- Updated argument parser in `gentypos.py` to register `-D, --deletion` and `-u, --duplication`.
- Updated CLI options reference table in `docs/gentypos.md`.
- Added unit tests in `tests/test_gentypos_short_flags.py`.

---
*PR created automatically by Jules for task [3308248898789914431](https://jules.google.com/task/3308248898789914431) started by @RainRat*