### PR TITLE
[UI/UX] Add -D short flag alias for --include-deletions in typostats.py

### DIFF
--- a/docs/typostats.md
+++ b/docs/typostats.md
@@ -45,7 +45,7 @@ The tool automatically recognizes several common ways of listing typos:
 - `-2`, `--allow-two-char`: Look for cases where you typed two letters instead of one (like `rn` instead of `m`) or one instead of two (like `f` instead of `ph`).
 - `--1to2`: Specifically look for cases where you typed two letters instead of one (like `rn` instead of `m`).
 - `--2to1`: Specifically look for cases where you typed one letter instead of two (like `f` instead of `ph`).
-- `--include-deletions`: Include cases where you added an extra letter or missed one (like typing `aa` instead of `a`).
+- `-D`, `--include-deletions`: Include cases where you added an extra letter or missed one (like typing `aa` instead of `a`).
 - `-t`, `--transposition`: Find swapped letters (like `teh` instead of `the`).
 - `-k`, `--keyboard`: Find typos caused by hitting keys next to each other on the keyboard.
 

--- a/tests/test_typostats.py
+++ b/tests/test_typostats.py
@@ -361,6 +361,15 @@ def test_main_cli_functionality():
         assert mock_process.call_args[1]['allow_1to2'] is True and mock_process.call_args[1]['allow_2to1'] is True
 
 
+def test_main_cli_short_flag_deletion():
+    with patch('sys.argv', ['typostats.py', 'input.txt', '-D', '-q']), \
+         patch('typostats._extract_pairs', return_value=[("a", "aa")]), \
+         patch('typostats.process_typos', return_value=({}, 0)) as mock_process, \
+         patch('typostats.generate_report'):
+        typostats.main()
+        assert mock_process.call_args[1]['include_deletions'] is True
+
+
 def test_main_cli_args_extra():
     # args.all = True if no flags
     with patch('sys.argv', ['typostats.py', 'input.txt']), \

--- a/typostats.py
+++ b/typostats.py
@@ -1168,6 +1168,7 @@ def main() -> None:
         help="Allow cases where you typed one letter instead of two (like 'f' instead of 'ph').",
     )
     analysis_group.add_argument(
+        '-D',
         '--include-deletions',
         action='store_true',
         help="Include cases where you added an extra letter or missed one (like typing 'aa' instead of 'a').",


### PR DESCRIPTION
Adds `-D` as a short option alias for `--include-deletions` in `typostats.py`, reducing CLI typing friction for common analysis tasks and aligning short flags across repository tools.

---
*PR created automatically by Jules for task [11795940310842851127](https://jules.google.com/task/11795940310842851127) started by @RainRat*