### PR TITLE
[UI/UX] Add --dry-run CLI option to typostats.py

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -51,6 +51,7 @@ The tool automatically recognizes several common ways of listing typos:
 
 ### Input & Output Options
 - `-i`, `--input`: One or more input files or patterns containing typo corrections.
+- `--dry-run`: Show configuration details and a sample preview of typo pattern analysis without writing or modifying files.
 - `-f`, `--format`: Choose the output format:
   - `arrow` (Default): Easy to read.
   - `csv`: Standard comma-separated values.

--- a/tests/test_typostats_dry_run.py
+++ b/tests/test_typostats_dry_run.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import tempfile
+import pytest
+from unittest.mock import patch
+import typostats
+
+
+def test_dry_run_stdout_and_no_file_creation(capsys):
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tmp_in:
+        tmp_in.write(b"teh -> the\nwrod -> word\n")
+        tmp_in_path = tmp_in.name
+
+    tmp_out_path = tmp_in_path + ".out"
+
+    try:
+        test_args = [
+            "typostats.py",
+            tmp_in_path,
+            "--output", tmp_out_path,
+            "--dry-run",
+            "-t",
+        ]
+        with patch.object(sys, "argv", test_args):
+            typostats.main()
+
+        captured = capsys.readouterr()
+        assert "--- TYPOSTATS DRY RUN ---" in captured.err
+        assert "Input Sources:" in captured.err
+        assert tmp_out_path in captured.err
+        assert "Sample Preview (First 5 replacements):" in captured.err
+        assert "eh -> he (Count: 1)" in captured.err or "or -> ro" in captured.err
+
+        # Output file should NOT be created in dry run
+        assert not os.path.exists(tmp_out_path)
+    finally:
+        if os.path.exists(tmp_in_path):
+            os.remove(tmp_in_path)
+        if os.path.exists(tmp_out_path):
+            os.remove(tmp_out_path)
+
+
+def test_dry_run_empty_matches(capsys):
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tmp_in:
+        tmp_in.write(b"hello -> world\n")
+        tmp_in_path = tmp_in.name
+
+    try:
+        test_args = [
+            "typostats.py",
+            tmp_in_path,
+            "--dry-run",
+            "--min", "10",
+        ]
+        with patch.object(sys, "argv", test_args):
+            typostats.main()
+
+        captured = capsys.readouterr()
+        assert "--- TYPOSTATS DRY RUN ---" in captured.err
+        assert "(No replacements found matching criteria)" in captured.err
+    finally:
+        if os.path.exists(tmp_in_path):
+            os.remove(tmp_in_path)
+
+
+def test_dry_run_sorting_options(capsys):
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tmp_in:
+        tmp_in.write(b"teh -> the\nwrod -> word\n")
+        tmp_in_path = tmp_in.name
+
+    try:
+        for sort_opt in ["typo", "correct", "count"]:
+            test_args = [
+                "typostats.py",
+                tmp_in_path,
+                "--dry-run",
+                "-s", sort_opt,
+                "-a",
+            ]
+            with patch.object(sys, "argv", test_args):
+                typostats.main()
+
+            captured = capsys.readouterr()
+            assert "--- TYPOSTATS DRY RUN ---" in captured.err
+            assert f"Sort By: {sort_opt}" in captured.err
+    finally:
+        if os.path.exists(tmp_in_path):
+            os.remove(tmp_in_path)

--- a/typostats.py
+++ b/typostats.py
@@ -1126,6 +1126,11 @@ def main() -> None:
         default=None,
         help="The format of the report. If not provided, it is automatically detected from the output file extension. (default: arrow).",
     )
+    io_group.add_argument(
+        '--dry-run',
+        action='store_true',
+        help="Show configuration details and a sample preview of typo pattern analysis without writing or modifying files.",
+    )
     io_group.add_argument('-q', '--quiet', action='store_true', help="Hide progress bars and status messages.")
 
     # Analysis Options Group
@@ -1276,6 +1281,8 @@ def main() -> None:
     total_lines_all = 0
     total_pairs_all = 0
 
+    dry_run_val = getattr(args, 'dry_run', False)
+
     for file_path in input_files:
         # Pre-calculate total lines for statistics and progress tracking
         try:
@@ -1300,6 +1307,50 @@ def main() -> None:
         for k, v in file_counts.items():
             all_counts[k] += v
         total_pairs_all += pairs_count
+
+    if dry_run_val:
+        use_color = _should_enable_color(sys.stderr)
+        c_blue = (BOLD + _BLUE) if use_color else ""
+        c_green = (BOLD + _GREEN) if use_color else ""
+        c_yellow = (BOLD + _YELLOW) if use_color else ""
+        c_reset = _RESET if use_color else ""
+
+        enabled_features = []
+        if keyboard:
+            enabled_features.append("keyboard")
+        if allow_transposition:
+            enabled_features.append("transposition")
+        if allow_1to2:
+            enabled_features.append("1-to-2")
+        if allow_2to1:
+            enabled_features.append("2-to-1")
+        if include_deletions:
+            enabled_features.append("deletions/insertions")
+
+        sys.stderr.write(f"\n{c_blue}--- TYPOSTATS DRY RUN ---{c_reset}\n")
+        sys.stderr.write(f"Input Sources: {input_files if input_files else 'stdin'}\n")
+        sys.stderr.write(f"Output Target: {output_file if output_file else 'stdout'} (Format: {output_format})\n")
+        sys.stderr.write(f"Sort By: {sort_by} | Min Occurrences: {min_occurrences} | Limit: {limit if limit is not None else 'None'}\n")
+        sys.stderr.write(f"Enabled Features: {', '.join(enabled_features) if enabled_features else 'None'}\n")
+        sys.stderr.write(f"Exclude Patterns: {exclude_patterns if exclude_patterns else 'None'}\n\n")
+
+        sys.stderr.write(f"{c_green}Sample Preview (First 5 replacements):{c_reset}\n")
+        filtered = {k: v for k, v in all_counts.items() if v >= min_occurrences}
+        if sort_by == 'typo':
+            sorted_replacements = sorted(filtered.items(), key=lambda x: (x[0][1], x[0][0]))
+        elif sort_by == 'correct':
+            sorted_replacements = sorted(filtered.items(), key=lambda x: (x[0][0], x[0][1]))
+        else:
+            sorted_replacements = sorted(filtered.items(), key=lambda x: x[1], reverse=True)
+
+        preview_items = sorted_replacements[:5]
+        if not preview_items:
+            sys.stderr.write(f"  {c_yellow}(No replacements found matching criteria){c_reset}\n")
+        else:
+            for (correct_char, typo_char), count in preview_items:
+                sys.stderr.write(f"  {typo_char} -> {correct_char} (Count: {count})\n")
+        sys.stderr.write("\n")
+        return
 
     generate_report(
         all_counts,


### PR DESCRIPTION
PR Title: [UI/UX] Add --dry-run CLI option to typostats.py

Description:
* Context: CLI (Command Line Interface)
* Problem: Users running `typostats.py` had no way to preview configuration settings (e.g., active analysis modes, exclusions, sorting, limits) or preview extracted character replacements without modifying or generating output files.
* Solution: Implemented a `--dry-run` CLI option in `typostats.py` that formats and prints a clear, color-aware configuration summary and a sample preview of character replacements on `sys.stderr`, aligning CLI behavior with `diff2typo.py`, `gentypos.py`, and `multitool.py`.

Changes:
- Added `--dry-run` flag to `typostats.py` argument parser under Input & Output Options.
- Added dry-run execution logic in `main()` to display settings and a sample preview on `sys.stderr` before exiting without creating output files.
- Documented `--dry-run` in `docs/typostats.md`.
- Added unit tests in `tests/test_typostats_dry_run.py`.

---
*PR created automatically by Jules for task [1034826809305181](https://jules.google.com/task/1034826809305181) started by @RainRat*