### PR TITLE
[FEAT] Add --dry-run CLI option to typostats.py

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -61,6 +61,7 @@ The tool automatically recognizes several common ways of listing typos:
 - `-o`, `--output`: Save the report to a file instead of showing it on the screen.
 - `-e`, `--exclude`: One or more file patterns (e.g., `*.json`, `tests/*`) to exclude from scanning.
 - `-q`, `--quiet`: Hide progress bars and status messages.
+- `--dry-run`: Preview execution settings and a sample list of found typo patterns without writing or outputting reports.
 
 ## Understanding the Report
 

--- a/tests/test_typostats_dry_run.py
+++ b/tests/test_typostats_dry_run.py
@@ -1,0 +1,64 @@
+from unittest.mock import patch
+import typostats
+
+
+def test_typostats_dry_run_basic(tmp_path, caplog):
+    typo_file = tmp_path / "typos.txt"
+    typo_file.write_text("teh -> the\nrecieve -> receive\n", encoding="utf-8")
+    out_file = tmp_path / "output.json"
+
+    with patch(
+        "sys.argv",
+        [
+            "typostats.py",
+            str(typo_file),
+            "-o",
+            str(out_file),
+            "--dry-run",
+            "-t",
+            "-k",
+        ],
+    ):
+        with patch("sys.stderr.isatty", return_value=True), caplog.at_level("INFO"):
+            typostats.main()
+
+    # Verify no output file was created
+    assert not out_file.exists()
+
+    # Verify dry run log header and execution settings
+    log_text = caplog.text
+    assert "--- TYPOSTATS DRY RUN ---" in log_text
+    assert str(typo_file) in log_text
+    assert str(out_file) in log_text
+    assert "keyboard" in log_text
+    assert "transposition" in log_text
+    assert "Dry run complete. No files were written or exported." in log_text
+    assert "Found 2 pattern candidate(s)" in log_text or "Found 1 pattern candidate(s)" in log_text
+
+
+def test_typostats_dry_run_directory_input(tmp_path, caplog):
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    f1 = subdir / "typos1.txt"
+    f1.write_text("teh -> the\n", encoding="utf-8")
+
+    with patch(
+        "sys.argv",
+        [
+            "typostats.py",
+            str(subdir),
+            "--dry-run",
+            "--1to2",
+            "--2to1",
+            "--include-deletions",
+        ],
+    ):
+        with caplog.at_level("INFO"):
+            typostats.main()
+
+    log_text = caplog.text
+    assert "--- TYPOSTATS DRY RUN ---" in log_text
+    assert "1to2" in log_text
+    assert "2to1" in log_text
+    assert "deletions" in log_text
+    assert "Dry run complete. No files were written or exported." in log_text

--- a/typostats.py
+++ b/typostats.py
@@ -1127,6 +1127,7 @@ def main() -> None:
         help="The format of the report. If not provided, it is automatically detected from the output file extension. (default: arrow).",
     )
     io_group.add_argument('-q', '--quiet', action='store_true', help="Hide progress bars and status messages.")
+    io_group.add_argument('--dry-run', action='store_true', help="Preview execution settings and found typo patterns without writing or outputting reports.")
 
     # Analysis Options Group
     analysis_group = parser.add_argument_group(f"{BLUE}ANALYSIS OPTIONS{RESET}")
@@ -1300,6 +1301,42 @@ def main() -> None:
         for k, v in file_counts.items():
             all_counts[k] += v
         total_pairs_all += pairs_count
+
+    if getattr(args, 'dry_run', False):
+        use_color = _should_enable_color(sys.stderr)
+        c_blue = (BOLD + BLUE) if use_color else ""
+        c_green = (BOLD + GREEN) if use_color else ""
+        c_reset = RESET if use_color else ""
+
+        logging.info(f"{c_blue}--- TYPOSTATS DRY RUN ---{c_reset}")
+        input_desc = input_files if input_files else "stdin"
+        logging.info(f"Input Source: {input_desc}")
+        logging.info(f"Output Target: {output_file or 'stdout'} (Format: {output_format})")
+        logging.info(f"Min Occurrences: {min_occurrences} | Sort: {sort_by} | Limit: {limit if limit is not None else 'None'}")
+        enabled_features = []
+        if keyboard:
+            enabled_features.append("keyboard")
+        if allow_transposition:
+            enabled_features.append("transposition")
+        if allow_1to2:
+            enabled_features.append("1to2")
+        if allow_2to1:
+            enabled_features.append("2to1")
+        if include_deletions:
+            enabled_features.append("deletions")
+        logging.info(f"Enabled Analysis: {', '.join(enabled_features) if enabled_features else 'None'}")
+        logging.info(f"Exclude Patterns: {exclude_patterns if exclude_patterns else 'None'}")
+
+        # Sample Preview
+        logging.info(f"\n{c_blue}Sample Typo Patterns Preview:{c_reset}")
+        sorted_counts = sorted(all_counts.items(), key=lambda x: x[1], reverse=True)
+        sample_items = sorted_counts[:10]
+        logging.info(f"  Found {len(all_counts)} pattern candidate(s):")
+        for (correct_char, typo_char), cnt in sample_items:
+            logging.info(f"    '{typo_char}' -> '{correct_char}' (Count: {cnt})")
+
+        logging.info(f"{c_green}Dry run complete. No files were written or exported.{c_reset}")
+        return
 
     generate_report(
         all_counts,


### PR DESCRIPTION
Added `--dry-run` flag to `typostats.py` to enable dry-run preview functionality, updated `docs/typostats.md`, and added tests in `tests/test_typostats_dry_run.py`.

---
*PR created automatically by Jules for task [16643026669376563316](https://jules.google.com/task/16643026669376563316) started by @RainRat*