### PR TITLE
[FEAT] Add `-s` / `--stop-on-first-error` flag and config option to `cmdrunner.py`

### DIFF
--- a/cmdrunner.py
+++ b/cmdrunner.py
@@ -210,6 +210,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if "fail_fast" in config and not isinstance(config["fail_fast"], bool):
         errors.append("The field 'fail_fast' must be a boolean.")
 
+    if "stop_on_first_error" in config and not isinstance(config["stop_on_first_error"], bool):
+        errors.append("The field 'stop_on_first_error' must be a boolean.")
+
     if "timeout" in config and (isinstance(config["timeout"], bool) or not isinstance(config["timeout"], (int, float))):
         errors.append("The field 'timeout' must be a number.")
 
@@ -551,7 +554,8 @@ def parse_arguments() -> argparse.Namespace:
         help='Hide status messages and progress bars.'
     )
     options_group.add_argument(
-        '--fail-fast',
+        '-s', '--stop-on-first-error', '--fail-fast',
+        dest='fail_fast',
         action='store_true',
         default=None,
         help='Stop running commands immediately if any command fails.'
@@ -624,7 +628,8 @@ def main() -> None:
     included = args.included_folders if args.included_folders is not None else config.get('included_folders', None)
 
     # Prioritize CLI values over config file values
-    fail_fast = args.fail_fast if args.fail_fast is not None else config.get('fail_fast', False)
+    config_fail_fast = config.get('stop_on_first_error', config.get('fail_fast', False))
+    fail_fast = args.fail_fast if args.fail_fast is not None else config_fail_fast
     timeout = args.timeout if args.timeout is not None else config.get('timeout', None)
     if_exists = args.if_exists or config.get('if_exists', None)
     if_not_exists = args.if_not_exists or config.get('if_not_exists', None)

--- a/docs/cmdrunner.md
+++ b/docs/cmdrunner.md
@@ -53,6 +53,7 @@ included_folders:
   - "my-app-2"
 
 # (Optional) Stop execution immediately if any command fails or times out
+stop_on_first_error: false
 fail_fast: false
 
 # (Optional) The maximum execution time in seconds for the command in each folder
@@ -78,7 +79,7 @@ jobs: 4
 - `-i`, `--included-folders`: A list of folders you want to run the command on. This overrides the configuration file.
 - `--dry-run`: Show which folders the tool will check without running any commands. Use this to test your setup safely.
 - `-q`, `--quiet`: Hide status messages and progress bars.
-- `--fail-fast`: Stop running commands immediately if any command fails. This overrides the configuration file.
+- `-s`, `--stop-on-first-error`, `--fail-fast`: Stop running commands immediately if any command fails. This overrides the configuration file.
 - `--timeout`: Set the maximum time in seconds for the command to run in each folder. This overrides the configuration file.
 - `--if-exists`: Only run the command in folders that contain this file or path (for example, `package.json`). This overrides the configuration file.
 - `--if-not-exists`: Only run the command in folders that do not contain this file or path (for example, `initialized.log`). This overrides the configuration file.

--- a/tests/test_cmdrunner.py
+++ b/tests/test_cmdrunner.py
@@ -1587,6 +1587,69 @@ def test_load_config_invalid_fail_fast(tmp_path):
         cmdrunner.load_config(str(config_file))
 
 
+def test_load_config_invalid_stop_on_first_error(tmp_path):
+    config_file = tmp_path / 'config_invalid_stop_on_first_error.yaml'
+    config_file.write_text(yaml.safe_dump({
+        'main_folder': str(tmp_path),
+        'command_to_run': 'echo test',
+        'stop_on_first_error': 'not-a-bool'
+    }))
+    with pytest.raises(cmdrunner.ConfigError, match="stop_on_first_error"):
+        cmdrunner.load_config(str(config_file))
+
+
+def test_main_cli_stop_on_first_error_flag(tmp_path, monkeypatch, caplog):
+    base_dir = tmp_path / "projects"
+    base_dir.mkdir()
+    (base_dir / "proj1").mkdir()
+
+    config_data = {
+        "main_folder": str(base_dir),
+        "command_to_run": "python3 -c \"import sys; sys.exit(1)\"",
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, "argv", [
+        "cmdrunner.py",
+        str(config_file),
+        "-s"
+    ])
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as excinfo:
+            cmdrunner.main()
+        assert excinfo.value.code == 1
+
+    assert any("The command failed in 'proj1'" in msg for msg in caplog.messages)
+
+
+def test_main_config_stop_on_first_error(tmp_path, monkeypatch, caplog):
+    base_dir = tmp_path / "projects"
+    base_dir.mkdir()
+    (base_dir / "proj1").mkdir()
+
+    config_data = {
+        "main_folder": str(base_dir),
+        "command_to_run": "python3 -c \"import sys; sys.exit(1)\"",
+        "stop_on_first_error": True,
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.safe_dump(config_data))
+
+    monkeypatch.setattr(sys, "argv", [
+        "cmdrunner.py",
+        str(config_file),
+    ])
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as excinfo:
+            cmdrunner.main()
+        assert excinfo.value.code == 1
+
+    assert any("The command failed in 'proj1'" in msg for msg in caplog.messages)
+
+
 def test_load_config_invalid_timeout_bool(tmp_path):
     config_file = tmp_path / 'config_invalid_timeout.yaml'
     config_file.write_text(yaml.safe_dump({


### PR DESCRIPTION
* **What:** Added short flag alias `-s`, long flag alias `--stop-on-first-error`, and YAML configuration key `stop_on_first_error` to `cmdrunner.py`. These options directly map to and enable the `fail_fast` behavior, which immediately halts command execution across remaining target directories if a command fails or times out.
* **Why:** Following usability and ergonomics principles across CLI utilities (where short flags like `-s` and descriptive flags like `--stop-on-first-error` are standard and intuitive), adding this flag alias reduces friction for users who expect a `-s` short flag or `stop_on_first_error` parameter when configuring batch task execution.

---
*PR created automatically by Jules for task [13959184965779397243](https://jules.google.com/task/13959184965779397243) started by @RainRat*