### PR TITLE
[DOCS] Fix invalid multitool scrub CLI flags in README Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ python typostats.py my_typos.txt --sort count
 ```
 
 ### 4. Fix Your Project
-Use `multitool.py` to fix found typos in your project files using your saved typo mapping file. The `--diff` flag lets you review the changes before they are applied:
+Use `multitool.py` to fix found typos in your project files using your saved typo mapping file. The `--diff` and `--dry-run` flags let you review the changes before they are applied:
 ```bash
-python multitool.py scrub . --mapping my_typos.txt --in-place --diff
+python multitool.py scrub . -s my_typos.txt --diff --dry-run
 ```
 You can also preview fixes for specific typos directly using `--add` and `--dry-run`:
 ```bash


### PR DESCRIPTION
Updated README.md Quick Start step 4 ("Fix Your Project") to use valid `multitool.py` CLI arguments `-s my_typos.txt --diff --dry-run` instead of the non-existent `--in-place` flag, ensuring accurate instructions and preventing errors when users copy and run example commands.

---
*PR created automatically by Jules for task [15945193804198176299](https://jules.google.com/task/15945193804198176299) started by @RainRat*