### PR TITLE
[DOCS] Add cmdrunner step to README Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ You can also preview fixes for specific typos directly using `--add` and `--dry-
 python multitool.py scrub . --add teh:the --diff --dry-run
 ```
 
+### 6. Run Commands Across Projects
+Use `cmdrunner.py` to run checks or commands across multiple project folders at once:
+```bash
+python cmdrunner.py --main-folder /path/to/projects --command-to-run "python multitool.py scrub . -s my_typos.txt --dry-run"
+```
+
 ## 🧪 Running Tests
 
 This project has a full suite of tests to make sure everything works correctly.


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Added step 6 ("Run Commands Across Projects") to the Quick Start section in `README.md`.
* **Why:** Completes the Quick Start workflow so all five core tools in the suite (`diff2typo`, `typostats`, `gentypos`, `multitool`, and `cmdrunner`) are clearly demonstrated with practical step-by-step examples for users.

---
*PR created automatically by Jules for task [15307075974201938676](https://jules.google.com/task/15307075974201938676) started by @RainRat*